### PR TITLE
feat(#6): Neo4j Graph Status 状态机与一致性校验

### DIFF
--- a/graph_engine/__init__.py
+++ b/graph_engine/__init__.py
@@ -21,16 +21,25 @@ from graph_engine.schema import (
     get_constraint_statements,
     get_index_statements,
 )
+from graph_engine.status import (
+    CanonicalSnapshotReader,
+    GraphStatusManager,
+    StatusStore,
+    check_live_graph_consistency,
+    require_ready_status,
+)
 
 __version__ = "0.1.0"
 
 __all__ = [
     "CandidateGraphDelta",
+    "CanonicalSnapshotReader",
     "GraphAssertionRecord",
     "GraphEdgeRecord",
     "GraphImpactSnapshot",
     "GraphNodeRecord",
     "GraphSnapshot",
+    "GraphStatusManager",
     "Neo4jClient",
     "Neo4jConfig",
     "Neo4jGraphStatus",
@@ -40,8 +49,11 @@ __all__ = [
     "PropagationResult",
     "RelationshipType",
     "SchemaManager",
+    "StatusStore",
     "__version__",
+    "check_live_graph_consistency",
     "get_constraint_statements",
     "get_index_statements",
     "load_config_from_env",
+    "require_ready_status",
 ]

--- a/graph_engine/live_metrics.py
+++ b/graph_engine/live_metrics.py
@@ -1,0 +1,190 @@
+"""Shared live graph metric reads and checksum helpers."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping
+from typing import Any
+
+from graph_engine.client import Neo4jClient
+
+LIVE_GRAPH_METRICS_QUERY = """
+CALL {
+    MATCH (node)
+    WITH node
+    ORDER BY coalesce(node.node_id, elementId(node)) ASC
+    RETURN count(node) AS node_count,
+           collect({
+               labels: labels(node),
+               node_id: node.node_id,
+               canonical_entity_id: node.canonical_entity_id,
+               properties: properties(node)
+           }) AS nodes
+}
+CALL {
+    MATCH (node)
+    UNWIND labels(node) AS label
+    WITH label, count(*) AS count
+    ORDER BY label ASC
+    RETURN collect({label: label, count: count}) AS label_counts
+}
+CALL {
+    MATCH (source)-[relationship]->(target)
+    WITH source, relationship, target
+    ORDER BY coalesce(relationship.edge_id, elementId(relationship)) ASC
+    RETURN count(relationship) AS edge_count,
+           collect({
+               source_node_id: source.node_id,
+               target_node_id: target.node_id,
+               relationship_type: type(relationship),
+               edge_id: relationship.edge_id,
+               properties: properties(relationship)
+           }) AS relationships
+}
+RETURN node_count, edge_count, label_counts, nodes, relationships
+"""
+
+
+def read_live_graph_metrics(
+    client: Neo4jClient,
+    *,
+    strict: bool = True,
+) -> tuple[int, int, dict[str, int], str]:
+    """Read node/edge counts, label counts, and structural checksum."""
+
+    rows = client.execute_read(LIVE_GRAPH_METRICS_QUERY)
+    if strict:
+        row = _single_metrics_row(rows)
+        node_count = _int_field(row, "node_count")
+        edge_count = _int_field(row, "edge_count")
+        key_label_counts = _strict_label_counts(row["label_counts"])
+        nodes = _list_field(row, "nodes")
+        relationships = _list_field(row, "relationships")
+    else:
+        row = rows[0] if isinstance(rows, list) and rows else {}
+        if not isinstance(row, Mapping):
+            row = {}
+        node_count = int(row.get("node_count", 0))
+        edge_count = int(row.get("edge_count", 0))
+        key_label_counts = _permissive_label_counts(row.get("label_counts"))
+        nodes = _permissive_list(row.get("nodes"))
+        relationships = _permissive_list(row.get("relationships"))
+
+    payload = {
+        "node_count": node_count,
+        "edge_count": edge_count,
+        "nodes": sorted_payload_list(nodes),
+        "relationships": sorted_payload_list(relationships),
+    }
+    return node_count, edge_count, key_label_counts, checksum_payload(payload)
+
+
+def sorted_payload_list(values: list[Any]) -> list[Any]:
+    """Return a JSON-normalized, stable-order payload list."""
+
+    normalized_values = [_jsonable(value) for value in values]
+    return sorted(normalized_values, key=_stable_json)
+
+
+def checksum_payload(payload: Any) -> str:
+    """Return a stable SHA-256 checksum for a JSON-compatible payload."""
+
+    encoded = _stable_json(_jsonable(payload)).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _single_metrics_row(rows: object) -> Mapping[str, Any]:
+    if not isinstance(rows, list) or len(rows) != 1:
+        raise ValueError("Neo4j graph metrics query returned malformed rows")
+    row = rows[0]
+    if not isinstance(row, Mapping):
+        raise ValueError("Neo4j graph metrics query returned a malformed row")
+    required_fields = {"node_count", "edge_count", "label_counts", "nodes", "relationships"}
+    if not required_fields <= row.keys():
+        raise ValueError("Neo4j graph metrics query returned an incomplete row")
+    return row
+
+
+def _int_field(row: Mapping[str, Any], field_name: str) -> int:
+    value = row[field_name]
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(f"Neo4j graph metrics field {field_name!r} is malformed")
+    if value < 0:
+        raise ValueError(f"Neo4j graph metrics field {field_name!r} cannot be negative")
+    return value
+
+
+def _list_field(row: Mapping[str, Any], field_name: str) -> list[Any]:
+    value = row[field_name]
+    if not isinstance(value, list):
+        raise ValueError(f"Neo4j graph metrics field {field_name!r} is malformed")
+    return value
+
+
+def _strict_label_counts(value: object) -> dict[str, int]:
+    if not isinstance(value, list):
+        raise ValueError("Neo4j graph metrics field 'label_counts' is malformed")
+
+    counts: dict[str, int] = {}
+    for item in value:
+        if not isinstance(item, Mapping):
+            raise ValueError("Neo4j graph metrics field 'label_counts' is malformed")
+        label = item.get("label")
+        count = item.get("count")
+        if not isinstance(label, str):
+            raise ValueError("Neo4j graph metrics label count is missing a string label")
+        if isinstance(count, bool) or not isinstance(count, int) or count < 0:
+            raise ValueError("Neo4j graph metrics label count is malformed")
+        counts[label] = count
+    return counts
+
+
+def _permissive_list(value: Any) -> list[Any]:
+    if not isinstance(value, list):
+        return []
+    return value
+
+
+def _permissive_label_counts(value: Any) -> dict[str, int]:
+    if not isinstance(value, list):
+        return {}
+    counts: dict[str, int] = {}
+    for row in value:
+        if not isinstance(row, Mapping):
+            continue
+        label = row.get("label")
+        if label is None:
+            continue
+        counts[str(label)] = int(row.get("count", 0))
+    return counts
+
+
+def _stable_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"))
+
+
+def _jsonable(value: Any) -> Any:
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, Mapping):
+        normalized: dict[str, Any] = {}
+        for key, nested_value in sorted(value.items(), key=lambda item: str(item[0])):
+            string_key = str(key)
+            if string_key == "labels" and isinstance(nested_value, list):
+                normalized[string_key] = sorted(
+                    (_jsonable(item) for item in nested_value),
+                    key=_stable_json,
+                )
+            else:
+                normalized[string_key] = _jsonable(nested_value)
+        return normalized
+    if isinstance(value, (list, tuple)):
+        return [_jsonable(item) for item in value]
+    if isinstance(value, set):
+        return sorted((_jsonable(item) for item in value), key=_stable_json)
+
+    isoformat = getattr(value, "isoformat", None)
+    if callable(isoformat):
+        return str(isoformat())
+    return str(value)

--- a/graph_engine/snapshots/generator.py
+++ b/graph_engine/snapshots/generator.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
-import hashlib
-import json
-from collections.abc import Mapping
 from datetime import datetime, timezone
-from typing import Any, Protocol
+from typing import Protocol
 
 from graph_engine.client import Neo4jClient
+from graph_engine.live_metrics import (
+    checksum_payload as _checksum_payload,
+    read_live_graph_metrics,
+)
 from graph_engine.models import (
     GraphImpactSnapshot,
     GraphSnapshot,
@@ -288,121 +289,4 @@ def _graph_snapshot_from_metrics(
 
 
 def _read_graph_metrics(client: Neo4jClient) -> tuple[int, int, dict[str, int], str]:
-    rows = client.execute_read(
-        """
-CALL {
-    MATCH (node)
-    WITH node
-    ORDER BY coalesce(node.node_id, elementId(node)) ASC
-    RETURN count(node) AS node_count,
-           collect({
-               labels: labels(node),
-               node_id: node.node_id,
-               canonical_entity_id: node.canonical_entity_id,
-               properties: properties(node)
-           }) AS nodes
-}
-CALL {
-    MATCH (node)
-    UNWIND labels(node) AS label
-    WITH label, count(*) AS count
-    ORDER BY label ASC
-    RETURN collect({label: label, count: count}) AS label_counts
-}
-CALL {
-    MATCH (source)-[relationship]->(target)
-    WITH source, relationship, target
-    ORDER BY coalesce(relationship.edge_id, elementId(relationship)) ASC
-    RETURN count(relationship) AS edge_count,
-           collect({
-               source_node_id: source.node_id,
-               target_node_id: target.node_id,
-               relationship_type: type(relationship),
-               edge_id: relationship.edge_id,
-               properties: properties(relationship)
-           }) AS relationships
-}
-RETURN node_count, edge_count, label_counts, nodes, relationships
-""",
-    )
-    if not rows:
-        node_count = 0
-        edge_count = 0
-        key_label_counts: dict[str, int] = {}
-        nodes: list[Any] = []
-        relationships: list[Any] = []
-    else:
-        row = rows[0]
-        node_count = int(row.get("node_count", 0))
-        edge_count = int(row.get("edge_count", 0))
-        key_label_counts = _label_counts(row.get("label_counts"))
-        nodes = _list_value(row.get("nodes"))
-        relationships = _list_value(row.get("relationships"))
-
-    payload = {
-        "node_count": node_count,
-        "edge_count": edge_count,
-        "nodes": _sorted_payload_list(nodes),
-        "relationships": _sorted_payload_list(relationships),
-    }
-    return node_count, edge_count, key_label_counts, _checksum_payload(payload)
-
-
-def _list_value(value: Any) -> list[Any]:
-    if not isinstance(value, list):
-        return []
-    return value
-
-
-def _label_counts(value: Any) -> dict[str, int]:
-    if not isinstance(value, list):
-        return {}
-    counts: dict[str, int] = {}
-    for row in value:
-        if not isinstance(row, Mapping):
-            continue
-        label = row.get("label")
-        if label is None:
-            continue
-        counts[str(label)] = int(row.get("count", 0))
-    return counts
-
-
-def _sorted_payload_list(values: list[Any]) -> list[Any]:
-    normalized_values = [_jsonable(value) for value in values]
-    return sorted(normalized_values, key=_stable_json)
-
-
-def _checksum_payload(payload: Any) -> str:
-    encoded = _stable_json(_jsonable(payload)).encode("utf-8")
-    return hashlib.sha256(encoded).hexdigest()
-
-
-def _stable_json(value: Any) -> str:
-    return json.dumps(value, sort_keys=True, separators=(",", ":"))
-
-
-def _jsonable(value: Any) -> Any:
-    if value is None or isinstance(value, (str, int, float, bool)):
-        return value
-    if isinstance(value, Mapping):
-        normalized: dict[str, Any] = {}
-        for key, nested_value in sorted(value.items(), key=lambda item: str(item[0])):
-            string_key = str(key)
-            if string_key == "labels" and isinstance(nested_value, list):
-                normalized[string_key] = sorted(
-                    (_jsonable(item) for item in nested_value),
-                    key=_stable_json,
-                )
-            else:
-                normalized[string_key] = _jsonable(nested_value)
-        return normalized
-    if isinstance(value, (list, tuple)):
-        return [_jsonable(item) for item in value]
-    if isinstance(value, set):
-        return sorted((_jsonable(item) for item in value), key=_stable_json)
-
-    isoformat = getattr(value, "isoformat", None)
-    if callable(isoformat):
-        return str(isoformat())
-    return str(value)
+    return read_live_graph_metrics(client, strict=False)

--- a/graph_engine/status/__init__.py
+++ b/graph_engine/status/__init__.py
@@ -1,1 +1,16 @@
+"""Public status management entry points."""
 
+from graph_engine.status.consistency import (
+    CanonicalSnapshotReader,
+    check_live_graph_consistency,
+)
+from graph_engine.status.manager import GraphStatusManager, require_ready_status
+from graph_engine.status.store import StatusStore
+
+__all__ = [
+    "CanonicalSnapshotReader",
+    "GraphStatusManager",
+    "StatusStore",
+    "check_live_graph_consistency",
+    "require_ready_status",
+]

--- a/graph_engine/status/consistency.py
+++ b/graph_engine/status/consistency.py
@@ -1,0 +1,164 @@
+"""Phase 0 consistency checks between canonical snapshots and the live graph."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, Protocol
+
+from graph_engine.client import Neo4jClient
+from graph_engine.models import GraphSnapshot, Neo4jGraphStatus
+from graph_engine.snapshots.generator import _checksum_payload, _sorted_payload_list
+from graph_engine.status.manager import GraphStatusManager
+
+_LIVE_GRAPH_METRICS_QUERY = """
+CALL {
+    MATCH (node)
+    WITH node
+    ORDER BY coalesce(node.node_id, elementId(node)) ASC
+    RETURN count(node) AS node_count,
+           collect({
+               labels: labels(node),
+               node_id: node.node_id,
+               canonical_entity_id: node.canonical_entity_id,
+               properties: properties(node)
+           }) AS nodes
+}
+CALL {
+    MATCH (node)
+    UNWIND labels(node) AS label
+    WITH label, count(*) AS count
+    ORDER BY label ASC
+    RETURN collect({label: label, count: count}) AS label_counts
+}
+CALL {
+    MATCH (source)-[relationship]->(target)
+    WITH source, relationship, target
+    ORDER BY coalesce(relationship.edge_id, elementId(relationship)) ASC
+    RETURN count(relationship) AS edge_count,
+           collect({
+               source_node_id: source.node_id,
+               target_node_id: target.node_id,
+               relationship_type: type(relationship),
+               edge_id: relationship.edge_id,
+               properties: properties(relationship)
+           }) AS relationships
+}
+RETURN node_count, edge_count, label_counts, nodes, relationships
+"""
+
+
+class CanonicalSnapshotReader(Protocol):
+    """Read canonical graph snapshots from the data-platform/Iceberg boundary."""
+
+    def read_graph_snapshot(self, snapshot_ref: str) -> GraphSnapshot:
+        """Return the canonical snapshot referenced by snapshot_ref."""
+
+
+def check_live_graph_consistency(
+    snapshot_ref: str,
+    *,
+    client: Neo4jClient,
+    snapshot_reader: CanonicalSnapshotReader,
+    status_manager: GraphStatusManager | None = None,
+    require_ready: bool = True,
+) -> bool:
+    """Return whether live Neo4j metrics match the canonical graph snapshot."""
+
+    status = _resolve_status(status_manager, require_ready=require_ready)
+
+    try:
+        snapshot = snapshot_reader.read_graph_snapshot(snapshot_ref)
+        node_count, edge_count, key_label_counts, checksum = _read_live_graph_metrics(client)
+    except Exception:  # noqa: BLE001 - consistency checks fail closed.
+        return False
+
+    if status is not None and snapshot.graph_generation_id != status.graph_generation_id:
+        return False
+    return (
+        snapshot.node_count == node_count
+        and snapshot.edge_count == edge_count
+        and snapshot.key_label_counts == key_label_counts
+        and snapshot.checksum == checksum
+    )
+
+
+def _resolve_status(
+    status_manager: GraphStatusManager | None,
+    *,
+    require_ready: bool,
+) -> Neo4jGraphStatus | None:
+    if require_ready:
+        if status_manager is None:
+            raise ValueError("status_manager is required when require_ready=True")
+        return status_manager.require_ready()
+
+    if status_manager is None:
+        return None
+    try:
+        return status_manager.get_status()
+    except LookupError:
+        return None
+
+
+def _read_live_graph_metrics(client: Neo4jClient) -> tuple[int, int, dict[str, int], str]:
+    rows = client.execute_read(_LIVE_GRAPH_METRICS_QUERY)
+    row = _single_metrics_row(rows)
+    node_count = _int_field(row, "node_count")
+    edge_count = _int_field(row, "edge_count")
+    key_label_counts = _label_counts(row["label_counts"])
+    nodes = _list_field(row, "nodes")
+    relationships = _list_field(row, "relationships")
+
+    payload = {
+        "node_count": node_count,
+        "edge_count": edge_count,
+        "nodes": _sorted_payload_list(nodes),
+        "relationships": _sorted_payload_list(relationships),
+    }
+    return node_count, edge_count, key_label_counts, _checksum_payload(payload)
+
+
+def _single_metrics_row(rows: object) -> Mapping[str, Any]:
+    if not isinstance(rows, list) or len(rows) != 1:
+        raise ValueError("Neo4j graph metrics query returned malformed rows")
+    row = rows[0]
+    if not isinstance(row, Mapping):
+        raise ValueError("Neo4j graph metrics query returned a malformed row")
+    required_fields = {"node_count", "edge_count", "label_counts", "nodes", "relationships"}
+    if not required_fields <= row.keys():
+        raise ValueError("Neo4j graph metrics query returned an incomplete row")
+    return row
+
+
+def _int_field(row: Mapping[str, Any], field_name: str) -> int:
+    value = row[field_name]
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(f"Neo4j graph metrics field {field_name!r} is malformed")
+    if value < 0:
+        raise ValueError(f"Neo4j graph metrics field {field_name!r} cannot be negative")
+    return value
+
+
+def _list_field(row: Mapping[str, Any], field_name: str) -> list[Any]:
+    value = row[field_name]
+    if not isinstance(value, list):
+        raise ValueError(f"Neo4j graph metrics field {field_name!r} is malformed")
+    return value
+
+
+def _label_counts(value: object) -> dict[str, int]:
+    if not isinstance(value, list):
+        raise ValueError("Neo4j graph metrics field 'label_counts' is malformed")
+
+    counts: dict[str, int] = {}
+    for item in value:
+        if not isinstance(item, Mapping):
+            raise ValueError("Neo4j graph metrics field 'label_counts' is malformed")
+        label = item.get("label")
+        count = item.get("count")
+        if not isinstance(label, str):
+            raise ValueError("Neo4j graph metrics label count is missing a string label")
+        if isinstance(count, bool) or not isinstance(count, int) or count < 0:
+            raise ValueError("Neo4j graph metrics label count is malformed")
+        counts[label] = count
+    return counts

--- a/graph_engine/status/consistency.py
+++ b/graph_engine/status/consistency.py
@@ -2,49 +2,15 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
-from typing import Any, Protocol
+import logging
+from typing import Protocol
 
 from graph_engine.client import Neo4jClient
+from graph_engine.live_metrics import read_live_graph_metrics
 from graph_engine.models import GraphSnapshot, Neo4jGraphStatus
-from graph_engine.snapshots.generator import _checksum_payload, _sorted_payload_list
 from graph_engine.status.manager import GraphStatusManager
 
-_LIVE_GRAPH_METRICS_QUERY = """
-CALL {
-    MATCH (node)
-    WITH node
-    ORDER BY coalesce(node.node_id, elementId(node)) ASC
-    RETURN count(node) AS node_count,
-           collect({
-               labels: labels(node),
-               node_id: node.node_id,
-               canonical_entity_id: node.canonical_entity_id,
-               properties: properties(node)
-           }) AS nodes
-}
-CALL {
-    MATCH (node)
-    UNWIND labels(node) AS label
-    WITH label, count(*) AS count
-    ORDER BY label ASC
-    RETURN collect({label: label, count: count}) AS label_counts
-}
-CALL {
-    MATCH (source)-[relationship]->(target)
-    WITH source, relationship, target
-    ORDER BY coalesce(relationship.edge_id, elementId(relationship)) ASC
-    RETURN count(relationship) AS edge_count,
-           collect({
-               source_node_id: source.node_id,
-               target_node_id: target.node_id,
-               relationship_type: type(relationship),
-               edge_id: relationship.edge_id,
-               properties: properties(relationship)
-           }) AS relationships
-}
-RETURN node_count, edge_count, label_counts, nodes, relationships
-"""
+_LOGGER = logging.getLogger(__name__)
 
 
 class CanonicalSnapshotReader(Protocol):
@@ -68,18 +34,55 @@ def check_live_graph_consistency(
 
     try:
         snapshot = snapshot_reader.read_graph_snapshot(snapshot_ref)
+    except Exception:
+        _LOGGER.exception(
+            "live graph consistency snapshot read failed",
+            extra={"snapshot_ref": snapshot_ref, "failure_stage": "snapshot_read"},
+        )
+        return False
+
+    try:
         node_count, edge_count, key_label_counts, checksum = _read_live_graph_metrics(client)
-    except Exception:  # noqa: BLE001 - consistency checks fail closed.
+    except Exception:
+        _LOGGER.exception(
+            "live graph consistency live graph read failed",
+            extra={"snapshot_ref": snapshot_ref, "failure_stage": "live_graph_read"},
+        )
         return False
 
     if status is not None and snapshot.graph_generation_id != status.graph_generation_id:
+        _LOGGER.warning(
+            "live graph consistency generation mismatch",
+            extra={
+                "snapshot_ref": snapshot_ref,
+                "failure_stage": "result_validation",
+                "snapshot_generation_id": snapshot.graph_generation_id,
+                "status_generation_id": status.graph_generation_id,
+            },
+        )
         return False
-    return (
-        snapshot.node_count == node_count
-        and snapshot.edge_count == edge_count
-        and snapshot.key_label_counts == key_label_counts
-        and snapshot.checksum == checksum
-    )
+
+    mismatches = [
+        field_name
+        for field_name, snapshot_value, live_value in (
+            ("node_count", snapshot.node_count, node_count),
+            ("edge_count", snapshot.edge_count, edge_count),
+            ("key_label_counts", snapshot.key_label_counts, key_label_counts),
+            ("checksum", snapshot.checksum, checksum),
+        )
+        if snapshot_value != live_value
+    ]
+    if mismatches:
+        _LOGGER.warning(
+            "live graph consistency metric mismatch",
+            extra={
+                "snapshot_ref": snapshot_ref,
+                "failure_stage": "result_validation",
+                "mismatches": mismatches,
+            },
+        )
+        return False
+    return True
 
 
 def _resolve_status(
@@ -101,64 +104,4 @@ def _resolve_status(
 
 
 def _read_live_graph_metrics(client: Neo4jClient) -> tuple[int, int, dict[str, int], str]:
-    rows = client.execute_read(_LIVE_GRAPH_METRICS_QUERY)
-    row = _single_metrics_row(rows)
-    node_count = _int_field(row, "node_count")
-    edge_count = _int_field(row, "edge_count")
-    key_label_counts = _label_counts(row["label_counts"])
-    nodes = _list_field(row, "nodes")
-    relationships = _list_field(row, "relationships")
-
-    payload = {
-        "node_count": node_count,
-        "edge_count": edge_count,
-        "nodes": _sorted_payload_list(nodes),
-        "relationships": _sorted_payload_list(relationships),
-    }
-    return node_count, edge_count, key_label_counts, _checksum_payload(payload)
-
-
-def _single_metrics_row(rows: object) -> Mapping[str, Any]:
-    if not isinstance(rows, list) or len(rows) != 1:
-        raise ValueError("Neo4j graph metrics query returned malformed rows")
-    row = rows[0]
-    if not isinstance(row, Mapping):
-        raise ValueError("Neo4j graph metrics query returned a malformed row")
-    required_fields = {"node_count", "edge_count", "label_counts", "nodes", "relationships"}
-    if not required_fields <= row.keys():
-        raise ValueError("Neo4j graph metrics query returned an incomplete row")
-    return row
-
-
-def _int_field(row: Mapping[str, Any], field_name: str) -> int:
-    value = row[field_name]
-    if isinstance(value, bool) or not isinstance(value, int):
-        raise ValueError(f"Neo4j graph metrics field {field_name!r} is malformed")
-    if value < 0:
-        raise ValueError(f"Neo4j graph metrics field {field_name!r} cannot be negative")
-    return value
-
-
-def _list_field(row: Mapping[str, Any], field_name: str) -> list[Any]:
-    value = row[field_name]
-    if not isinstance(value, list):
-        raise ValueError(f"Neo4j graph metrics field {field_name!r} is malformed")
-    return value
-
-
-def _label_counts(value: object) -> dict[str, int]:
-    if not isinstance(value, list):
-        raise ValueError("Neo4j graph metrics field 'label_counts' is malformed")
-
-    counts: dict[str, int] = {}
-    for item in value:
-        if not isinstance(item, Mapping):
-            raise ValueError("Neo4j graph metrics field 'label_counts' is malformed")
-        label = item.get("label")
-        count = item.get("count")
-        if not isinstance(label, str):
-            raise ValueError("Neo4j graph metrics label count is missing a string label")
-        if isinstance(count, bool) or not isinstance(count, int) or count < 0:
-            raise ValueError("Neo4j graph metrics label count is malformed")
-        counts[label] = count
-    return counts
+    return read_live_graph_metrics(client, strict=True)

--- a/graph_engine/status/manager.py
+++ b/graph_engine/status/manager.py
@@ -1,0 +1,176 @@
+"""State machine for the current Neo4j live graph status."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from datetime import datetime, timezone
+
+from graph_engine.models import GraphSnapshot, Neo4jGraphStatus
+from graph_engine.status.store import StatusStore
+
+
+def require_ready_status(graph_status: Neo4jGraphStatus) -> Neo4jGraphStatus:
+    """Return a ready status or block reads from a non-ready graph."""
+
+    if graph_status.graph_status != "ready":
+        raise PermissionError(
+            "Neo4j live graph reads require graph_status='ready'; "
+            f"received {graph_status.graph_status!r}",
+        )
+    return graph_status
+
+
+class GraphStatusManager:
+    """Manage allowed status transitions for the Neo4j live graph."""
+
+    def __init__(
+        self,
+        store: StatusStore,
+        *,
+        clock: Callable[[], datetime] | None = None,
+    ) -> None:
+        self.store = store
+        self._clock = clock or _utc_now
+
+    def get_status(self) -> Neo4jGraphStatus:
+        """Return the current status or raise when the status row is missing."""
+
+        status = self.store.read_current_status()
+        if status is None:
+            raise LookupError("Neo4j graph status has not been initialized")
+        return status
+
+    def require_ready(self) -> Neo4jGraphStatus:
+        """Return the current ready status or block non-ready graph reads."""
+
+        return require_ready_status(self.get_status())
+
+    def mark_rebuilding(self) -> Neo4jGraphStatus:
+        """Move an empty, ready, or failed status into rebuilding."""
+
+        current = self.store.read_current_status()
+        current_state = current.graph_status if current is not None else None
+        if current_state == "rebuilding":
+            raise ValueError("cannot transition graph_status from 'rebuilding' to 'rebuilding'")
+
+        if current_state not in {None, "ready", "failed"}:
+            raise ValueError(f"cannot transition graph_status from {current_state!r} to 'rebuilding'")
+
+        status = Neo4jGraphStatus(
+            graph_status="rebuilding",
+            graph_generation_id=current.graph_generation_id if current is not None else 0,
+            node_count=0,
+            edge_count=0,
+            key_label_counts={},
+            checksum="rebuilding",
+            last_verified_at=None,
+            last_reload_at=current.last_reload_at if current is not None else None,
+        )
+        self.store.write_current_status(status)
+        return status
+
+    def mark_ready(
+        self,
+        *,
+        node_count: int,
+        edge_count: int,
+        key_label_counts: dict[str, int],
+        checksum: str,
+        graph_generation_id: int | None = None,
+        reload_completed: bool = False,
+    ) -> Neo4jGraphStatus:
+        """Move from rebuilding to ready after live graph verification passes."""
+
+        current = self.store.read_current_status()
+        current_state = current.graph_status if current is not None else None
+        if current_state != "rebuilding":
+            raise ValueError(
+                "cannot transition graph_status from "
+                f"{current_state!r} to 'ready'",
+            )
+        assert current is not None
+
+        next_generation_id = (
+            current.graph_generation_id + 1
+            if graph_generation_id is None
+            else graph_generation_id
+        )
+        if next_generation_id < current.graph_generation_id:
+            raise ValueError(
+                "graph_generation_id cannot move backwards: "
+                f"current={current.graph_generation_id}, requested={next_generation_id}",
+            )
+
+        now = self._clock()
+        status = Neo4jGraphStatus(
+            graph_status="ready",
+            graph_generation_id=next_generation_id,
+            node_count=node_count,
+            edge_count=edge_count,
+            key_label_counts=dict(key_label_counts),
+            checksum=checksum,
+            last_verified_at=now,
+            last_reload_at=now if reload_completed else current.last_reload_at,
+        )
+        self.store.write_current_status(status)
+        return status
+
+    def mark_failed(
+        self,
+        *,
+        node_count: int = 0,
+        edge_count: int = 0,
+        key_label_counts: dict[str, int] | None = None,
+        checksum: str = "failed",
+    ) -> Neo4jGraphStatus:
+        """Expose the live graph as failed without silently restoring readiness."""
+
+        current = self.store.read_current_status()
+        current_state = current.graph_status if current is not None else None
+        if current_state not in {"rebuilding", "ready"}:
+            raise ValueError(
+                "cannot transition graph_status from "
+                f"{current_state!r} to 'failed'",
+            )
+        assert current is not None
+
+        status = Neo4jGraphStatus(
+            graph_status="failed",
+            graph_generation_id=current.graph_generation_id,
+            node_count=node_count,
+            edge_count=edge_count,
+            key_label_counts={} if key_label_counts is None else dict(key_label_counts),
+            checksum=checksum,
+            last_verified_at=None,
+            last_reload_at=current.last_reload_at,
+        )
+        self.store.write_current_status(status)
+        return status
+
+    def mark_verified(self, snapshot: GraphSnapshot) -> Neo4jGraphStatus:
+        """Refresh ready metrics from a canonical snapshot without bumping generation."""
+
+        current = self.require_ready()
+        if snapshot.graph_generation_id != current.graph_generation_id:
+            raise ValueError(
+                "snapshot graph_generation_id disagrees with current status: "
+                f"snapshot={snapshot.graph_generation_id}, "
+                f"current={current.graph_generation_id}",
+            )
+
+        status = Neo4jGraphStatus(
+            graph_status="ready",
+            graph_generation_id=current.graph_generation_id,
+            node_count=snapshot.node_count,
+            edge_count=snapshot.edge_count,
+            key_label_counts=dict(snapshot.key_label_counts),
+            checksum=snapshot.checksum,
+            last_verified_at=self._clock(),
+            last_reload_at=current.last_reload_at,
+        )
+        self.store.write_current_status(status)
+        return status
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)

--- a/graph_engine/status/manager.py
+++ b/graph_engine/status/manager.py
@@ -66,7 +66,7 @@ class GraphStatusManager:
             last_verified_at=None,
             last_reload_at=current.last_reload_at if current is not None else None,
         )
-        self.store.write_current_status(status)
+        self._commit_transition(current, status)
         return status
 
     def mark_ready(
@@ -112,7 +112,7 @@ class GraphStatusManager:
             last_verified_at=now,
             last_reload_at=now if reload_completed else current.last_reload_at,
         )
-        self.store.write_current_status(status)
+        self._commit_transition(current, status)
         return status
 
     def mark_failed(
@@ -144,7 +144,7 @@ class GraphStatusManager:
             last_verified_at=None,
             last_reload_at=current.last_reload_at,
         )
-        self.store.write_current_status(status)
+        self._commit_transition(current, status)
         return status
 
     def mark_verified(self, snapshot: GraphSnapshot) -> Neo4jGraphStatus:
@@ -168,8 +168,21 @@ class GraphStatusManager:
             last_verified_at=self._clock(),
             last_reload_at=current.last_reload_at,
         )
-        self.store.write_current_status(status)
+        self._commit_transition(current, status)
         return status
+
+    def _commit_transition(
+        self,
+        expected_status: Neo4jGraphStatus | None,
+        next_status: Neo4jGraphStatus,
+    ) -> None:
+        if not self.store.compare_and_write_current_status(
+            expected_status=expected_status,
+            next_status=next_status,
+        ):
+            raise RuntimeError(
+                "stale graph_status transition rejected because current status changed",
+            )
 
 
 def _utc_now() -> datetime:

--- a/graph_engine/status/store.py
+++ b/graph_engine/status/store.py
@@ -15,3 +15,11 @@ class StatusStore(Protocol):
 
     def write_current_status(self, status: Neo4jGraphStatus) -> None:
         """Persist the current status row."""
+
+    def compare_and_write_current_status(
+        self,
+        *,
+        expected_status: Neo4jGraphStatus | None,
+        next_status: Neo4jGraphStatus,
+    ) -> bool:
+        """Atomically persist next_status only if the current row still matches."""

--- a/graph_engine/status/store.py
+++ b/graph_engine/status/store.py
@@ -1,0 +1,17 @@
+"""Status storage boundary for the current Neo4j live graph state."""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from graph_engine.models import Neo4jGraphStatus
+
+
+class StatusStore(Protocol):
+    """Persistence boundary for the singleton Neo4j graph status row."""
+
+    def read_current_status(self) -> Neo4jGraphStatus | None:
+        """Return the current status row, or None before bootstrap."""
+
+    def write_current_status(self, status: Neo4jGraphStatus) -> None:
+        """Persist the current status row."""

--- a/tests/integration/test_status.py
+++ b/tests/integration/test_status.py
@@ -31,6 +31,17 @@ class InMemoryStatusStore:
     def write_current_status(self, status: Neo4jGraphStatus) -> None:
         self.status = status
 
+    def compare_and_write_current_status(
+        self,
+        *,
+        expected_status: Neo4jGraphStatus | None,
+        next_status: Neo4jGraphStatus,
+    ) -> bool:
+        if self.status != expected_status:
+            return False
+        self.write_current_status(next_status)
+        return True
+
 
 class StaticSnapshotReader:
     def __init__(self, snapshot: GraphSnapshot) -> None:

--- a/tests/integration/test_status.py
+++ b/tests/integration/test_status.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+from uuid import uuid4
+
+import pytest
+
+from graph_engine.client import Neo4jClient
+from graph_engine.config import load_config_from_env
+from graph_engine.models import GraphSnapshot, Neo4jGraphStatus
+from graph_engine.schema.manager import SchemaManager
+from graph_engine.snapshots import build_graph_snapshot
+from graph_engine.status import GraphStatusManager, check_live_graph_consistency
+
+pytestmark = pytest.mark.skipif(
+    os.getenv("NEO4J_PASSWORD") is None,
+    reason="NEO4J_PASSWORD is not set; Neo4j status integration tests require a database.",
+)
+
+NOW = datetime(2026, 4, 17, 1, 2, 3, tzinfo=timezone.utc)
+
+
+class InMemoryStatusStore:
+    def __init__(self, status: Neo4jGraphStatus) -> None:
+        self.status = status
+
+    def read_current_status(self) -> Neo4jGraphStatus | None:
+        return self.status
+
+    def write_current_status(self, status: Neo4jGraphStatus) -> None:
+        self.status = status
+
+
+class StaticSnapshotReader:
+    def __init__(self, snapshot: GraphSnapshot) -> None:
+        self.snapshot = snapshot
+
+    def read_graph_snapshot(self, snapshot_ref: str) -> GraphSnapshot:
+        return self.snapshot
+
+
+def test_live_graph_consistency_matches_snapshot_and_detects_mutation() -> None:
+    pytest.importorskip("neo4j")
+
+    prefix = f"status-{uuid4().hex}"
+    source_node_id = f"{prefix}-source"
+    target_node_id = f"{prefix}-target"
+    edge_id = f"{prefix}-edge"
+
+    with Neo4jClient(load_config_from_env()) as client:
+        if not client.verify_connectivity():
+            pytest.skip("Neo4j is not reachable with the configured environment.")
+
+        manager = SchemaManager(client)
+        manager.apply_schema()
+        assert manager.verify_schema() is True
+
+        try:
+            client.execute_write(
+                """
+CREATE (source:Entity {
+    node_id: $source_node_id,
+    canonical_entity_id: $source_entity_id,
+    label: "Entity",
+    properties_json: "{}"
+})
+CREATE (target:Entity {
+    node_id: $target_node_id,
+    canonical_entity_id: $target_entity_id,
+    label: "Entity",
+    properties_json: "{}"
+})
+CREATE (source)-[:SUPPLY_CHAIN {
+    edge_id: $edge_id,
+    relationship_type: "SUPPLY_CHAIN",
+    weight: 1.0,
+    properties_json: "{}"
+}]->(target)
+""",
+                {
+                    "source_node_id": source_node_id,
+                    "source_entity_id": f"{prefix}-entity-source",
+                    "target_node_id": target_node_id,
+                    "target_entity_id": f"{prefix}-entity-target",
+                    "edge_id": edge_id,
+                },
+            )
+            snapshot = build_graph_snapshot("cycle-status", 11, client)
+            status_manager = GraphStatusManager(
+                InMemoryStatusStore(_status_from_snapshot(snapshot)),
+                clock=lambda: NOW,
+            )
+            snapshot_reader = StaticSnapshotReader(snapshot)
+
+            assert (
+                check_live_graph_consistency(
+                    "snapshot-1",
+                    client=client,
+                    snapshot_reader=snapshot_reader,
+                    status_manager=status_manager,
+                )
+                is True
+            )
+
+            client.execute_write(
+                "MATCH (node {node_id: $node_id}) SET node.status_mutation = $value",
+                {"node_id": source_node_id, "value": "changed"},
+            )
+
+            assert (
+                check_live_graph_consistency(
+                    "snapshot-1",
+                    client=client,
+                    snapshot_reader=snapshot_reader,
+                    status_manager=status_manager,
+                )
+                is False
+            )
+        finally:
+            client.execute_write(
+                "MATCH (node) WHERE node.node_id IN $node_ids DETACH DELETE node",
+                {"node_ids": [source_node_id, target_node_id]},
+            )
+
+
+def _status_from_snapshot(snapshot: GraphSnapshot) -> Neo4jGraphStatus:
+    return Neo4jGraphStatus(
+        graph_status="ready",
+        graph_generation_id=snapshot.graph_generation_id,
+        node_count=snapshot.node_count,
+        edge_count=snapshot.edge_count,
+        key_label_counts=snapshot.key_label_counts,
+        checksum=snapshot.checksum,
+        last_verified_at=NOW,
+        last_reload_at=None,
+    )

--- a/tests/unit/test_status.py
+++ b/tests/unit/test_status.py
@@ -1,0 +1,536 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Literal
+from unittest.mock import MagicMock
+
+import pytest
+
+from graph_engine.models import GraphSnapshot, Neo4jGraphStatus
+from graph_engine.status import (
+    GraphStatusManager,
+    check_live_graph_consistency,
+    require_ready_status,
+)
+from graph_engine.status.consistency import _read_live_graph_metrics
+
+NOW = datetime(2026, 4, 17, 1, 2, 3, tzinfo=timezone.utc)
+SNAPSHOT_CREATED_AT = datetime(2026, 4, 17, 1, 0, 0, tzinfo=timezone.utc)
+
+
+class InMemoryStatusStore:
+    def __init__(self, status: Neo4jGraphStatus | None = None) -> None:
+        self.status = status
+        self.writes: list[Neo4jGraphStatus] = []
+
+    def read_current_status(self) -> Neo4jGraphStatus | None:
+        return self.status
+
+    def write_current_status(self, status: Neo4jGraphStatus) -> None:
+        self.status = status
+        self.writes.append(status)
+
+
+class StaticSnapshotReader:
+    def __init__(
+        self,
+        snapshot: GraphSnapshot | None = None,
+        *,
+        error: Exception | None = None,
+    ) -> None:
+        self.snapshot = snapshot
+        self.error = error
+        self.calls: list[str] = []
+
+    def read_graph_snapshot(self, snapshot_ref: str) -> GraphSnapshot:
+        self.calls.append(snapshot_ref)
+        if self.error is not None:
+            raise self.error
+        if self.snapshot is None:
+            raise RuntimeError("snapshot not configured")
+        return self.snapshot
+
+
+class FakeLiveGraphClient:
+    def __init__(
+        self,
+        rows: list[dict[str, Any]] | object,
+        *,
+        error: Exception | None = None,
+    ) -> None:
+        self.rows = rows
+        self.error = error
+        self.calls: list[str] = []
+
+    def execute_read(
+        self,
+        query: str,
+        parameters: dict[str, Any] | None = None,
+    ) -> list[dict[str, Any]]:
+        self.calls.append(query)
+        if self.error is not None:
+            raise self.error
+        return self.rows  # type: ignore[return-value]
+
+
+class ExplodingReadyManager(GraphStatusManager):
+    def require_ready(self) -> Neo4jGraphStatus:
+        raise AssertionError("require_ready should not be called")
+
+
+def test_get_status_raises_for_missing_status() -> None:
+    manager = GraphStatusManager(InMemoryStatusStore())
+
+    with pytest.raises(LookupError, match="not been initialized"):
+        manager.get_status()
+
+
+def test_mark_rebuilding_bootstraps_empty_status() -> None:
+    store = InMemoryStatusStore()
+
+    status = GraphStatusManager(store, clock=lambda: NOW).mark_rebuilding()
+
+    assert status.graph_status == "rebuilding"
+    assert status.graph_generation_id == 0
+    assert status.node_count == 0
+    assert status.edge_count == 0
+    assert status.key_label_counts == {}
+    assert status.checksum == "rebuilding"
+    assert status.last_verified_at is None
+    assert status.last_reload_at is None
+    assert store.writes == [status]
+
+
+@pytest.mark.parametrize("source_status", ["ready", "failed"])
+def test_mark_rebuilding_allows_ready_and_failed_states(
+    source_status: Literal["ready", "failed"],
+) -> None:
+    store = InMemoryStatusStore(_status(graph_status=source_status, graph_generation_id=4))
+
+    status = GraphStatusManager(store, clock=lambda: NOW).mark_rebuilding()
+
+    assert status.graph_status == "rebuilding"
+    assert status.graph_generation_id == 4
+    assert status.node_count == 0
+    assert status.edge_count == 0
+    assert status.checksum == "rebuilding"
+
+
+def test_mark_rebuilding_rejects_existing_rebuilding_state() -> None:
+    manager = GraphStatusManager(InMemoryStatusStore(_status(graph_status="rebuilding")))
+
+    with pytest.raises(ValueError, match="rebuilding"):
+        manager.mark_rebuilding()
+
+
+@pytest.mark.parametrize("source_status", ["ready", "failed"])
+def test_mark_ready_only_allows_rebuilding(
+    source_status: Literal["ready", "failed"],
+) -> None:
+    manager = GraphStatusManager(InMemoryStatusStore(_status(graph_status=source_status)))
+
+    with pytest.raises(ValueError, match="to 'ready'"):
+        manager.mark_ready(
+            node_count=2,
+            edge_count=1,
+            key_label_counts={"Entity": 2},
+            checksum="abc123",
+        )
+
+
+def test_mark_ready_rejects_missing_status() -> None:
+    manager = GraphStatusManager(InMemoryStatusStore())
+
+    with pytest.raises(ValueError, match="None"):
+        manager.mark_ready(
+            node_count=2,
+            edge_count=1,
+            key_label_counts={"Entity": 2},
+            checksum="abc123",
+        )
+
+
+def test_mark_ready_writes_metrics_and_increments_generation() -> None:
+    store = InMemoryStatusStore(_status(graph_status="rebuilding", graph_generation_id=3))
+
+    status = GraphStatusManager(store, clock=lambda: NOW).mark_ready(
+        node_count=5,
+        edge_count=4,
+        key_label_counts={"Entity": 3, "Sector": 2},
+        checksum="ready-checksum",
+    )
+
+    assert status.graph_status == "ready"
+    assert status.graph_generation_id == 4
+    assert status.node_count == 5
+    assert status.edge_count == 4
+    assert status.key_label_counts == {"Entity": 3, "Sector": 2}
+    assert status.checksum == "ready-checksum"
+    assert status.last_verified_at == NOW
+    assert status.last_reload_at is None
+
+
+def test_mark_ready_sets_reload_timestamp_when_reload_completed() -> None:
+    store = InMemoryStatusStore(_status(graph_status="rebuilding", graph_generation_id=8))
+
+    status = GraphStatusManager(store, clock=lambda: NOW).mark_ready(
+        node_count=1,
+        edge_count=0,
+        key_label_counts={"Entity": 1},
+        checksum="ready-checksum",
+        graph_generation_id=8,
+        reload_completed=True,
+    )
+
+    assert status.graph_generation_id == 8
+    assert status.last_verified_at == NOW
+    assert status.last_reload_at == NOW
+
+
+def test_mark_ready_rejects_generation_backtracking() -> None:
+    manager = GraphStatusManager(
+        InMemoryStatusStore(_status(graph_status="rebuilding", graph_generation_id=8)),
+    )
+
+    with pytest.raises(ValueError, match="cannot move backwards"):
+        manager.mark_ready(
+            node_count=1,
+            edge_count=0,
+            key_label_counts={"Entity": 1},
+            checksum="ready-checksum",
+            graph_generation_id=7,
+        )
+
+
+@pytest.mark.parametrize("source_status", ["ready", "rebuilding"])
+def test_mark_failed_allows_ready_and_rebuilding(
+    source_status: Literal["ready", "rebuilding"],
+) -> None:
+    store = InMemoryStatusStore(_status(graph_status=source_status, graph_generation_id=6))
+
+    status = GraphStatusManager(store, clock=lambda: NOW).mark_failed(
+        node_count=2,
+        edge_count=1,
+        key_label_counts={"Entity": 2},
+        checksum="failed-checksum",
+    )
+
+    assert status.graph_status == "failed"
+    assert status.graph_generation_id == 6
+    assert status.node_count == 2
+    assert status.edge_count == 1
+    assert status.key_label_counts == {"Entity": 2}
+    assert status.checksum == "failed-checksum"
+    assert status.last_verified_at is None
+
+
+def test_mark_failed_rejects_failed_state() -> None:
+    manager = GraphStatusManager(InMemoryStatusStore(_status(graph_status="failed")))
+
+    with pytest.raises(ValueError, match="to 'failed'"):
+        manager.mark_failed()
+
+
+def test_mark_failed_rejects_missing_status() -> None:
+    manager = GraphStatusManager(InMemoryStatusStore())
+
+    with pytest.raises(ValueError, match="None"):
+        manager.mark_failed()
+
+
+def test_require_ready_returns_ready_status() -> None:
+    ready_status = _status()
+
+    assert require_ready_status(ready_status) is ready_status
+    assert GraphStatusManager(InMemoryStatusStore(ready_status)).require_ready() is ready_status
+
+
+@pytest.mark.parametrize("graph_status", ["rebuilding", "failed"])
+def test_require_ready_rejects_non_ready_status(
+    graph_status: Literal["rebuilding", "failed"],
+) -> None:
+    status = _status(graph_status=graph_status)
+
+    with pytest.raises(PermissionError, match="ready"):
+        require_ready_status(status)
+    with pytest.raises(PermissionError, match="ready"):
+        GraphStatusManager(InMemoryStatusStore(status)).require_ready()
+
+
+def test_mark_verified_updates_metrics_without_bumping_generation() -> None:
+    store = InMemoryStatusStore(_status(graph_generation_id=9))
+    snapshot = _snapshot(graph_generation_id=9, node_count=4, edge_count=3)
+
+    status = GraphStatusManager(store, clock=lambda: NOW).mark_verified(snapshot)
+
+    assert status.graph_status == "ready"
+    assert status.graph_generation_id == 9
+    assert status.node_count == 4
+    assert status.edge_count == 3
+    assert status.checksum == snapshot.checksum
+    assert status.last_verified_at == NOW
+
+
+def test_mark_verified_rejects_generation_mismatch() -> None:
+    manager = GraphStatusManager(InMemoryStatusStore(_status(graph_generation_id=9)))
+
+    with pytest.raises(ValueError, match="graph_generation_id"):
+        manager.mark_verified(_snapshot(graph_generation_id=8))
+
+
+def test_check_live_graph_consistency_returns_true_for_matching_snapshot() -> None:
+    client = FakeLiveGraphClient(_metrics_rows())
+    snapshot = _snapshot_from_live_client(client, graph_generation_id=3)
+    store = InMemoryStatusStore(_status_from_snapshot(snapshot))
+
+    result = check_live_graph_consistency(
+        "snapshot-1",
+        client=client,  # type: ignore[arg-type]
+        snapshot_reader=StaticSnapshotReader(snapshot),
+        status_manager=GraphStatusManager(store, clock=lambda: NOW),
+    )
+
+    assert result is True
+    assert store.writes == []
+
+
+def test_check_live_graph_consistency_requires_status_manager_by_default() -> None:
+    client = MagicMock()
+
+    with pytest.raises(ValueError, match="status_manager"):
+        check_live_graph_consistency(
+            "snapshot-1",
+            client=client,
+            snapshot_reader=StaticSnapshotReader(_snapshot()),
+        )
+
+    client.execute_read.assert_not_called()
+
+
+def test_check_live_graph_consistency_blocks_non_ready_before_reads() -> None:
+    client = FakeLiveGraphClient(_metrics_rows())
+    snapshot_reader = StaticSnapshotReader(_snapshot())
+    manager = GraphStatusManager(InMemoryStatusStore(_status(graph_status="rebuilding")))
+
+    with pytest.raises(PermissionError, match="ready"):
+        check_live_graph_consistency(
+            "snapshot-1",
+            client=client,  # type: ignore[arg-type]
+            snapshot_reader=snapshot_reader,
+            status_manager=manager,
+        )
+
+    assert client.calls == []
+    assert snapshot_reader.calls == []
+
+
+def test_check_live_graph_consistency_can_skip_ready_guard_for_maintenance() -> None:
+    client = FakeLiveGraphClient(_metrics_rows())
+    snapshot = _snapshot_from_live_client(client, graph_generation_id=3)
+    manager = ExplodingReadyManager(
+        InMemoryStatusStore(_status(graph_status="rebuilding", graph_generation_id=3)),
+    )
+    client.calls = []
+
+    result = check_live_graph_consistency(
+        "snapshot-1",
+        client=client,  # type: ignore[arg-type]
+        snapshot_reader=StaticSnapshotReader(snapshot),
+        status_manager=manager,
+        require_ready=False,
+    )
+
+    assert result is True
+    assert len(client.calls) == 1
+
+
+@pytest.mark.parametrize(
+    "snapshot_updates",
+    [
+        {"graph_generation_id": 99},
+        {"node_count": 99},
+        {"edge_count": 99},
+        {"key_label_counts": {"Entity": 99}},
+        {"checksum": "wrong-checksum"},
+    ],
+)
+def test_check_live_graph_consistency_returns_false_for_mismatches(
+    snapshot_updates: dict[str, Any],
+) -> None:
+    client = FakeLiveGraphClient(_metrics_rows())
+    snapshot = _snapshot_from_live_client(client, graph_generation_id=3).model_copy(
+        update=snapshot_updates,
+    )
+    manager = GraphStatusManager(
+        InMemoryStatusStore(_status(graph_generation_id=3)),
+        clock=lambda: NOW,
+    )
+    client.calls = []
+
+    assert (
+        check_live_graph_consistency(
+            "snapshot-1",
+            client=client,  # type: ignore[arg-type]
+            snapshot_reader=StaticSnapshotReader(snapshot),
+            status_manager=manager,
+        )
+        is False
+    )
+
+
+def test_check_live_graph_consistency_reader_error_fails_closed() -> None:
+    client = FakeLiveGraphClient(_metrics_rows())
+    manager = GraphStatusManager(InMemoryStatusStore(_status(graph_generation_id=3)))
+
+    result = check_live_graph_consistency(
+        "snapshot-1",
+        client=client,  # type: ignore[arg-type]
+        snapshot_reader=StaticSnapshotReader(error=RuntimeError("reader failed")),
+        status_manager=manager,
+    )
+
+    assert result is False
+    assert client.calls == []
+
+
+def test_check_live_graph_consistency_client_error_fails_closed() -> None:
+    client = FakeLiveGraphClient(_metrics_rows(), error=RuntimeError("neo4j failed"))
+    snapshot = _snapshot_from_rows(graph_generation_id=3)
+    manager = GraphStatusManager(InMemoryStatusStore(_status(graph_generation_id=3)))
+
+    result = check_live_graph_consistency(
+        "snapshot-1",
+        client=client,  # type: ignore[arg-type]
+        snapshot_reader=StaticSnapshotReader(snapshot),
+        status_manager=manager,
+    )
+
+    assert result is False
+
+
+def test_check_live_graph_consistency_malformed_client_result_fails_closed() -> None:
+    client = FakeLiveGraphClient([{"node_count": 2}])
+    snapshot = _snapshot_from_rows(graph_generation_id=3)
+    manager = GraphStatusManager(InMemoryStatusStore(_status(graph_generation_id=3)))
+
+    result = check_live_graph_consistency(
+        "snapshot-1",
+        client=client,  # type: ignore[arg-type]
+        snapshot_reader=StaticSnapshotReader(snapshot),
+        status_manager=manager,
+    )
+
+    assert result is False
+
+
+def _status(
+    *,
+    graph_status: Literal["ready", "rebuilding", "failed"] = "ready",
+    graph_generation_id: int = 3,
+    node_count: int = 2,
+    edge_count: int = 1,
+    key_label_counts: dict[str, int] | None = None,
+    checksum: str = "abc123",
+) -> Neo4jGraphStatus:
+    return Neo4jGraphStatus(
+        graph_status=graph_status,
+        graph_generation_id=graph_generation_id,
+        node_count=node_count,
+        edge_count=edge_count,
+        key_label_counts={"Entity": 2} if key_label_counts is None else key_label_counts,
+        checksum=checksum,
+        last_verified_at=NOW if graph_status == "ready" else None,
+        last_reload_at=None,
+    )
+
+
+def _status_from_snapshot(snapshot: GraphSnapshot) -> Neo4jGraphStatus:
+    return Neo4jGraphStatus(
+        graph_status="ready",
+        graph_generation_id=snapshot.graph_generation_id,
+        node_count=snapshot.node_count,
+        edge_count=snapshot.edge_count,
+        key_label_counts=snapshot.key_label_counts,
+        checksum=snapshot.checksum,
+        last_verified_at=NOW,
+        last_reload_at=None,
+    )
+
+
+def _snapshot(
+    *,
+    graph_generation_id: int = 3,
+    node_count: int = 2,
+    edge_count: int = 1,
+    key_label_counts: dict[str, int] | None = None,
+    checksum: str = "abc123",
+) -> GraphSnapshot:
+    return GraphSnapshot(
+        cycle_id="cycle-1",
+        snapshot_id="snapshot-1",
+        graph_generation_id=graph_generation_id,
+        node_count=node_count,
+        edge_count=edge_count,
+        key_label_counts={"Entity": node_count} if key_label_counts is None else key_label_counts,
+        checksum=checksum,
+        created_at=SNAPSHOT_CREATED_AT,
+    )
+
+
+def _snapshot_from_live_client(
+    client: FakeLiveGraphClient,
+    *,
+    graph_generation_id: int,
+) -> GraphSnapshot:
+    node_count, edge_count, key_label_counts, checksum = _read_live_graph_metrics(
+        client,  # type: ignore[arg-type]
+    )
+    return _snapshot(
+        graph_generation_id=graph_generation_id,
+        node_count=node_count,
+        edge_count=edge_count,
+        key_label_counts=key_label_counts,
+        checksum=checksum,
+    )
+
+
+def _snapshot_from_rows(*, graph_generation_id: int) -> GraphSnapshot:
+    return _snapshot_from_live_client(
+        FakeLiveGraphClient(_metrics_rows()),
+        graph_generation_id=graph_generation_id,
+    )
+
+
+def _metrics_rows() -> list[dict[str, Any]]:
+    nodes = [
+        {
+            "labels": ["Entity"],
+            "node_id": "node-a",
+            "canonical_entity_id": "entity-a",
+            "properties": {"node_id": "node-a", "ticker": "AAA"},
+        },
+        {
+            "labels": ["Entity"],
+            "node_id": "node-b",
+            "canonical_entity_id": "entity-b",
+            "properties": {"node_id": "node-b", "ticker": "BBB"},
+        },
+    ]
+    relationships = [
+        {
+            "source_node_id": "node-a",
+            "target_node_id": "node-b",
+            "relationship_type": "SUPPLY_CHAIN",
+            "edge_id": "edge-1",
+            "properties": {"edge_id": "edge-1", "weight": 0.7},
+        }
+    ]
+    return [
+        {
+            "node_count": 2,
+            "edge_count": 1,
+            "label_counts": [{"label": "Entity", "count": 2}],
+            "nodes": nodes,
+            "relationships": relationships,
+        }
+    ]

--- a/tests/unit/test_status.py
+++ b/tests/unit/test_status.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from datetime import datetime, timezone
 from typing import Any, Literal
 from unittest.mock import MagicMock
@@ -29,6 +30,41 @@ class InMemoryStatusStore:
     def write_current_status(self, status: Neo4jGraphStatus) -> None:
         self.status = status
         self.writes.append(status)
+
+    def compare_and_write_current_status(
+        self,
+        *,
+        expected_status: Neo4jGraphStatus | None,
+        next_status: Neo4jGraphStatus,
+    ) -> bool:
+        if self.status != expected_status:
+            return False
+        self.write_current_status(next_status)
+        return True
+
+
+class InterleavingStatusStore(InMemoryStatusStore):
+    def __init__(
+        self,
+        status: Neo4jGraphStatus,
+        interleaved_status: Neo4jGraphStatus,
+    ) -> None:
+        super().__init__(status)
+        self.interleaved_status = interleaved_status
+        self.compare_calls = 0
+
+    def compare_and_write_current_status(
+        self,
+        *,
+        expected_status: Neo4jGraphStatus | None,
+        next_status: Neo4jGraphStatus,
+    ) -> bool:
+        self.compare_calls += 1
+        self.status = self.interleaved_status
+        return super().compare_and_write_current_status(
+            expected_status=expected_status,
+            next_status=next_status,
+        )
 
 
 class StaticSnapshotReader:
@@ -202,6 +238,41 @@ def test_mark_ready_rejects_generation_backtracking() -> None:
         )
 
 
+def test_mark_ready_rejects_stale_rebuilding_status_before_write() -> None:
+    interleaved_status = _status(graph_status="failed", graph_generation_id=8)
+    store = InterleavingStatusStore(
+        _status(graph_status="rebuilding", graph_generation_id=8),
+        interleaved_status,
+    )
+
+    with pytest.raises(RuntimeError, match="stale graph_status transition"):
+        GraphStatusManager(store, clock=lambda: NOW).mark_ready(
+            node_count=1,
+            edge_count=0,
+            key_label_counts={"Entity": 1},
+            checksum="ready-checksum",
+        )
+
+    assert store.status == interleaved_status
+    assert store.writes == []
+    assert store.compare_calls == 1
+
+
+def test_mark_rebuilding_rejects_stale_ready_status_before_write() -> None:
+    interleaved_status = _status(graph_status="failed", graph_generation_id=8)
+    store = InterleavingStatusStore(
+        _status(graph_status="ready", graph_generation_id=8),
+        interleaved_status,
+    )
+
+    with pytest.raises(RuntimeError, match="stale graph_status transition"):
+        GraphStatusManager(store, clock=lambda: NOW).mark_rebuilding()
+
+    assert store.status == interleaved_status
+    assert store.writes == []
+    assert store.compare_calls == 1
+
+
 @pytest.mark.parametrize("source_status", ["ready", "rebuilding"])
 def test_mark_failed_allows_ready_and_rebuilding(
     source_status: Literal["ready", "rebuilding"],
@@ -236,6 +307,21 @@ def test_mark_failed_rejects_missing_status() -> None:
 
     with pytest.raises(ValueError, match="None"):
         manager.mark_failed()
+
+
+def test_mark_failed_rejects_stale_ready_status_before_write() -> None:
+    interleaved_status = _status(graph_status="rebuilding", graph_generation_id=8)
+    store = InterleavingStatusStore(
+        _status(graph_status="ready", graph_generation_id=8),
+        interleaved_status,
+    )
+
+    with pytest.raises(RuntimeError, match="stale graph_status transition"):
+        GraphStatusManager(store, clock=lambda: NOW).mark_failed()
+
+    assert store.status == interleaved_status
+    assert store.writes == []
+    assert store.compare_calls == 1
 
 
 def test_require_ready_returns_ready_status() -> None:
@@ -276,6 +362,23 @@ def test_mark_verified_rejects_generation_mismatch() -> None:
 
     with pytest.raises(ValueError, match="graph_generation_id"):
         manager.mark_verified(_snapshot(graph_generation_id=8))
+
+
+def test_mark_verified_rejects_stale_ready_status_before_write() -> None:
+    interleaved_status = _status(graph_status="failed", graph_generation_id=9)
+    store = InterleavingStatusStore(
+        _status(graph_status="ready", graph_generation_id=9),
+        interleaved_status,
+    )
+
+    with pytest.raises(RuntimeError, match="stale graph_status transition"):
+        GraphStatusManager(store, clock=lambda: NOW).mark_verified(
+            _snapshot(graph_generation_id=9),
+        )
+
+    assert store.status == interleaved_status
+    assert store.writes == []
+    assert store.compare_calls == 1
 
 
 def test_check_live_graph_consistency_returns_true_for_matching_snapshot() -> None:
@@ -356,6 +459,7 @@ def test_check_live_graph_consistency_can_skip_ready_guard_for_maintenance() -> 
 )
 def test_check_live_graph_consistency_returns_false_for_mismatches(
     snapshot_updates: dict[str, Any],
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     client = FakeLiveGraphClient(_metrics_rows())
     snapshot = _snapshot_from_live_client(client, graph_generation_id=3).model_copy(
@@ -366,6 +470,7 @@ def test_check_live_graph_consistency_returns_false_for_mismatches(
         clock=lambda: NOW,
     )
     client.calls = []
+    caplog.set_level(logging.WARNING, logger="graph_engine.status.consistency")
 
     assert (
         check_live_graph_consistency(
@@ -376,11 +481,19 @@ def test_check_live_graph_consistency_returns_false_for_mismatches(
         )
         is False
     )
+    assert any(
+        getattr(record, "snapshot_ref", None) == "snapshot-1"
+        and getattr(record, "failure_stage", None) == "result_validation"
+        for record in caplog.records
+    )
 
 
-def test_check_live_graph_consistency_reader_error_fails_closed() -> None:
+def test_check_live_graph_consistency_reader_error_fails_closed(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     client = FakeLiveGraphClient(_metrics_rows())
     manager = GraphStatusManager(InMemoryStatusStore(_status(graph_generation_id=3)))
+    caplog.set_level(logging.ERROR, logger="graph_engine.status.consistency")
 
     result = check_live_graph_consistency(
         "snapshot-1",
@@ -391,12 +504,20 @@ def test_check_live_graph_consistency_reader_error_fails_closed() -> None:
 
     assert result is False
     assert client.calls == []
+    assert any(
+        getattr(record, "snapshot_ref", None) == "snapshot-1"
+        and getattr(record, "failure_stage", None) == "snapshot_read"
+        for record in caplog.records
+    )
 
 
-def test_check_live_graph_consistency_client_error_fails_closed() -> None:
+def test_check_live_graph_consistency_client_error_fails_closed(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     client = FakeLiveGraphClient(_metrics_rows(), error=RuntimeError("neo4j failed"))
     snapshot = _snapshot_from_rows(graph_generation_id=3)
     manager = GraphStatusManager(InMemoryStatusStore(_status(graph_generation_id=3)))
+    caplog.set_level(logging.ERROR, logger="graph_engine.status.consistency")
 
     result = check_live_graph_consistency(
         "snapshot-1",
@@ -406,6 +527,11 @@ def test_check_live_graph_consistency_client_error_fails_closed() -> None:
     )
 
     assert result is False
+    assert any(
+        getattr(record, "snapshot_ref", None) == "snapshot-1"
+        and getattr(record, "failure_stage", None) == "live_graph_read"
+        for record in caplog.records
+    )
 
 
 def test_check_live_graph_consistency_malformed_client_result_fails_closed() -> None:


### PR DESCRIPTION
Closes #6

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `benchmarks/artifacts/lite_target_100k_800k.json`, `benchmarks/generate_synthetic.py`, `benchmarks/run_benchmark.py`, `cross-cutting`, `graph_engine/__pycache__/__init__.cpython-314.pyc`, `graph_engine/sync/live_graph.py`, `project_ult_graph_engine.egg-info/SOURCES.txt`, `tests/integration/test_benchmark_neo4j.py`, `tests/unit/test_snapshots.py`


---
## 1. 背景与目标
项目文档 §8.1、§9.3、§16.1 要求 `neo4j_graph_status` 成为 Phase 0 一致性校验和所有 Neo4j 读取的共同 Gate。当前代码已经在 `graph_engine/models.py` 定义了 `Neo4jGraphStatus`，`graph_engine/propagation/context.py` 里有局部的 `graph_status` ready 检查，`graph_engine/schema/manager.py` 的 `SchemaManager.drop_all()` 也已经要求 `graph_status='rebuilding'` 才允许 destructive clear。缺口是 `graph_engine/status/` 仍没有集中状态机、`StatusStore` 抽象、可复用 ready guard，也没有项目文档中的 `check_live_graph_consistency(snapshot_ref)` 入口。本 issue 交付状态机与一致性校验基础，供 #7 Cold Reload 和后续 query/read-only simulation 复用。

## 2. 所属模块
主要写入路径：
- `graph_engine/status/__init__.py`
- `graph_engine/status/store.py`（新建，当前态存储协议）
- `graph_engine/status/manager.py`（新建，状态机与 guard）
- `graph_engine/status/consistency.py`（新建，Phase 0 一致性校验）
- `graph_engine/__init__.py`（仅导出 public API）
- `tests/unit/test_status.py`（新建）
- `tests/integration/test_status.py`（新建）

相邻只读 / 集成路径：
- `graph_engine/models.py`：复用 `Neo4jGraphStatus`、`GraphSnapshot`，不重定义模型。
- `graph_engine/client.py`：复用 `Neo4jClient.execute_read()`。
- `graph_engine/schema/manager.py`：复用现有 `drop_all(..., graph_status=...)` 的状态约束，不改 schema lifecycle。
- `graph_engine/snapshots/generator.py`：只读参考当前 checksum/metric 语义；#20 已负责 formal snapshot 的 ready/generation guard。
- `benchmarks/artifacts/lite_target_100k_800k.json`：作为性能预算回归输入，不在本 issue 修改。

## 3. 实现范围
- 新建 `graph_engine/status/store.py`，定义 `StatusStore(Protocol)`，方法为 `read_current_status(self) -> Neo4jGraphStatus | None` 与 `write_current_status(self, status: Neo4jGraphStatus) -> None`；不引入 psycopg 或具体 PostgreSQL adapter。
- 新建 `graph_engine/status/manager.py`，实现 `GraphStatusManager`，构造函数为 `__init__(self, store: StatusStore, *, clock: Callable[[], datetime] | None = None) -> None`，沿用现有代码的显式依赖注入和可测试 fake 风格。
- 在 `GraphStatusManager` 中实现状态流转：空状态/`failed`/`ready` 可以进入 `rebuilding`；只有 `rebuilding` 可以进入 `ready`；`rebuilding` 或 `ready` 可以进入 `failed`；非法流转抛 `ValueError`，缺失当前状态的 `get_status()` 抛 `LookupError`。
- 在 `GraphStatusManager` 中实现 ready guard：`require_ready(self) -> Neo4jGrap