### PR TITLE
feat(#30): [milestone-2 review] P0: Ready gate is not integrated across all Neo4j read paths

### DIFF
--- a/graph_engine/__init__.py
+++ b/graph_engine/__init__.py
@@ -15,6 +15,7 @@ from graph_engine.models import (
     PropagationResult,
     PromotionPlan,
 )
+from graph_engine.query import query_subgraph, simulate_readonly_impact
 from graph_engine.reload import (
     CanonicalReader,
     ColdReloadTimeoutError,
@@ -66,6 +67,8 @@ __all__ = [
     "get_constraint_statements",
     "get_index_statements",
     "load_config_from_env",
+    "query_subgraph",
     "rebuild_gds_projection",
     "require_ready_status",
+    "simulate_readonly_impact",
 ]

--- a/graph_engine/propagation/fundamental.py
+++ b/graph_engine/propagation/fundamental.py
@@ -34,7 +34,6 @@ def run_fundamental_propagation(
 
     if status_manager is None:
         raise ValueError("fundamental propagation requires status_manager")
-    status_manager.require_ready()
 
     if _FUNDAMENTAL_CHANNEL not in context.enabled_channels:
         raise PermissionError("fundamental propagation requires the fundamental channel")
@@ -43,23 +42,24 @@ def run_fundamental_propagation(
     if result_limit < 1:
         raise ValueError("result_limit must be greater than zero")
 
-    projection_name = graph_name or _default_projection_name(context)
-    _drop_projection_if_exists(client, projection_name)
-    try:
-        _create_projection(client, projection_name)
-        pagerank_entities = _stream_pagerank(
-            client,
-            projection_name,
-            max_iterations=max_iterations,
-            result_limit=result_limit,
-        )
-        activated_paths = _read_activated_paths(
-            context,
-            client,
-            result_limit=result_limit,
-        )
-    finally:
+    with status_manager.ready_read():
+        projection_name = graph_name or _default_projection_name(context)
         _drop_projection_if_exists(client, projection_name)
+        try:
+            _create_projection(client, projection_name)
+            pagerank_entities = _stream_pagerank(
+                client,
+                projection_name,
+                max_iterations=max_iterations,
+                result_limit=result_limit,
+            )
+            activated_paths = _read_activated_paths(
+                context,
+                client,
+                result_limit=result_limit,
+            )
+        finally:
+            _drop_projection_if_exists(client, projection_name)
 
     # Keep PageRank as the GDS topology pass, but rank persisted impacts by the
     # documented five-factor path scores so the snapshot outputs stay coherent.

--- a/graph_engine/propagation/fundamental.py
+++ b/graph_engine/propagation/fundamental.py
@@ -10,6 +10,7 @@ from graph_engine.client import Neo4jClient
 from graph_engine.models import PropagationContext, PropagationResult
 from graph_engine.propagation.scoring import build_score_explanation
 from graph_engine.schema.definitions import RelationshipType
+from graph_engine.status import GraphStatusManager
 
 FUNDAMENTAL_RELATIONSHIP_TYPES = (
     RelationshipType.SUPPLY_CHAIN.value,
@@ -24,11 +25,16 @@ def run_fundamental_propagation(
     context: PropagationContext,
     client: Neo4jClient,
     *,
+    status_manager: GraphStatusManager | None = None,
     graph_name: str | None = None,
     max_iterations: int = 20,
     result_limit: int = 100,
 ) -> PropagationResult:
     """Run weighted PageRank for the fundamental channel and explain edge paths."""
+
+    if status_manager is None:
+        raise ValueError("fundamental propagation requires status_manager")
+    status_manager.require_ready()
 
     if _FUNDAMENTAL_CHANNEL not in context.enabled_channels:
         raise PermissionError("fundamental propagation requires the fundamental channel")

--- a/graph_engine/query/__init__.py
+++ b/graph_engine/query/__init__.py
@@ -41,6 +41,7 @@ RETURN [node IN nodes WHERE node IS NOT NULL | {
            properties: properties(relationship)
        }] AS subgraph_edges
 """
+MAX_QUERY_DEPTH = 10
 
 
 def query_subgraph(
@@ -52,13 +53,15 @@ def query_subgraph(
 ) -> dict[str, Any]:
     """Return a local subgraph only when the live graph is ready."""
 
-    ready_status = _require_ready(status_manager, "subgraph query")
-    return _query_subgraph_after_ready(
-        seed_entities,
-        depth,
-        client=client,
-        ready_status=ready_status,
-    )
+    if status_manager is None:
+        raise ValueError("subgraph query requires status_manager")
+    with status_manager.ready_read() as ready_status:
+        return _query_subgraph_after_ready(
+            seed_entities,
+            depth,
+            client=client,
+            ready_status=ready_status,
+        )
 
 
 def simulate_readonly_impact(
@@ -70,20 +73,22 @@ def simulate_readonly_impact(
 ) -> dict[str, Any]:
     """Run the read-only local simulation boundary behind the ready gate."""
 
-    ready_status = _require_ready(status_manager, "readonly simulation")
-    depth = _context_int(context, "depth", default=1)
-    subgraph = _query_subgraph_after_ready(
-        seed_entities,
-        depth,
-        client=client,
-        ready_status=ready_status,
-    )
-    return {
-        "graph_generation_id": ready_status.graph_generation_id,
-        "seed_entities": list(seed_entities),
-        "impacted_subgraph": subgraph,
-        "status": "ready",
-    }
+    if status_manager is None:
+        raise ValueError("readonly simulation requires status_manager")
+    with status_manager.ready_read() as ready_status:
+        depth = _context_int(context, "depth", default=1)
+        subgraph = _query_subgraph_after_ready(
+            seed_entities,
+            depth,
+            client=client,
+            ready_status=ready_status,
+        )
+        return {
+            "graph_generation_id": ready_status.graph_generation_id,
+            "seed_entities": list(seed_entities),
+            "impacted_subgraph": subgraph,
+            "status": "ready",
+        }
 
 
 def _query_subgraph_after_ready(
@@ -108,15 +113,6 @@ def _query_subgraph_after_ready(
     }
 
 
-def _require_ready(
-    status_manager: GraphStatusManager | None,
-    operation_name: str,
-) -> Neo4jGraphStatus:
-    if status_manager is None:
-        raise ValueError(f"{operation_name} requires status_manager")
-    return status_manager.require_ready()
-
-
 def _validated_seed_entities(seed_entities: Sequence[str]) -> list[str]:
     seeds = [seed for seed in seed_entities if isinstance(seed, str) and seed.strip()]
     if not seeds:
@@ -129,6 +125,8 @@ def _validated_depth(depth: int) -> int:
         raise ValueError("depth must be an integer")
     if depth < 0:
         raise ValueError("depth must be non-negative")
+    if depth > MAX_QUERY_DEPTH:
+        raise ValueError(f"depth must be <= {MAX_QUERY_DEPTH}")
     return depth
 
 

--- a/graph_engine/query/__init__.py
+++ b/graph_engine/query/__init__.py
@@ -1,1 +1,162 @@
+"""Status-gated public Neo4j read APIs."""
 
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from graph_engine.client import Neo4jClient
+from graph_engine.models import Neo4jGraphStatus
+from graph_engine.status import GraphStatusManager
+
+_SUBGRAPH_QUERY_TEMPLATE = """
+MATCH (seed)
+WHERE seed.canonical_entity_id IN $seed_entities
+   OR seed.node_id IN $seed_entities
+OPTIONAL MATCH path = (seed)-[*0..__DEPTH__]-(connected)
+WITH collect(DISTINCT seed) AS seeds,
+     collect(path) AS paths
+WITH seeds,
+     reduce(nodes_acc = [], path IN paths | nodes_acc + nodes(path)) AS path_nodes,
+     reduce(edges_acc = [], path IN paths | edges_acc + relationships(path)) AS path_edges
+WITH seeds + path_nodes AS raw_nodes,
+     path_edges AS raw_edges
+UNWIND raw_nodes AS node
+WITH collect(DISTINCT node) AS nodes,
+     raw_edges
+UNWIND CASE WHEN raw_edges = [] THEN [NULL] ELSE raw_edges END AS relationship
+WITH nodes,
+     [item IN collect(DISTINCT relationship) WHERE item IS NOT NULL] AS relationships
+RETURN [node IN nodes WHERE node IS NOT NULL | {
+           node_id: node.node_id,
+           canonical_entity_id: node.canonical_entity_id,
+           labels: labels(node),
+           properties: properties(node)
+       }] AS subgraph_nodes,
+       [relationship IN relationships | {
+           edge_id: relationship.edge_id,
+           source_node_id: startNode(relationship).node_id,
+           target_node_id: endNode(relationship).node_id,
+           relationship_type: type(relationship),
+           properties: properties(relationship)
+       }] AS subgraph_edges
+"""
+
+
+def query_subgraph(
+    seed_entities: list[str],
+    depth: int,
+    *,
+    client: Neo4jClient,
+    status_manager: GraphStatusManager | None = None,
+) -> dict[str, Any]:
+    """Return a local subgraph only when the live graph is ready."""
+
+    ready_status = _require_ready(status_manager, "subgraph query")
+    return _query_subgraph_after_ready(
+        seed_entities,
+        depth,
+        client=client,
+        ready_status=ready_status,
+    )
+
+
+def simulate_readonly_impact(
+    seed_entities: list[str],
+    context: object,
+    *,
+    client: Neo4jClient,
+    status_manager: GraphStatusManager | None = None,
+) -> dict[str, Any]:
+    """Run the read-only local simulation boundary behind the ready gate."""
+
+    ready_status = _require_ready(status_manager, "readonly simulation")
+    depth = _context_int(context, "depth", default=1)
+    subgraph = _query_subgraph_after_ready(
+        seed_entities,
+        depth,
+        client=client,
+        ready_status=ready_status,
+    )
+    return {
+        "graph_generation_id": ready_status.graph_generation_id,
+        "seed_entities": list(seed_entities),
+        "impacted_subgraph": subgraph,
+        "status": "ready",
+    }
+
+
+def _query_subgraph_after_ready(
+    seed_entities: list[str],
+    depth: int,
+    *,
+    client: Neo4jClient,
+    ready_status: Neo4jGraphStatus,
+) -> dict[str, Any]:
+    seeds = _validated_seed_entities(seed_entities)
+    query_depth = _validated_depth(depth)
+    rows = client.execute_read(
+        _SUBGRAPH_QUERY_TEMPLATE.replace("__DEPTH__", str(query_depth)),
+        {"seed_entities": seeds},
+    )
+    row = _first_row(rows)
+    return {
+        "graph_generation_id": ready_status.graph_generation_id,
+        "subgraph_nodes": _list_field(row, "subgraph_nodes"),
+        "subgraph_edges": _list_field(row, "subgraph_edges"),
+        "status": "ready",
+    }
+
+
+def _require_ready(
+    status_manager: GraphStatusManager | None,
+    operation_name: str,
+) -> Neo4jGraphStatus:
+    if status_manager is None:
+        raise ValueError(f"{operation_name} requires status_manager")
+    return status_manager.require_ready()
+
+
+def _validated_seed_entities(seed_entities: Sequence[str]) -> list[str]:
+    seeds = [seed for seed in seed_entities if isinstance(seed, str) and seed.strip()]
+    if not seeds:
+        raise ValueError("seed_entities must contain at least one entity id")
+    return seeds
+
+
+def _validated_depth(depth: int) -> int:
+    if isinstance(depth, bool) or not isinstance(depth, int):
+        raise ValueError("depth must be an integer")
+    if depth < 0:
+        raise ValueError("depth must be non-negative")
+    return depth
+
+
+def _first_row(rows: object) -> Mapping[str, Any]:
+    if not isinstance(rows, list) or not rows:
+        return {}
+    row = rows[0]
+    if not isinstance(row, Mapping):
+        return {}
+    return row
+
+
+def _list_field(row: Mapping[str, Any], field_name: str) -> list[Any]:
+    value = row.get(field_name)
+    if not isinstance(value, list):
+        return []
+    return value
+
+
+def _context_int(context: object, field_name: str, *, default: int) -> int:
+    value: object
+    if isinstance(context, Mapping):
+        value = context.get(field_name, default)
+    else:
+        value = getattr(context, field_name, default)
+    if isinstance(value, bool) or not isinstance(value, int):
+        return default
+    return value
+
+
+__all__ = ["query_subgraph", "simulate_readonly_impact"]

--- a/graph_engine/snapshots/__init__.py
+++ b/graph_engine/snapshots/__init__.py
@@ -1,7 +1,6 @@
 """Public snapshot generation entry points."""
 
 from graph_engine.snapshots.generator import (
-    GraphStatusReader,
     build_graph_impact_snapshot,
     build_graph_snapshot,
     compute_graph_snapshots,
@@ -9,7 +8,6 @@ from graph_engine.snapshots.generator import (
 from graph_engine.snapshots.writer import SnapshotWriter
 
 __all__ = [
-    "GraphStatusReader",
     "SnapshotWriter",
     "build_graph_impact_snapshot",
     "build_graph_snapshot",

--- a/graph_engine/snapshots/generator.py
+++ b/graph_engine/snapshots/generator.py
@@ -19,6 +19,7 @@ from graph_engine.models import (
 from graph_engine.propagation.context import RegimeContextReader, build_propagation_context
 from graph_engine.propagation.fundamental import run_fundamental_propagation
 from graph_engine.snapshots.writer import SnapshotWriter
+from graph_engine.status import GraphStatusManager
 
 
 class GraphStatusReader(Protocol):
@@ -32,9 +33,12 @@ def build_graph_snapshot(
     cycle_id: str,
     graph_generation_id: int,
     client: Neo4jClient,
+    *,
+    status_manager: GraphStatusManager | None = None,
 ) -> GraphSnapshot:
     """Read live graph metrics and return a deterministic structural snapshot."""
 
+    _resolve_ready_graph_status(status_manager)
     node_count, edge_count, key_label_counts, checksum = _read_graph_metrics(client)
     return _graph_snapshot_from_metrics(
         cycle_id,
@@ -80,14 +84,14 @@ def compute_graph_snapshots(
     graph_generation_id: int | None = None,
     regime_reader: RegimeContextReader,
     snapshot_writer: SnapshotWriter,
+    status_manager: GraphStatusManager | None = None,
     graph_status: Neo4jGraphStatus | None = None,
     status_reader: GraphStatusReader | None = None,
     graph_name: str | None = None,
 ) -> tuple[GraphSnapshot, GraphImpactSnapshot]:
     """Run fundamental propagation and write graph plus impact snapshots."""
 
-    ready_status = _resolve_ready_graph_status(graph_status, status_reader)
-    _require_publication_status_reader(status_reader)
+    ready_status = _resolve_ready_graph_status(status_manager)
     _validate_generation_input(graph_generation_id, ready_status)
     node_count, edge_count, key_label_counts, checksum = _read_graph_metrics(client)
     _validate_status_metrics(
@@ -108,6 +112,7 @@ def compute_graph_snapshots(
     propagation_result = run_fundamental_propagation(
         context,
         client,
+        status_manager=status_manager,
         graph_name=graph_name,
     )
     graph_snapshot = _graph_snapshot_from_metrics(
@@ -125,7 +130,7 @@ def compute_graph_snapshots(
     )
     _validate_publication_status_and_metrics(
         ready_status,
-        status_reader,
+        status_manager,
         client,
     )
     snapshot_writer.write_snapshots(graph_snapshot, impact_snapshot)
@@ -133,32 +138,13 @@ def compute_graph_snapshots(
 
 
 def _resolve_ready_graph_status(
-    graph_status: Neo4jGraphStatus | None,
-    status_reader: GraphStatusReader | None,
+    status_manager: GraphStatusManager | None,
 ) -> Neo4jGraphStatus:
-    if graph_status is None:
-        if status_reader is None:
-            raise ValueError(
-                "formal snapshot computation requires graph_status or status_reader",
-            )
-        graph_status = status_reader.read_graph_status()
-
-    if graph_status.graph_status != "ready":
-        raise PermissionError(
-            "snapshot computation requires graph_status='ready'; "
-            f"received {graph_status.graph_status!r}",
-        )
-    return graph_status
-
-
-def _require_publication_status_reader(
-    status_reader: GraphStatusReader | None,
-) -> None:
-    if status_reader is None:
+    if status_manager is None:
         raise ValueError(
-            "formal snapshot publication requires status_reader "
-            "for write-boundary validation",
+            "formal snapshot computation requires status_manager",
         )
+    return status_manager.require_ready()
 
 
 def _validate_generation_input(
@@ -210,20 +196,16 @@ def _validate_status_metrics(
 
 def _validate_publication_status_and_metrics(
     ready_status: Neo4jGraphStatus,
-    status_reader: GraphStatusReader | None,
+    status_manager: GraphStatusManager | None,
     client: Neo4jClient,
 ) -> None:
-    if status_reader is None:
-        raise ValueError(
-            "formal snapshot publication requires status_reader "
-            "for write-boundary validation",
-        )
-
-    current_status = status_reader.read_graph_status()
-    if current_status.graph_status != "ready":
+    try:
+        current_status = _resolve_ready_graph_status(status_manager)
+    except PermissionError as exc:
         raise RuntimeError(
             "ready graph status changed before snapshot publication",
-        )
+        ) from exc
+
     _validate_status_matches_ready_status(current_status, ready_status)
 
     node_count, edge_count, key_label_counts, checksum = _read_graph_metrics(client)

--- a/graph_engine/snapshots/generator.py
+++ b/graph_engine/snapshots/generator.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from typing import Protocol
 
 from graph_engine.client import Neo4jClient
 from graph_engine.live_metrics import (
@@ -22,13 +21,6 @@ from graph_engine.snapshots.writer import SnapshotWriter
 from graph_engine.status import GraphStatusManager
 
 
-class GraphStatusReader(Protocol):
-    """Read the current live graph status from the status boundary."""
-
-    def read_graph_status(self) -> Neo4jGraphStatus:
-        """Return the current Neo4j graph status."""
-
-
 def build_graph_snapshot(
     cycle_id: str,
     graph_generation_id: int,
@@ -38,16 +30,18 @@ def build_graph_snapshot(
 ) -> GraphSnapshot:
     """Read live graph metrics and return a deterministic structural snapshot."""
 
-    _resolve_ready_graph_status(status_manager)
-    node_count, edge_count, key_label_counts, checksum = _read_graph_metrics(client)
-    return _graph_snapshot_from_metrics(
-        cycle_id,
-        graph_generation_id,
-        node_count=node_count,
-        edge_count=edge_count,
-        key_label_counts=key_label_counts,
-        checksum=checksum,
-    )
+    if status_manager is None:
+        raise ValueError("graph snapshot generation requires status_manager")
+    with status_manager.ready_read():
+        node_count, edge_count, key_label_counts, checksum = _read_graph_metrics(client)
+        return _graph_snapshot_from_metrics(
+            cycle_id,
+            graph_generation_id,
+            node_count=node_count,
+            edge_count=edge_count,
+            key_label_counts=key_label_counts,
+            checksum=checksum,
+        )
 
 
 def build_graph_impact_snapshot(
@@ -85,56 +79,56 @@ def compute_graph_snapshots(
     regime_reader: RegimeContextReader,
     snapshot_writer: SnapshotWriter,
     status_manager: GraphStatusManager | None = None,
-    graph_status: Neo4jGraphStatus | None = None,
-    status_reader: GraphStatusReader | None = None,
     graph_name: str | None = None,
 ) -> tuple[GraphSnapshot, GraphImpactSnapshot]:
     """Run fundamental propagation and write graph plus impact snapshots."""
 
-    ready_status = _resolve_ready_graph_status(status_manager)
-    _validate_generation_input(graph_generation_id, ready_status)
-    node_count, edge_count, key_label_counts, checksum = _read_graph_metrics(client)
-    _validate_status_metrics(
-        ready_status,
-        node_count=node_count,
-        edge_count=edge_count,
-        key_label_counts=key_label_counts,
-        checksum=checksum,
-    )
+    if status_manager is None:
+        raise ValueError("formal snapshot computation requires status_manager")
+    with status_manager.ready_read() as ready_status:
+        _validate_generation_input(graph_generation_id, ready_status)
+        node_count, edge_count, key_label_counts, checksum = _read_graph_metrics(client)
+        _validate_status_metrics(
+            ready_status,
+            node_count=node_count,
+            edge_count=edge_count,
+            key_label_counts=key_label_counts,
+            checksum=checksum,
+        )
 
-    context = build_propagation_context(
-        cycle_id,
-        world_state_ref,
-        ready_status.graph_generation_id,
-        regime_reader=regime_reader,
-        graph_status=ready_status,
-    )
-    propagation_result = run_fundamental_propagation(
-        context,
-        client,
-        status_manager=status_manager,
-        graph_name=graph_name,
-    )
-    graph_snapshot = _graph_snapshot_from_metrics(
-        cycle_id,
-        ready_status.graph_generation_id,
-        node_count=node_count,
-        edge_count=edge_count,
-        key_label_counts=key_label_counts,
-        checksum=checksum,
-    )
-    impact_snapshot = build_graph_impact_snapshot(
-        cycle_id,
-        world_state_ref,
-        propagation_result,
-    )
-    _validate_publication_status_and_metrics(
-        ready_status,
-        status_manager,
-        client,
-    )
-    snapshot_writer.write_snapshots(graph_snapshot, impact_snapshot)
-    return graph_snapshot, impact_snapshot
+        context = build_propagation_context(
+            cycle_id,
+            world_state_ref,
+            ready_status.graph_generation_id,
+            regime_reader=regime_reader,
+            graph_status=ready_status,
+        )
+        propagation_result = run_fundamental_propagation(
+            context,
+            client,
+            status_manager=status_manager,
+            graph_name=graph_name,
+        )
+        graph_snapshot = _graph_snapshot_from_metrics(
+            cycle_id,
+            ready_status.graph_generation_id,
+            node_count=node_count,
+            edge_count=edge_count,
+            key_label_counts=key_label_counts,
+            checksum=checksum,
+        )
+        impact_snapshot = build_graph_impact_snapshot(
+            cycle_id,
+            world_state_ref,
+            propagation_result,
+        )
+        _validate_publication_status_and_metrics(
+            ready_status,
+            status_manager,
+            client,
+        )
+        snapshot_writer.write_snapshots(graph_snapshot, impact_snapshot)
+        return graph_snapshot, impact_snapshot
 
 
 def _resolve_ready_graph_status(

--- a/graph_engine/status/consistency.py
+++ b/graph_engine/status/consistency.py
@@ -30,7 +30,34 @@ def check_live_graph_consistency(
 ) -> bool:
     """Return whether live Neo4j metrics match the canonical graph snapshot."""
 
-    status = _resolve_status(status_manager, require_ready=require_ready)
+    if require_ready:
+        if status_manager is None:
+            raise ValueError("status_manager is required when require_ready=True")
+        with status_manager.ready_read() as status:
+            return _check_live_graph_consistency_after_status(
+                snapshot_ref,
+                client=client,
+                snapshot_reader=snapshot_reader,
+                status=status,
+            )
+
+    status = _resolve_status(status_manager, require_ready=False)
+    return _check_live_graph_consistency_after_status(
+        snapshot_ref,
+        client=client,
+        snapshot_reader=snapshot_reader,
+        status=status,
+    )
+
+
+def _check_live_graph_consistency_after_status(
+    snapshot_ref: str,
+    *,
+    client: Neo4jClient,
+    snapshot_reader: CanonicalSnapshotReader,
+    status: Neo4jGraphStatus | None,
+) -> bool:
+    """Run consistency reads after the caller has established status safety."""
 
     try:
         snapshot = snapshot_reader.read_graph_snapshot(snapshot_ref)

--- a/graph_engine/status/manager.py
+++ b/graph_engine/status/manager.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
 from datetime import datetime, timezone
+from threading import Condition, RLock
 from typing import Literal
 
 from graph_engine.models import GraphSnapshot, Neo4jGraphStatus
@@ -32,6 +34,10 @@ class GraphStatusManager:
     ) -> None:
         self.store = store
         self._clock = clock or _utc_now
+        self._transition_lock = RLock()
+        self._transition_condition = Condition(self._transition_lock)
+        self._active_read_leases = 0
+        self._pending_transitions = 0
 
     def get_status(self) -> Neo4jGraphStatus:
         """Return the current status or raise when the status row is missing."""
@@ -45,6 +51,23 @@ class GraphStatusManager:
         """Return the current ready status or block non-ready graph reads."""
 
         return require_ready_status(self.get_status())
+
+    @contextmanager
+    def ready_read(self) -> Iterator[Neo4jGraphStatus]:
+        """Hold a ready read lease across live Neo4j reads."""
+
+        with self._transition_condition:
+            while self._pending_transitions > 0:
+                self._transition_condition.wait()
+            status = require_ready_status(self.get_status())
+            self._active_read_leases += 1
+        try:
+            yield status
+        finally:
+            with self._transition_condition:
+                self._active_read_leases -= 1
+                if self._active_read_leases == 0:
+                    self._transition_condition.notify_all()
 
     def mark_rebuilding(self) -> Neo4jGraphStatus:
         """Move an empty, ready, or failed status into rebuilding."""
@@ -228,13 +251,21 @@ class GraphStatusManager:
         expected_status: Neo4jGraphStatus | None,
         next_status: Neo4jGraphStatus,
     ) -> None:
-        if not self.store.compare_and_write_current_status(
-            expected_status=expected_status,
-            next_status=next_status,
-        ):
-            raise RuntimeError(
-                "stale graph_status transition rejected because current status changed",
-            )
+        with self._transition_condition:
+            self._pending_transitions += 1
+            try:
+                while self._active_read_leases > 0:
+                    self._transition_condition.wait()
+                if not self.store.compare_and_write_current_status(
+                    expected_status=expected_status,
+                    next_status=next_status,
+                ):
+                    raise RuntimeError(
+                        "stale graph_status transition rejected because current status changed",
+                    )
+            finally:
+                self._pending_transitions -= 1
+                self._transition_condition.notify_all()
 
 
 def _utc_now() -> datetime:

--- a/graph_engine/status/manager.py
+++ b/graph_engine/status/manager.py
@@ -5,11 +5,15 @@ from __future__ import annotations
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from datetime import datetime, timezone
-from threading import Condition, RLock
+from threading import Condition, RLock, get_ident
 from typing import Literal
 
 from graph_engine.models import GraphSnapshot, Neo4jGraphStatus
 from graph_engine.status.store import StatusStore
+
+_STORE_BARRIER_ATTR = "_graph_engine_status_read_barrier"
+_BARRIER_REGISTRY_LOCK = RLock()
+_BARRIER_REGISTRY: dict[int, "_ReadyReadBarrier"] = {}
 
 
 def require_ready_status(graph_status: Neo4jGraphStatus) -> Neo4jGraphStatus:
@@ -34,10 +38,7 @@ class GraphStatusManager:
     ) -> None:
         self.store = store
         self._clock = clock or _utc_now
-        self._transition_lock = RLock()
-        self._transition_condition = Condition(self._transition_lock)
-        self._active_read_leases = 0
-        self._pending_transitions = 0
+        self._read_barrier = _barrier_for_store(store)
 
     def get_status(self) -> Neo4jGraphStatus:
         """Return the current status or raise when the status row is missing."""
@@ -56,18 +57,8 @@ class GraphStatusManager:
     def ready_read(self) -> Iterator[Neo4jGraphStatus]:
         """Hold a ready read lease across live Neo4j reads."""
 
-        with self._transition_condition:
-            while self._pending_transitions > 0:
-                self._transition_condition.wait()
-            status = require_ready_status(self.get_status())
-            self._active_read_leases += 1
-        try:
+        with self._read_barrier.ready_read(self.get_status) as status:
             yield status
-        finally:
-            with self._transition_condition:
-                self._active_read_leases -= 1
-                if self._active_read_leases == 0:
-                    self._transition_condition.notify_all()
 
     def mark_rebuilding(self) -> Neo4jGraphStatus:
         """Move an empty, ready, or failed status into rebuilding."""
@@ -251,21 +242,88 @@ class GraphStatusManager:
         expected_status: Neo4jGraphStatus | None,
         next_status: Neo4jGraphStatus,
     ) -> None:
-        with self._transition_condition:
+        with self._read_barrier.transition():
+            if not self.store.compare_and_write_current_status(
+                expected_status=expected_status,
+                next_status=next_status,
+            ):
+                raise RuntimeError(
+                    "stale graph_status transition rejected because current status changed",
+                )
+
+
+class _ReadyReadBarrier:
+    """Coordinate ready reads and status transitions for one status store."""
+
+    def __init__(self) -> None:
+        self._condition = Condition(RLock())
+        self._active_read_leases = 0
+        self._pending_transitions = 0
+        self._read_depth_by_thread: dict[int, int] = {}
+
+    @contextmanager
+    def ready_read(
+        self,
+        read_status: Callable[[], Neo4jGraphStatus],
+    ) -> Iterator[Neo4jGraphStatus]:
+        thread_id = get_ident()
+        acquired_outer_lease = False
+        with self._condition:
+            depth = self._read_depth_by_thread.get(thread_id, 0)
+            if depth > 0:
+                status = require_ready_status(read_status())
+                self._read_depth_by_thread[thread_id] = depth + 1
+            else:
+                while self._pending_transitions > 0:
+                    self._condition.wait()
+                status = require_ready_status(read_status())
+                self._active_read_leases += 1
+                self._read_depth_by_thread[thread_id] = 1
+                acquired_outer_lease = True
+        try:
+            yield status
+        finally:
+            with self._condition:
+                depth = self._read_depth_by_thread[thread_id]
+                if depth > 1:
+                    self._read_depth_by_thread[thread_id] = depth - 1
+                else:
+                    del self._read_depth_by_thread[thread_id]
+                    if acquired_outer_lease:
+                        self._active_read_leases -= 1
+                        if self._active_read_leases == 0:
+                            self._condition.notify_all()
+
+    @contextmanager
+    def transition(self) -> Iterator[None]:
+        with self._condition:
             self._pending_transitions += 1
-            try:
-                while self._active_read_leases > 0:
-                    self._transition_condition.wait()
-                if not self.store.compare_and_write_current_status(
-                    expected_status=expected_status,
-                    next_status=next_status,
-                ):
-                    raise RuntimeError(
-                        "stale graph_status transition rejected because current status changed",
-                    )
-            finally:
+            while self._active_read_leases > 0:
+                self._condition.wait()
+        try:
+            yield
+        finally:
+            with self._condition:
                 self._pending_transitions -= 1
-                self._transition_condition.notify_all()
+                self._condition.notify_all()
+
+
+def _barrier_for_store(store: StatusStore) -> _ReadyReadBarrier:
+    with _BARRIER_REGISTRY_LOCK:
+        barrier = getattr(store, _STORE_BARRIER_ATTR, None)
+        if isinstance(barrier, _ReadyReadBarrier):
+            return barrier
+
+        barrier = _BARRIER_REGISTRY.get(id(store))
+        if barrier is None:
+            barrier = _ReadyReadBarrier()
+            _BARRIER_REGISTRY[id(store)] = barrier
+
+        try:
+            setattr(store, _STORE_BARRIER_ATTR, barrier)
+        except Exception:
+            return barrier
+        return barrier
 
 
 def _utc_now() -> datetime:

--- a/tests/integration/test_propagation_snapshot.py
+++ b/tests/integration/test_propagation_snapshot.py
@@ -20,6 +20,7 @@ from graph_engine.models import (
 from graph_engine.schema.definitions import NodeLabel, RelationshipType
 from graph_engine.schema.manager import SchemaManager
 from graph_engine.snapshots import build_graph_snapshot, compute_graph_snapshots
+from graph_engine.status import GraphStatusManager
 from graph_engine.sync import sync_live_graph
 
 pytestmark = pytest.mark.skipif(
@@ -52,12 +53,26 @@ class CapturingSnapshotWriter:
         self.calls.append((graph_snapshot, impact_snapshot))
 
 
-class StaticStatusReader:
-    def __init__(self, graph_status: Neo4jGraphStatus) -> None:
-        self.graph_status = graph_status
+class InMemoryStatusStore:
+    def __init__(self, status: Neo4jGraphStatus) -> None:
+        self.status = status
 
-    def read_graph_status(self) -> Neo4jGraphStatus:
-        return self.graph_status
+    def read_current_status(self) -> Neo4jGraphStatus | None:
+        return self.status
+
+    def write_current_status(self, status: Neo4jGraphStatus) -> None:
+        self.status = status
+
+    def compare_and_write_current_status(
+        self,
+        *,
+        expected_status: Neo4jGraphStatus | None,
+        next_status: Neo4jGraphStatus,
+    ) -> bool:
+        if self.status != expected_status:
+            return False
+        self.write_current_status(next_status)
+        return True
 
 
 def test_compute_graph_snapshots_runs_fundamental_pagerank_on_promoted_graph() -> None:
@@ -80,7 +95,14 @@ def test_compute_graph_snapshots_runs_fundamental_pagerank_on_promoted_graph() -
 
         try:
             sync_live_graph(_promotion_plan(source_node_id, target_node_id, edge_id), client)
-            live_snapshot = build_graph_snapshot("cycle-1", 1, client)
+            live_snapshot = build_graph_snapshot(
+                "cycle-1",
+                1,
+                client,
+                status_manager=GraphStatusManager(
+                    InMemoryStatusStore(_status(graph_generation_id=1)),
+                ),
+            )
             graph_status = Neo4jGraphStatus(
                 graph_status="ready",
                 graph_generation_id=live_snapshot.graph_generation_id,
@@ -100,7 +122,7 @@ def test_compute_graph_snapshots_runs_fundamental_pagerank_on_promoted_graph() -
                     graph_generation_id=1,
                     regime_reader=StaticRegimeReader(),
                     snapshot_writer=writer,
-                    status_reader=StaticStatusReader(graph_status),
+                    status_manager=GraphStatusManager(InMemoryStatusStore(graph_status)),
                     graph_name=f"{prefix}-projection",
                 )
             except RuntimeError as exc:
@@ -169,4 +191,17 @@ def _edge_record(
         weight=10.0,
         created_at=NOW,
         updated_at=NOW,
+    )
+
+
+def _status(*, graph_generation_id: int) -> Neo4jGraphStatus:
+    return Neo4jGraphStatus(
+        graph_status="ready",
+        graph_generation_id=graph_generation_id,
+        node_count=0,
+        edge_count=0,
+        key_label_counts={},
+        checksum="bootstrap",
+        last_verified_at=NOW,
+        last_reload_at=None,
     )

--- a/tests/integration/test_reload.py
+++ b/tests/integration/test_reload.py
@@ -95,7 +95,14 @@ def test_cold_reload_rebuilds_live_graph_and_gds_projection() -> None:
 
         try:
             sync_live_graph(promotion_plan, client)
-            expected_snapshot = build_graph_snapshot("cycle-reload", 7, client)
+            expected_snapshot = build_graph_snapshot(
+                "cycle-reload",
+                7,
+                client,
+                status_manager=GraphStatusManager(
+                    InMemoryStatusStore(_status(graph_generation_id=7)),
+                ),
+            )
             plan = ColdReloadPlan(
                 snapshot_ref="snapshot-ref-reload",
                 cycle_id="cycle-reload",

--- a/tests/integration/test_status.py
+++ b/tests/integration/test_status.py
@@ -97,7 +97,14 @@ CREATE (source)-[:SUPPLY_CHAIN {
                     "edge_id": edge_id,
                 },
             )
-            snapshot = build_graph_snapshot("cycle-status", 11, client)
+            snapshot = build_graph_snapshot(
+                "cycle-status",
+                11,
+                client,
+                status_manager=GraphStatusManager(
+                    InMemoryStatusStore(_status(graph_generation_id=11)),
+                ),
+            )
             status_manager = GraphStatusManager(
                 InMemoryStatusStore(_status_from_snapshot(snapshot)),
                 clock=lambda: NOW,
@@ -143,6 +150,19 @@ def _status_from_snapshot(snapshot: GraphSnapshot) -> Neo4jGraphStatus:
         edge_count=snapshot.edge_count,
         key_label_counts=snapshot.key_label_counts,
         checksum=snapshot.checksum,
+        last_verified_at=NOW,
+        last_reload_at=None,
+    )
+
+
+def _status(*, graph_generation_id: int) -> Neo4jGraphStatus:
+    return Neo4jGraphStatus(
+        graph_status="ready",
+        graph_generation_id=graph_generation_id,
+        node_count=0,
+        edge_count=0,
+        key_label_counts={},
+        checksum="bootstrap",
         last_verified_at=NOW,
         last_reload_at=None,
     )

--- a/tests/unit/test_propagation.py
+++ b/tests/unit/test_propagation.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import sys
 from datetime import datetime, timezone
-from typing import Any
+from typing import Any, Literal
 
 import pytest
 
@@ -13,6 +13,7 @@ from graph_engine.propagation import (
     compute_path_score,
     run_fundamental_propagation,
 )
+from graph_engine.status import GraphStatusManager
 
 NOW = datetime(2026, 4, 17, 1, 2, 3, tzinfo=timezone.utc)
 
@@ -132,6 +133,28 @@ class FakeGDSClient:
         return []
 
 
+class InMemoryStatusStore:
+    def __init__(self, status: Neo4jGraphStatus) -> None:
+        self.status = status
+
+    def read_current_status(self) -> Neo4jGraphStatus | None:
+        return self.status
+
+    def write_current_status(self, status: Neo4jGraphStatus) -> None:
+        self.status = status
+
+    def compare_and_write_current_status(
+        self,
+        *,
+        expected_status: Neo4jGraphStatus | None,
+        next_status: Neo4jGraphStatus,
+    ) -> bool:
+        if self.status != expected_status:
+            return False
+        self.write_current_status(next_status)
+        return True
+
+
 def test_compute_path_score_uses_documented_multiplication() -> None:
     assert compute_path_score(
         relation_weight=0.8,
@@ -197,6 +220,7 @@ def test_run_fundamental_propagation_uses_gds_projection_and_explains_paths() ->
     result = run_fundamental_propagation(
         context,
         client,  # type: ignore[arg-type]
+        status_manager=_status_manager(),
         graph_name="unit-fundamental",
         max_iterations=5,
         result_limit=10,
@@ -248,8 +272,16 @@ def test_run_fundamental_propagation_generates_unique_default_projection_names()
     first_client = FakeGDSClient()
     second_client = FakeGDSClient()
 
-    run_fundamental_propagation(_context(), first_client)  # type: ignore[arg-type]
-    run_fundamental_propagation(_context(), second_client)  # type: ignore[arg-type]
+    run_fundamental_propagation(  # type: ignore[arg-type]
+        _context(),
+        first_client,
+        status_manager=_status_manager(),
+    )
+    run_fundamental_propagation(  # type: ignore[arg-type]
+        _context(),
+        second_client,
+        status_manager=_status_manager(),
+    )
 
     first_project = next(
         params["graph_name"]
@@ -302,6 +334,7 @@ def test_impacted_entities_use_five_factor_path_scores() -> None:
     result = run_fundamental_propagation(
         _context(),
         client,  # type: ignore[arg-type]
+        status_manager=_status_manager(),
         graph_name="unit-fundamental",
     )
 
@@ -361,6 +394,7 @@ def test_activated_paths_limit_applies_after_five_factor_scoring() -> None:
     result = run_fundamental_propagation(
         _context(),
         client,  # type: ignore[arg-type]
+        status_manager=_status_manager(),
         graph_name="unit-fundamental",
         result_limit=2,
     )
@@ -389,12 +423,31 @@ def test_run_fundamental_propagation_cleans_up_projection_on_exception() -> None
         run_fundamental_propagation(
             _context(),
             client,  # type: ignore[arg-type]
+            status_manager=_status_manager(),
             graph_name="unit-fundamental",
         )
 
     write_queries = [query for query, _ in client.write_calls]
     assert any("gds.graph.project" in query for query in write_queries)
     assert any("gds.graph.drop" in query for query in write_queries)
+
+
+@pytest.mark.parametrize("graph_status", ["syncing", "rebuilding", "failed"])
+def test_run_fundamental_propagation_blocks_non_ready_status_before_reads(
+    graph_status: Literal["syncing", "rebuilding", "failed"],
+) -> None:
+    client = FakeGDSClient()
+
+    with pytest.raises(PermissionError, match="ready"):
+        run_fundamental_propagation(
+            _context(),
+            client,  # type: ignore[arg-type]
+            status_manager=_status_manager(graph_status=graph_status),
+            graph_name="unit-fundamental",
+        )
+
+    assert client.read_calls == []
+    assert client.write_calls == []
 
 
 def _context() -> PropagationContext:
@@ -407,6 +460,29 @@ def _context() -> PropagationContext:
         regime_multipliers={"fundamental": 0.5},
         decay_policy={},
         regime_context={},
+    )
+
+
+def _status_manager(
+    *,
+    graph_status: Literal["ready", "syncing", "rebuilding", "failed"] = "ready",
+) -> GraphStatusManager:
+    return GraphStatusManager(InMemoryStatusStore(_status(graph_status=graph_status)))
+
+
+def _status(
+    *,
+    graph_status: Literal["ready", "syncing", "rebuilding", "failed"] = "ready",
+) -> Neo4jGraphStatus:
+    return Neo4jGraphStatus(
+        graph_status=graph_status,
+        graph_generation_id=1,
+        node_count=2,
+        edge_count=1,
+        key_label_counts={"Entity": 2},
+        checksum="abc123",
+        last_verified_at=NOW if graph_status == "ready" else None,
+        last_reload_at=None,
     )
 
 

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -6,7 +6,7 @@ from typing import Any, Literal
 import pytest
 
 from graph_engine.models import Neo4jGraphStatus
-from graph_engine.query import query_subgraph, simulate_readonly_impact
+from graph_engine.query import MAX_QUERY_DEPTH, query_subgraph, simulate_readonly_impact
 from graph_engine.status import GraphStatusManager
 
 NOW = datetime(2026, 4, 17, 1, 2, 3, tzinfo=timezone.utc)
@@ -112,6 +112,21 @@ def test_query_subgraph_returns_ready_result() -> None:
     assert client.write_calls == []
 
 
+def test_query_subgraph_rejects_depth_above_supported_bound_before_reads() -> None:
+    client = FakeQueryClient()
+
+    with pytest.raises(ValueError, match=f"<= {MAX_QUERY_DEPTH}"):
+        query_subgraph(
+            ["entity-a"],
+            MAX_QUERY_DEPTH + 1,
+            client=client,  # type: ignore[arg-type]
+            status_manager=_status_manager(),
+        )
+
+    assert client.read_calls == []
+    assert client.write_calls == []
+
+
 @pytest.mark.parametrize("graph_status", ["syncing", "rebuilding", "failed"])
 def test_simulate_readonly_impact_blocks_non_ready_status_before_reads(
     graph_status: Literal["syncing", "rebuilding", "failed"],
@@ -144,6 +159,21 @@ def test_simulate_readonly_impact_uses_ready_gated_subgraph_read() -> None:
     assert result["status"] == "ready"
     assert result["impacted_subgraph"]["subgraph_nodes"][0]["node_id"] == "node-a"
     assert "[*0..2]" in client.read_calls[0][0]
+    assert client.write_calls == []
+
+
+def test_simulate_readonly_impact_rejects_depth_above_supported_bound_before_reads() -> None:
+    client = FakeQueryClient()
+
+    with pytest.raises(ValueError, match=f"<= {MAX_QUERY_DEPTH}"):
+        simulate_readonly_impact(
+            ["entity-a"],
+            {"depth": MAX_QUERY_DEPTH + 1},
+            client=client,  # type: ignore[arg-type]
+            status_manager=_status_manager(),
+        )
+
+    assert client.read_calls == []
     assert client.write_calls == []
 
 

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Literal
+
+import pytest
+
+from graph_engine.models import Neo4jGraphStatus
+from graph_engine.query import query_subgraph, simulate_readonly_impact
+from graph_engine.status import GraphStatusManager
+
+NOW = datetime(2026, 4, 17, 1, 2, 3, tzinfo=timezone.utc)
+
+
+class InMemoryStatusStore:
+    def __init__(self, status: Neo4jGraphStatus) -> None:
+        self.status = status
+
+    def read_current_status(self) -> Neo4jGraphStatus | None:
+        return self.status
+
+    def write_current_status(self, status: Neo4jGraphStatus) -> None:
+        self.status = status
+
+    def compare_and_write_current_status(
+        self,
+        *,
+        expected_status: Neo4jGraphStatus | None,
+        next_status: Neo4jGraphStatus,
+    ) -> bool:
+        if self.status != expected_status:
+            return False
+        self.write_current_status(next_status)
+        return True
+
+
+class FakeQueryClient:
+    def __init__(self) -> None:
+        self.read_calls: list[tuple[str, dict[str, Any]]] = []
+        self.write_calls: list[tuple[str, dict[str, Any]]] = []
+
+    def execute_read(
+        self,
+        query: str,
+        parameters: dict[str, Any] | None = None,
+    ) -> list[dict[str, Any]]:
+        self.read_calls.append((query, parameters or {}))
+        return [
+            {
+                "subgraph_nodes": [
+                    {
+                        "node_id": "node-a",
+                        "canonical_entity_id": "entity-a",
+                        "labels": ["Entity"],
+                    }
+                ],
+                "subgraph_edges": [],
+            }
+        ]
+
+    def execute_write(
+        self,
+        query: str,
+        parameters: dict[str, Any] | None = None,
+    ) -> list[dict[str, Any]]:
+        self.write_calls.append((query, parameters or {}))
+        return []
+
+
+@pytest.mark.parametrize("graph_status", ["syncing", "rebuilding", "failed"])
+def test_query_subgraph_blocks_non_ready_status_before_reads(
+    graph_status: Literal["syncing", "rebuilding", "failed"],
+) -> None:
+    client = FakeQueryClient()
+
+    with pytest.raises(PermissionError, match="ready"):
+        query_subgraph(
+            ["entity-a"],
+            1,
+            client=client,  # type: ignore[arg-type]
+            status_manager=_status_manager(graph_status=graph_status),
+        )
+
+    assert client.read_calls == []
+    assert client.write_calls == []
+
+
+def test_query_subgraph_returns_ready_result() -> None:
+    client = FakeQueryClient()
+
+    result = query_subgraph(
+        ["entity-a"],
+        2,
+        client=client,  # type: ignore[arg-type]
+        status_manager=_status_manager(),
+    )
+
+    assert result == {
+        "graph_generation_id": 3,
+        "subgraph_nodes": [
+            {
+                "node_id": "node-a",
+                "canonical_entity_id": "entity-a",
+                "labels": ["Entity"],
+            }
+        ],
+        "subgraph_edges": [],
+        "status": "ready",
+    }
+    assert client.read_calls[0][1] == {"seed_entities": ["entity-a"]}
+    assert "[*0..2]" in client.read_calls[0][0]
+    assert client.write_calls == []
+
+
+@pytest.mark.parametrize("graph_status", ["syncing", "rebuilding", "failed"])
+def test_simulate_readonly_impact_blocks_non_ready_status_before_reads(
+    graph_status: Literal["syncing", "rebuilding", "failed"],
+) -> None:
+    client = FakeQueryClient()
+
+    with pytest.raises(PermissionError, match="ready"):
+        simulate_readonly_impact(
+            ["entity-a"],
+            {"depth": 1},
+            client=client,  # type: ignore[arg-type]
+            status_manager=_status_manager(graph_status=graph_status),
+        )
+
+    assert client.read_calls == []
+    assert client.write_calls == []
+
+
+def test_simulate_readonly_impact_uses_ready_gated_subgraph_read() -> None:
+    client = FakeQueryClient()
+
+    result = simulate_readonly_impact(
+        ["entity-a"],
+        {"depth": 2},
+        client=client,  # type: ignore[arg-type]
+        status_manager=_status_manager(),
+    )
+
+    assert result["graph_generation_id"] == 3
+    assert result["status"] == "ready"
+    assert result["impacted_subgraph"]["subgraph_nodes"][0]["node_id"] == "node-a"
+    assert "[*0..2]" in client.read_calls[0][0]
+    assert client.write_calls == []
+
+
+def _status_manager(
+    *,
+    graph_status: Literal["ready", "syncing", "rebuilding", "failed"] = "ready",
+) -> GraphStatusManager:
+    return GraphStatusManager(InMemoryStatusStore(_status(graph_status=graph_status)))
+
+
+def _status(
+    *,
+    graph_status: Literal["ready", "syncing", "rebuilding", "failed"] = "ready",
+) -> Neo4jGraphStatus:
+    return Neo4jGraphStatus(
+        graph_status=graph_status,
+        graph_generation_id=3,
+        node_count=1,
+        edge_count=0,
+        key_label_counts={"Entity": 1},
+        checksum="query-ready",
+        last_verified_at=NOW if graph_status == "ready" else None,
+        last_reload_at=None,
+    )

--- a/tests/unit/test_snapshots.py
+++ b/tests/unit/test_snapshots.py
@@ -19,6 +19,7 @@ from graph_engine.snapshots import (
     build_graph_snapshot,
     compute_graph_snapshots,
 )
+from graph_engine.status import GraphStatusManager
 
 NOW = datetime(2026, 4, 17, 1, 2, 3, tzinfo=timezone.utc)
 
@@ -93,7 +94,7 @@ class RaisingSnapshotWriter:
         raise RuntimeError("writer failed")
 
 
-class StaticStatusReader:
+class InMemoryStatusStore:
     def __init__(
         self,
         graph_status: Neo4jGraphStatus | list[Neo4jGraphStatus],
@@ -103,11 +104,28 @@ class StaticStatusReader:
         else:
             self.graph_statuses = [graph_status]
         self.calls = 0
+        self.status = self.graph_statuses[0]
 
-    def read_graph_status(self) -> Neo4jGraphStatus:
+    def read_current_status(self) -> Neo4jGraphStatus | None:
         self.calls += 1
         index = min(self.calls - 1, len(self.graph_statuses) - 1)
-        return self.graph_statuses[index]
+        self.status = self.graph_statuses[index]
+        return self.status
+
+    def write_current_status(self, status: Neo4jGraphStatus) -> None:
+        self.status = status
+        self.graph_statuses = [status]
+
+    def compare_and_write_current_status(
+        self,
+        *,
+        expected_status: Neo4jGraphStatus | None,
+        next_status: Neo4jGraphStatus,
+    ) -> bool:
+        if self.status != expected_status:
+            return False
+        self.write_current_status(next_status)
+        return True
 
 
 def test_build_graph_snapshot_reads_metrics_and_stable_checksum() -> None:
@@ -137,8 +155,20 @@ def test_build_graph_snapshot_reads_metrics_and_stable_checksum() -> None:
         ],
     )
 
-    first = build_graph_snapshot("cycle-1", 3, client)  # type: ignore[arg-type]
-    second = build_graph_snapshot("cycle-1", 3, client)  # type: ignore[arg-type]
+    status_manager = _status_manager(_ready_status(graph_generation_id=3))
+
+    first = build_graph_snapshot(  # type: ignore[arg-type]
+        "cycle-1",
+        3,
+        client,
+        status_manager=status_manager,
+    )
+    second = build_graph_snapshot(  # type: ignore[arg-type]
+        "cycle-1",
+        3,
+        client,
+        status_manager=status_manager,
+    )
 
     assert first.node_count == 2
     assert first.edge_count == 1
@@ -151,9 +181,28 @@ def test_build_graph_snapshot_reads_metrics_and_stable_checksum() -> None:
         **client.relationships[0],
         "properties": {"weight": 0.9},
     }
-    changed = build_graph_snapshot("cycle-1", 3, client)  # type: ignore[arg-type]
+    changed = build_graph_snapshot(  # type: ignore[arg-type]
+        "cycle-1",
+        3,
+        client,
+        status_manager=status_manager,
+    )
     assert changed.checksum != first.checksum
     assert len(client.read_calls) == 3
+
+
+def test_build_graph_snapshot_blocks_non_ready_status_before_reads() -> None:
+    client = FakeSnapshotClient(nodes=[], relationships=[])
+
+    with pytest.raises(PermissionError, match="ready"):
+        build_graph_snapshot(
+            "cycle-1",
+            3,
+            client,  # type: ignore[arg-type]
+            status_manager=_status_manager(_ready_status(graph_status="rebuilding")),
+        )
+
+    assert client.read_calls == []
 
 
 def test_build_graph_impact_snapshot_preserves_propagation_payload() -> None:
@@ -176,7 +225,7 @@ def test_compute_graph_snapshots_requires_status_source_without_side_effects() -
     reader = StaticRegimeReader()
     writer = RecordingSnapshotWriter()
 
-    with pytest.raises(ValueError, match="graph_status or status_reader"):
+    with pytest.raises(ValueError, match="status_manager"):
         compute_graph_snapshots(
             "cycle-1",
             "world-state-1",
@@ -192,7 +241,10 @@ def test_compute_graph_snapshots_requires_status_source_without_side_effects() -
     client.execute_write.assert_not_called()
 
 
-def test_compute_graph_snapshots_rejects_non_ready_status_without_side_effects() -> None:
+@pytest.mark.parametrize("graph_status", ["syncing", "rebuilding", "failed"])
+def test_compute_graph_snapshots_rejects_non_ready_status_without_side_effects(
+    graph_status: Literal["syncing", "rebuilding", "failed"],
+) -> None:
     client = MagicMock()
     reader = StaticRegimeReader()
     writer = RecordingSnapshotWriter()
@@ -205,12 +257,14 @@ def test_compute_graph_snapshots_rejects_non_ready_status_without_side_effects()
             graph_generation_id=1,
             regime_reader=reader,
             snapshot_writer=writer,
-            graph_status=_ready_status(
-                graph_status="failed",
-                node_count=0,
-                edge_count=0,
-                key_label_counts={},
-                checksum="failed",
+            status_manager=_status_manager(
+                _ready_status(
+                    graph_status=graph_status,
+                    node_count=0,
+                    edge_count=0,
+                    key_label_counts={},
+                    checksum=graph_status,
+                ),
             ),
         )
 
@@ -220,11 +274,12 @@ def test_compute_graph_snapshots_rejects_non_ready_status_without_side_effects()
     client.execute_write.assert_not_called()
 
 
-def test_compute_graph_snapshots_uses_status_reader_and_derives_generation(
+def test_compute_graph_snapshots_uses_status_manager_and_derives_generation(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     events: list[str] = []
-    status_reader = StaticStatusReader(_ready_status(graph_generation_id=7))
+    status_store = InMemoryStatusStore(_ready_status(graph_generation_id=7))
+    status_manager = GraphStatusManager(status_store)
     writer = RecordingSnapshotWriter(events)
 
     _patch_metrics(monkeypatch, events)
@@ -255,10 +310,10 @@ def test_compute_graph_snapshots_uses_status_reader_and_derives_generation(
         client=MagicMock(),
         regime_reader=StaticRegimeReader(),
         snapshot_writer=writer,
-        status_reader=status_reader,
+        status_manager=status_manager,
     )
 
-    assert status_reader.calls == 2
+    assert status_store.calls == 2
     assert graph_snapshot.graph_generation_id == 7
     assert graph_snapshot.node_count == 2
     assert graph_snapshot.edge_count == 1
@@ -307,7 +362,7 @@ def test_compute_graph_snapshots_rejects_status_disagreements_before_propagation
             graph_generation_id=graph_generation_id,
             regime_reader=reader,
             snapshot_writer=writer,
-            status_reader=StaticStatusReader(graph_status),
+            status_manager=_status_manager(graph_status),
         )
 
     assert events == expected_events
@@ -315,7 +370,7 @@ def test_compute_graph_snapshots_rejects_status_disagreements_before_propagation
     assert writer.calls == []
 
 
-def test_compute_graph_snapshots_rejects_direct_ready_status_without_reader(
+def test_compute_graph_snapshots_rejects_direct_ready_status_without_manager(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     events: list[str] = []
@@ -324,7 +379,7 @@ def test_compute_graph_snapshots_rejects_direct_ready_status_without_reader(
 
     _patch_metrics(monkeypatch, events)
 
-    with pytest.raises(ValueError, match="status_reader"):
+    with pytest.raises(ValueError, match="status_manager"):
         compute_graph_snapshots(
             "cycle-1",
             "world-state-1",
@@ -371,7 +426,7 @@ def test_compute_graph_snapshots_writes_once_after_both_snapshots(
         graph_generation_id=1,
         regime_reader=StaticRegimeReader(),
         snapshot_writer=writer,
-        status_reader=StaticStatusReader(_ready_status()),
+        status_manager=_status_manager(_ready_status()),
     )
 
     graph_snapshot = result[0]
@@ -389,7 +444,8 @@ def test_compute_graph_snapshots_rechecks_status_before_write(
     events: list[str] = []
     ready_status = _ready_status()
     rebuilding_status = _ready_status(graph_status="rebuilding")
-    status_reader = StaticStatusReader([ready_status, rebuilding_status])
+    status_store = InMemoryStatusStore([ready_status, rebuilding_status])
+    status_manager = GraphStatusManager(status_store)
     writer = RecordingSnapshotWriter(events)
 
     _patch_metrics(monkeypatch, events)
@@ -417,10 +473,10 @@ def test_compute_graph_snapshots_rechecks_status_before_write(
             graph_generation_id=1,
             regime_reader=StaticRegimeReader(),
             snapshot_writer=writer,
-            status_reader=status_reader,
+            status_manager=status_manager,
         )
 
-    assert status_reader.calls == 2
+    assert status_store.calls == 2
     assert events == ["metrics", "context", "propagation", "impact"]
     assert writer.calls == []
 
@@ -463,7 +519,7 @@ def test_compute_graph_snapshots_rechecks_live_metrics_before_write(
             graph_generation_id=1,
             regime_reader=StaticRegimeReader(),
             snapshot_writer=writer,
-            status_reader=StaticStatusReader(_ready_status()),
+            status_manager=_status_manager(_ready_status()),
         )
 
     assert events == ["metrics", "context", "propagation", "impact", "metrics"]
@@ -504,7 +560,7 @@ def test_compute_graph_snapshots_does_not_write_if_snapshot_build_fails(
             graph_generation_id=1,
             regime_reader=StaticRegimeReader(),
             snapshot_writer=writer,
-            status_reader=StaticStatusReader(_ready_status()),
+            status_manager=_status_manager(_ready_status()),
         )
 
     assert writer.calls == []
@@ -538,7 +594,7 @@ def test_compute_graph_snapshots_surfaces_writer_errors(
             graph_generation_id=1,
             regime_reader=StaticRegimeReader(),
             snapshot_writer=RaisingSnapshotWriter(),
-            status_reader=StaticStatusReader(_ready_status()),
+            status_manager=_status_manager(_ready_status()),
         )
 
 
@@ -561,9 +617,13 @@ def _patch_metrics(
     monkeypatch.setattr(snapshot_generator, "_read_graph_metrics", read_metrics)
 
 
+def _status_manager(status: Neo4jGraphStatus) -> GraphStatusManager:
+    return GraphStatusManager(InMemoryStatusStore(status))
+
+
 def _ready_status(
     *,
-    graph_status: Literal["ready", "rebuilding", "failed"] = "ready",
+    graph_status: Literal["ready", "syncing", "rebuilding", "failed"] = "ready",
     graph_generation_id: int = 1,
     node_count: int = 2,
     edge_count: int = 1,

--- a/tests/unit/test_snapshots.py
+++ b/tests/unit/test_snapshots.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 from datetime import datetime, timezone
 from typing import Any, Literal
 from unittest.mock import MagicMock
@@ -370,29 +371,12 @@ def test_compute_graph_snapshots_rejects_status_disagreements_before_propagation
     assert writer.calls == []
 
 
-def test_compute_graph_snapshots_rejects_direct_ready_status_without_manager(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    events: list[str] = []
-    reader = StaticRegimeReader()
-    writer = RecordingSnapshotWriter()
+def test_compute_graph_snapshots_only_accepts_status_manager_gate() -> None:
+    parameters = inspect.signature(compute_graph_snapshots).parameters
 
-    _patch_metrics(monkeypatch, events)
-
-    with pytest.raises(ValueError, match="status_manager"):
-        compute_graph_snapshots(
-            "cycle-1",
-            "world-state-1",
-            client=MagicMock(),
-            graph_generation_id=1,
-            regime_reader=reader,
-            snapshot_writer=writer,
-            graph_status=_ready_status(),
-        )
-
-    assert events == []
-    assert reader.calls == []
-    assert writer.calls == []
+    assert "status_manager" in parameters
+    assert "graph_status" not in parameters
+    assert "status_reader" not in parameters
 
 
 def test_compute_graph_snapshots_writes_once_after_both_snapshots(

--- a/tests/unit/test_status.py
+++ b/tests/unit/test_status.py
@@ -407,6 +407,96 @@ def test_ready_read_lease_blocks_rebuilding_transition_until_released() -> None:
     assert store.status.graph_status == "rebuilding"
 
 
+def test_ready_read_is_reentrant_while_transition_waits() -> None:
+    store = InMemoryStatusStore(_status(graph_status="ready", graph_generation_id=8))
+    manager = GraphStatusManager(store, clock=lambda: NOW)
+    nested_acquired = threading.Event()
+    scenario_finished = threading.Event()
+    scenario_errors: list[BaseException] = []
+
+    def scenario() -> None:
+        transition_started = threading.Event()
+        transition_finished = threading.Event()
+        transition_errors: list[BaseException] = []
+
+        def transition() -> None:
+            transition_started.set()
+            try:
+                manager.mark_rebuilding()
+            except BaseException as exc:  # pragma: no cover - asserted after join.
+                transition_errors.append(exc)
+            finally:
+                transition_finished.set()
+
+        try:
+            with manager.ready_read() as ready_status:
+                thread = threading.Thread(target=transition, daemon=True)
+                thread.start()
+                assert transition_started.wait(timeout=1)
+                with manager.ready_read() as nested_status:
+                    nested_acquired.set()
+                    assert nested_status == ready_status
+                assert not transition_finished.wait(timeout=0.05)
+
+            assert transition_finished.wait(timeout=1)
+            thread.join(timeout=1)
+            assert transition_errors == []
+        except BaseException as exc:  # pragma: no cover - asserted by parent thread.
+            scenario_errors.append(exc)
+        finally:
+            scenario_finished.set()
+
+    scenario_thread = threading.Thread(target=scenario, daemon=True)
+    scenario_thread.start()
+
+    assert scenario_finished.wait(timeout=2)
+    assert scenario_errors == []
+    assert nested_acquired.is_set()
+    assert store.status is not None
+    assert store.status.graph_status == "rebuilding"
+
+
+@pytest.mark.parametrize(
+    ("transition_name", "expected_status"),
+    [("mark_rebuilding", "rebuilding"), ("begin_sync", "syncing")],
+)
+def test_ready_read_barrier_is_shared_by_managers_using_same_store(
+    transition_name: str,
+    expected_status: str,
+) -> None:
+    store = InMemoryStatusStore(_status(graph_status="ready", graph_generation_id=8))
+    read_manager = GraphStatusManager(store, clock=lambda: NOW)
+    transition_manager = GraphStatusManager(store, clock=lambda: NOW)
+    transition_started = threading.Event()
+    transition_finished = threading.Event()
+    transition_errors: list[BaseException] = []
+
+    def transition() -> None:
+        transition_started.set()
+        try:
+            if transition_name == "mark_rebuilding":
+                transition_manager.mark_rebuilding()
+            else:
+                transition_manager.begin_sync()
+        except BaseException as exc:  # pragma: no cover - asserted after join.
+            transition_errors.append(exc)
+        finally:
+            transition_finished.set()
+
+    with read_manager.ready_read() as ready_status:
+        thread = threading.Thread(target=transition)
+        thread.start()
+        assert transition_started.wait(timeout=1)
+        assert not transition_finished.wait(timeout=0.05)
+        assert store.status == ready_status
+
+    assert transition_finished.wait(timeout=1)
+    thread.join(timeout=1)
+    assert transition_errors == []
+    assert store.status is not None
+    assert store.status.graph_status == expected_status
+
+
 @pytest.mark.parametrize("graph_status", ["syncing", "rebuilding", "failed"])
 def test_require_ready_rejects_non_ready_status(
     graph_status: Literal["syncing", "rebuilding", "failed"],

--- a/tests/unit/test_status.py
+++ b/tests/unit/test_status.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import threading
 from datetime import datetime, timezone
 from typing import Any, Literal
 from unittest.mock import MagicMock
@@ -373,6 +374,37 @@ def test_require_ready_returns_ready_status() -> None:
 
     assert require_ready_status(ready_status) is ready_status
     assert GraphStatusManager(InMemoryStatusStore(ready_status)).require_ready() is ready_status
+
+
+def test_ready_read_lease_blocks_rebuilding_transition_until_released() -> None:
+    store = InMemoryStatusStore(_status(graph_status="ready", graph_generation_id=8))
+    manager = GraphStatusManager(store, clock=lambda: NOW)
+    transition_started = threading.Event()
+    transition_finished = threading.Event()
+    transition_errors: list[BaseException] = []
+
+    def transition() -> None:
+        transition_started.set()
+        try:
+            manager.mark_rebuilding()
+        except BaseException as exc:  # pragma: no cover - asserted after join.
+            transition_errors.append(exc)
+        finally:
+            transition_finished.set()
+
+    with manager.ready_read() as ready_status:
+        assert ready_status.graph_status == "ready"
+        thread = threading.Thread(target=transition)
+        thread.start()
+        assert transition_started.wait(timeout=1)
+        assert not transition_finished.wait(timeout=0.05)
+        assert store.status == ready_status
+
+    assert transition_finished.wait(timeout=1)
+    thread.join(timeout=1)
+    assert transition_errors == []
+    assert store.status is not None
+    assert store.status.graph_status == "rebuilding"
 
 
 @pytest.mark.parametrize("graph_status", ["syncing", "rebuilding", "failed"])


### PR DESCRIPTION
Closes #30

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `benchmarks/artifacts/lite_target_100k_800k.json`, `benchmarks/generate_synthetic.py`, `benchmarks/run_benchmark.py`, `cross-cutting`, `graph_engine/__pycache__/__init__.cpython-314.pyc`, `graph_engine/live_metrics.py`, `graph_engine/reload/service.py`, `graph_engine/snapshots/generator.py`, `graph_engine/status/consistency.py`, `graph_engine/sync/live_graph.py`


---
## 背景与目标
Milestone review for milestone-2 发现阻塞性问题，必须在进入下一阶段前修复。

## 问题描述
The new ready gate is wired into consistency checks and promotion sync, but the milestone does not make it the common gate for all Neo4j reads. Snapshot generation still reads live metrics directly, and the combined diff does not show query, readonly simulation, or propagation read APIs being moved behind GraphStatusManager. This violates issue #6's goal that neo4j_graph_status be the shared gate for all Neo4j reads.

## 实现范围
- 修改文件: `cross-cutting`
- Introduce a status-gated read boundary or require GraphStatusManager on every public Neo4j read API, then add tests that non-ready states block snapshot, query, readonly simulation, and propagation reads.

## 验收标准
- [ ] 原始 P0 问题已修复
- [ ] 新增回归测试覆盖该场景
- [ ] 构建通过

## 验证命令
```bash
/Users/fanjie/Desktop/Cowork/project-ult/graph-engine/.venv/bin/python -m pytest
```
