### PR TITLE
feat(#29): [milestone-2 review] P0: No durable StatusStore implementation backs the state machine

### DIFF
--- a/graph_engine/__init__.py
+++ b/graph_engine/__init__.py
@@ -31,6 +31,8 @@ from graph_engine.schema import (
 from graph_engine.status import (
     CanonicalSnapshotReader,
     GraphStatusManager,
+    PostgreSQLStatusStore,
+    PostgresStatusStore,
     StatusStore,
     check_live_graph_consistency,
     require_ready_status,
@@ -54,6 +56,8 @@ __all__ = [
     "Neo4jConfig",
     "Neo4jGraphStatus",
     "NodeLabel",
+    "PostgreSQLStatusStore",
+    "PostgresStatusStore",
     "PromotionPlan",
     "PropagationContext",
     "PropagationResult",

--- a/graph_engine/status/__init__.py
+++ b/graph_engine/status/__init__.py
@@ -5,11 +5,13 @@ from graph_engine.status.consistency import (
     check_live_graph_consistency,
 )
 from graph_engine.status.manager import GraphStatusManager, require_ready_status
-from graph_engine.status.store import StatusStore
+from graph_engine.status.store import PostgreSQLStatusStore, PostgresStatusStore, StatusStore
 
 __all__ = [
     "CanonicalSnapshotReader",
     "GraphStatusManager",
+    "PostgreSQLStatusStore",
+    "PostgresStatusStore",
     "StatusStore",
     "check_live_graph_consistency",
     "require_ready_status",

--- a/graph_engine/status/store.py
+++ b/graph_engine/status/store.py
@@ -2,7 +2,14 @@
 
 from __future__ import annotations
 
-from typing import Protocol
+import json
+import importlib
+import os
+import re
+from collections.abc import Callable, Iterator, Mapping
+from contextlib import contextmanager
+from threading import Lock
+from typing import Any, Protocol
 
 from graph_engine.models import Neo4jGraphStatus
 
@@ -23,3 +30,310 @@ class StatusStore(Protocol):
         next_status: Neo4jGraphStatus,
     ) -> bool:
         """Atomically persist next_status only if the current row still matches."""
+
+
+class PostgreSQLStatusStore:
+    """PostgreSQL-backed singleton status store.
+
+    The store keeps one row in ``neo4j_graph_status`` by default.  It expects
+    PostgreSQL ``READ COMMITTED`` isolation or stronger: compare-and-set writes
+    are a single ``UPDATE ... WHERE`` statement, so PostgreSQL locks the row and
+    rechecks the expected fields after any competing transaction commits.  Empty
+    store bootstrap uses the singleton primary key with ``ON CONFLICT DO
+    NOTHING`` so only one process can create the first status row.
+    """
+
+    def __init__(
+        self,
+        database_url: str | None = None,
+        *,
+        connection_factory: Callable[[], Any] | None = None,
+        table_name: str = "neo4j_graph_status",
+        status_key: str = "current",
+        auto_bootstrap: bool = True,
+        connect_kwargs: Mapping[str, Any] | None = None,
+    ) -> None:
+        if connection_factory is None:
+            resolved_database_url = database_url or os.getenv("DATABASE_URL")
+            if resolved_database_url is None:
+                raise ValueError(
+                    "database_url or DATABASE_URL is required for PostgreSQLStatusStore",
+                )
+            connection_factory = _build_psycopg_connection_factory(
+                resolved_database_url,
+                connect_kwargs=dict(connect_kwargs or {}),
+            )
+
+        if not status_key:
+            raise ValueError("status_key must be non-empty")
+
+        self._connection_factory = connection_factory
+        self._table_name = _quote_qualified_identifier(table_name)
+        self._status_key = status_key
+        self._auto_bootstrap = auto_bootstrap
+        self._bootstrapped = False
+        self._bootstrap_lock = Lock()
+
+    @classmethod
+    def from_database_url(
+        cls,
+        database_url: str | None = None,
+        *,
+        table_name: str = "neo4j_graph_status",
+        status_key: str = "current",
+        auto_bootstrap: bool = True,
+        connect_kwargs: Mapping[str, Any] | None = None,
+    ) -> PostgreSQLStatusStore:
+        """Build a store from a PostgreSQL URL, defaulting to ``DATABASE_URL``."""
+
+        return cls(
+            database_url,
+            table_name=table_name,
+            status_key=status_key,
+            auto_bootstrap=auto_bootstrap,
+            connect_kwargs=connect_kwargs,
+        )
+
+    def bootstrap(self) -> None:
+        """Create the status table if assembly has not already provisioned it."""
+
+        with self._bootstrap_lock:
+            if self._bootstrapped:
+                return
+            with self._transaction() as connection:
+                with connection.cursor() as cursor:
+                    cursor.execute(
+                        f"""
+CREATE TABLE IF NOT EXISTS {self._table_name} (
+    status_key text PRIMARY KEY,
+    graph_status text NOT NULL CHECK (
+        graph_status IN ('ready', 'syncing', 'rebuilding', 'failed')
+    ),
+    graph_generation_id bigint NOT NULL CHECK (graph_generation_id >= 0),
+    node_count bigint NOT NULL CHECK (node_count >= 0),
+    edge_count bigint NOT NULL CHECK (edge_count >= 0),
+    key_label_counts jsonb NOT NULL CHECK (jsonb_typeof(key_label_counts) = 'object'),
+    checksum text NOT NULL CHECK (checksum <> ''),
+    last_verified_at timestamptz NULL,
+    last_reload_at timestamptz NULL,
+    updated_at timestamptz NOT NULL DEFAULT now()
+)
+""",
+                    )
+            self._bootstrapped = True
+
+    def ensure_schema(self) -> None:
+        """Alias for callers that name bootstrap as schema provisioning."""
+
+        self.bootstrap()
+
+    def read_current_status(self) -> Neo4jGraphStatus | None:
+        """Return the current status row, or None before row bootstrap."""
+
+        self._ensure_bootstrap()
+        with self._transaction() as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    f"""
+SELECT graph_status,
+       graph_generation_id,
+       node_count,
+       edge_count,
+       key_label_counts,
+       checksum,
+       last_verified_at,
+       last_reload_at
+FROM {self._table_name}
+WHERE status_key = %s
+""",
+                    (self._status_key,),
+                )
+                row = cursor.fetchone()
+        if row is None:
+            return None
+        return _status_from_row(row)
+
+    def write_current_status(self, status: Neo4jGraphStatus) -> None:
+        """Persist the current status row without comparing the previous value."""
+
+        self._ensure_bootstrap()
+        values = _status_write_values(status)
+        with self._transaction() as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    f"""
+INSERT INTO {self._table_name} (
+    status_key,
+    graph_status,
+    graph_generation_id,
+    node_count,
+    edge_count,
+    key_label_counts,
+    checksum,
+    last_verified_at,
+    last_reload_at
+)
+VALUES (%s, %s, %s, %s, %s, %s::jsonb, %s, %s, %s)
+ON CONFLICT (status_key) DO UPDATE SET
+    graph_status = EXCLUDED.graph_status,
+    graph_generation_id = EXCLUDED.graph_generation_id,
+    node_count = EXCLUDED.node_count,
+    edge_count = EXCLUDED.edge_count,
+    key_label_counts = EXCLUDED.key_label_counts,
+    checksum = EXCLUDED.checksum,
+    last_verified_at = EXCLUDED.last_verified_at,
+    last_reload_at = EXCLUDED.last_reload_at,
+    updated_at = now()
+""",
+                    (self._status_key, *values),
+                )
+
+    def compare_and_write_current_status(
+        self,
+        *,
+        expected_status: Neo4jGraphStatus | None,
+        next_status: Neo4jGraphStatus,
+    ) -> bool:
+        """Atomically persist next_status only if the current row still matches."""
+
+        self._ensure_bootstrap()
+        next_values = _status_write_values(next_status)
+        if expected_status is None:
+            return self._insert_if_missing(next_values)
+
+        expected_values = _status_write_values(expected_status)
+        with self._transaction() as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    f"""
+UPDATE {self._table_name}
+SET graph_status = %s,
+    graph_generation_id = %s,
+    node_count = %s,
+    edge_count = %s,
+    key_label_counts = %s::jsonb,
+    checksum = %s,
+    last_verified_at = %s,
+    last_reload_at = %s,
+    updated_at = now()
+WHERE status_key = %s
+  AND graph_status = %s
+  AND graph_generation_id = %s
+  AND node_count = %s
+  AND edge_count = %s
+  AND key_label_counts = %s::jsonb
+  AND checksum = %s
+  AND last_verified_at IS NOT DISTINCT FROM %s
+  AND last_reload_at IS NOT DISTINCT FROM %s
+RETURNING status_key
+""",
+                    (*next_values, self._status_key, *expected_values),
+                )
+                return cursor.fetchone() is not None
+
+    def _insert_if_missing(self, next_values: tuple[Any, ...]) -> bool:
+        with self._transaction() as connection:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    f"""
+INSERT INTO {self._table_name} (
+    status_key,
+    graph_status,
+    graph_generation_id,
+    node_count,
+    edge_count,
+    key_label_counts,
+    checksum,
+    last_verified_at,
+    last_reload_at
+)
+VALUES (%s, %s, %s, %s, %s, %s::jsonb, %s, %s, %s)
+ON CONFLICT (status_key) DO NOTHING
+RETURNING status_key
+""",
+                    (self._status_key, *next_values),
+                )
+                return cursor.fetchone() is not None
+
+    def _ensure_bootstrap(self) -> None:
+        if self._auto_bootstrap and not self._bootstrapped:
+            self.bootstrap()
+
+    @contextmanager
+    def _transaction(self) -> Iterator[Any]:
+        connection = self._connection_factory()
+        try:
+            yield connection
+            connection.commit()
+        except Exception:
+            connection.rollback()
+            raise
+        finally:
+            connection.close()
+
+
+PostgresStatusStore = PostgreSQLStatusStore
+
+
+_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def _build_psycopg_connection_factory(
+    database_url: str,
+    *,
+    connect_kwargs: dict[str, Any],
+) -> Callable[[], Any]:
+    try:
+        psycopg = importlib.import_module("psycopg")
+    except ModuleNotFoundError as exc:  # pragma: no cover - exercised by integration envs.
+        raise RuntimeError(
+            "PostgreSQLStatusStore requires the optional 'psycopg' package",
+        ) from exc
+
+    return lambda: psycopg.connect(database_url, **connect_kwargs)
+
+
+def _quote_qualified_identifier(identifier: str) -> str:
+    parts = identifier.split(".")
+    if not parts or any(_IDENTIFIER_RE.fullmatch(part) is None for part in parts):
+        raise ValueError(f"invalid PostgreSQL identifier: {identifier!r}")
+    return ".".join(f'"{part}"' for part in parts)
+
+
+def _status_write_values(status: Neo4jGraphStatus) -> tuple[Any, ...]:
+    return (
+        status.graph_status,
+        status.graph_generation_id,
+        status.node_count,
+        status.edge_count,
+        json.dumps(status.key_label_counts, sort_keys=True, separators=(",", ":")),
+        status.checksum,
+        status.last_verified_at,
+        status.last_reload_at,
+    )
+
+
+def _status_from_row(row: Any) -> Neo4jGraphStatus:
+    (
+        graph_status,
+        graph_generation_id,
+        node_count,
+        edge_count,
+        key_label_counts,
+        checksum,
+        last_verified_at,
+        last_reload_at,
+    ) = row
+    if isinstance(key_label_counts, str):
+        key_label_counts = json.loads(key_label_counts)
+
+    return Neo4jGraphStatus(
+        graph_status=graph_status,
+        graph_generation_id=graph_generation_id,
+        node_count=node_count,
+        edge_count=edge_count,
+        key_label_counts=dict(key_label_counts),
+        checksum=checksum,
+        last_verified_at=last_verified_at,
+        last_reload_at=last_reload_at,
+    )

--- a/tests/integration/test_postgresql_status_store.py
+++ b/tests/integration/test_postgresql_status_store.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import os
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime, timezone
+from threading import Barrier
+from typing import Any
+from uuid import uuid4
+
+import pytest
+
+from graph_engine.models import Neo4jGraphStatus
+from graph_engine.status import GraphStatusManager
+from graph_engine.status.store import PostgreSQLStatusStore
+
+pytestmark = pytest.mark.skipif(
+    os.getenv("DATABASE_URL") is None,
+    reason="DATABASE_URL is not set; PostgreSQL status store tests require a database.",
+)
+
+NOW = datetime(2026, 4, 17, 1, 2, 3, tzinfo=timezone.utc)
+
+
+class BarrierStatusStore(PostgreSQLStatusStore):
+    def __init__(self, *args: Any, barrier: Barrier, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._barrier = barrier
+
+    def read_current_status(self) -> Neo4jGraphStatus | None:
+        status = super().read_current_status()
+        if status is not None and status.graph_status == "ready":
+            self._barrier.wait(timeout=10)
+        return status
+
+
+def test_postgresql_status_store_bootstraps_empty_row_and_persists_transitions() -> None:
+    pytest.importorskip("psycopg")
+
+    database_url = _database_url()
+    table_name = _table_name()
+    store = PostgreSQLStatusStore(database_url, table_name=table_name)
+
+    try:
+        assert store.read_current_status() is None
+
+        rebuilding = GraphStatusManager(store, clock=lambda: NOW).mark_rebuilding()
+        assert rebuilding.graph_status == "rebuilding"
+        assert store.read_current_status() == rebuilding
+
+        ready = GraphStatusManager(store, clock=lambda: NOW).mark_ready(
+            node_count=3,
+            edge_count=2,
+            key_label_counts={"Entity": 2, "Sector": 1},
+            checksum="ready-checksum",
+            reload_completed=True,
+        )
+
+        assert store.read_current_status() == ready
+        assert ready.graph_status == "ready"
+        assert ready.graph_generation_id == 1
+        assert ready.last_verified_at == NOW
+        assert ready.last_reload_at == NOW
+    finally:
+        _drop_table(database_url, table_name)
+
+
+def test_postgresql_status_store_rejects_competing_reload_and_sync_transitions() -> None:
+    pytest.importorskip("psycopg")
+
+    database_url = _database_url()
+    table_name = _table_name()
+    store = PostgreSQLStatusStore(database_url, table_name=table_name)
+    store.write_current_status(_status())
+    barrier = Barrier(2)
+
+    try:
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            futures = [
+                executor.submit(_begin_sync, database_url, table_name, barrier),
+                executor.submit(_mark_rebuilding, database_url, table_name, barrier),
+            ]
+            outcomes = [future.result(timeout=20) for future in futures]
+
+        assert outcomes.count("stale") == 1
+        assert outcomes.count("syncing") + outcomes.count("rebuilding") == 1
+        final_status = store.read_current_status()
+        assert final_status is not None
+        assert final_status.graph_status in {"syncing", "rebuilding"}
+    finally:
+        _drop_table(database_url, table_name)
+
+
+def _begin_sync(database_url: str, table_name: str, barrier: Barrier) -> str:
+    store = BarrierStatusStore(database_url, table_name=table_name, barrier=barrier)
+    manager = GraphStatusManager(store, clock=lambda: NOW)
+    try:
+        _, status = manager.begin_sync()
+    except RuntimeError as exc:
+        assert "stale graph_status transition" in str(exc)
+        return "stale"
+    return status.graph_status
+
+
+def _mark_rebuilding(database_url: str, table_name: str, barrier: Barrier) -> str:
+    store = BarrierStatusStore(database_url, table_name=table_name, barrier=barrier)
+    manager = GraphStatusManager(store, clock=lambda: NOW)
+    try:
+        status = manager.mark_rebuilding()
+    except RuntimeError as exc:
+        assert "stale graph_status transition" in str(exc)
+        return "stale"
+    return status.graph_status
+
+
+def _status() -> Neo4jGraphStatus:
+    return Neo4jGraphStatus(
+        graph_status="ready",
+        graph_generation_id=8,
+        node_count=2,
+        edge_count=1,
+        key_label_counts={"Entity": 2},
+        checksum="ready-checksum",
+        last_verified_at=NOW,
+        last_reload_at=None,
+    )
+
+
+def _database_url() -> str:
+    database_url = os.getenv("DATABASE_URL")
+    assert database_url is not None
+    return database_url
+
+
+def _table_name() -> str:
+    return f"neo4j_graph_status_test_{uuid4().hex}"
+
+
+def _drop_table(database_url: str, table_name: str) -> None:
+    psycopg = pytest.importorskip("psycopg")
+    with psycopg.connect(database_url) as connection:
+        with connection.cursor() as cursor:
+            cursor.execute(f'DROP TABLE IF EXISTS "{table_name}"')


### PR DESCRIPTION
Closes #29

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `benchmarks/artifacts/lite_target_100k_800k.json`, `benchmarks/generate_synthetic.py`, `benchmarks/run_benchmark.py`, `cross-cutting`, `graph_engine/__pycache__/__init__.cpython-314.pyc`, `graph_engine/live_metrics.py`, `graph_engine/reload/service.py`, `graph_engine/status/consistency.py`, `graph_engine/sync/live_graph.py`, `project_ult_graph_engine.egg-info/SOURCES.txt`


---
## 背景与目标
Milestone review for milestone-2 发现阻塞性问题，必须在进入下一阶段前修复。

## 问题描述
StatusStore is only a Protocol and the tests use in-memory stores. The core safety property for this milestone is atomic compare-and-write across promotion, cold reload, and read gates, but there is no PostgreSQL-backed implementation or integration test proving cross-process atomicity. In production, separate workers would not have a shared gate unless assembly provides a compatible implementation outside this milestone.

## 实现范围
- 修改文件: `graph_engine/status/store.py`
- Add a PostgreSQL StatusStore with row-level compare-and-set semantics, bootstrap behavior, transaction isolation expectations, and concurrency tests covering competing reload/sync transitions.

## 验收标准
- [ ] 原始 P0 问题已修复
- [ ] 新增回归测试覆盖该场景
- [ ] 构建通过

## 验证命令
```bash
/Users/fanjie/Desktop/Cowork/project-ult/graph-engine/.venv/bin/python -m pytest
```
