### PR TITLE
feat(#28): [milestone-2 review] P0: Public graph_status contract was expanded with transient syncing state

### DIFF
--- a/graph_engine/models.py
+++ b/graph_engine/models.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any, Literal
+from typing import Any, Literal, Self
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 
 class GraphNodeRecord(BaseModel):
@@ -162,7 +162,7 @@ class Neo4jGraphStatus(BaseModel):
 
     model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
 
-    graph_status: Literal["ready", "syncing", "rebuilding", "failed"]
+    graph_status: Literal["ready", "rebuilding", "failed"]
     graph_generation_id: int = Field(ge=0)
     node_count: int = Field(ge=0)
     edge_count: int = Field(ge=0)
@@ -170,3 +170,10 @@ class Neo4jGraphStatus(BaseModel):
     checksum: str = Field(min_length=1)
     last_verified_at: datetime | None
     last_reload_at: datetime | None
+    writer_lock_token: str | None = Field(default=None, min_length=1)
+
+    @model_validator(mode="after")
+    def _writer_lock_requires_ready_status(self) -> Self:
+        if self.writer_lock_token is not None and self.graph_status != "ready":
+            raise ValueError("writer_lock_token requires graph_status='ready'")
+        return self

--- a/graph_engine/promotion/service.py
+++ b/graph_engine/promotion/service.py
@@ -55,26 +55,26 @@ def _sync_live_graph_with_status_barrier(
 ) -> None:
     """Mirror a promotion only while the ready status token still holds."""
 
-    ready_status, syncing_status = status_manager.begin_sync()
+    ready_status, locked_status = status_manager.begin_sync()
 
     try:
         _require_status_token_unchanged(
             status_manager,
-            syncing_status,
+            locked_status,
             "before promotion live sync",
         )
         sync_live_graph(plan, client)
         _require_status_token_unchanged(
             status_manager,
-            syncing_status,
+            locked_status,
             "after promotion live sync",
         )
         status_manager.finish_sync(
-            expected_status=syncing_status,
+            expected_status=locked_status,
             ready_status=ready_status,
         )
     except Exception:
-        _mark_sync_failed_safely(status_manager, syncing_status)
+        _mark_sync_failed_safely(status_manager, locked_status)
         raise
 
 
@@ -93,9 +93,9 @@ def _require_status_token_unchanged(
 
 def _mark_sync_failed_safely(
     status_manager: GraphStatusManager,
-    syncing_status: Neo4jGraphStatus,
+    locked_status: Neo4jGraphStatus,
 ) -> None:
     try:
-        status_manager.mark_sync_failed(expected_status=syncing_status)
+        status_manager.mark_sync_failed(expected_status=locked_status)
     except Exception:  # noqa: BLE001 - preserve the original promotion sync failure.
         return

--- a/graph_engine/status/manager.py
+++ b/graph_engine/status/manager.py
@@ -4,10 +4,11 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from datetime import datetime, timezone
-from typing import Literal
 
 from graph_engine.models import GraphSnapshot, Neo4jGraphStatus
 from graph_engine.status.store import StatusStore
+
+_SYNC_WRITER_LOCK_TOKEN = "incremental-sync"
 
 
 def require_ready_status(graph_status: Neo4jGraphStatus) -> Neo4jGraphStatus:
@@ -51,6 +52,8 @@ class GraphStatusManager:
 
         current = self.store.read_current_status()
         current_state = current.graph_status if current is not None else None
+        if current is not None and current.writer_lock_token is not None:
+            raise ValueError("cannot transition graph_status with active writer lock to 'rebuilding'")
         if current_state == "rebuilding":
             raise ValueError("cannot transition graph_status from 'rebuilding' to 'rebuilding'")
 
@@ -74,7 +77,10 @@ class GraphStatusManager:
         """Acquire an exclusive live-graph writer token for incremental sync."""
 
         current = self.require_ready()
-        status = _copy_status_with_graph_status(current, "syncing")
+        if current.writer_lock_token is not None:
+            raise ValueError("incremental sync writer lock is already held")
+
+        status = _copy_status_with_writer_lock(current, _SYNC_WRITER_LOCK_TOKEN)
         self._commit_transition(current, status)
         return current, status
 
@@ -86,10 +92,12 @@ class GraphStatusManager:
     ) -> Neo4jGraphStatus:
         """Release an incremental sync writer token back to its ready status."""
 
-        if expected_status.graph_status != "syncing":
-            raise ValueError("finish_sync requires expected graph_status='syncing'")
+        if expected_status.graph_status != "ready" or expected_status.writer_lock_token is None:
+            raise ValueError("finish_sync requires an active incremental sync writer lock")
         if ready_status.graph_status != "ready":
             raise ValueError("finish_sync requires ready graph_status='ready'")
+        if ready_status.writer_lock_token is not None:
+            raise ValueError("finish_sync requires ready status without writer lock")
 
         self._commit_transition(expected_status, ready_status)
         return ready_status
@@ -105,8 +113,8 @@ class GraphStatusManager:
     ) -> Neo4jGraphStatus:
         """Release a failed incremental sync by exposing live graph failure."""
 
-        if expected_status.graph_status != "syncing":
-            raise ValueError("mark_sync_failed requires expected graph_status='syncing'")
+        if expected_status.graph_status != "ready" or expected_status.writer_lock_token is None:
+            raise ValueError("mark_sync_failed requires an active incremental sync writer lock")
 
         status = Neo4jGraphStatus(
             graph_status="failed",
@@ -179,7 +187,7 @@ class GraphStatusManager:
 
         current = self.store.read_current_status()
         current_state = current.graph_status if current is not None else None
-        if current_state not in {"rebuilding", "ready", "syncing"}:
+        if current_state not in {"rebuilding", "ready"}:
             raise ValueError(
                 "cannot transition graph_status from "
                 f"{current_state!r} to 'failed'",
@@ -203,6 +211,8 @@ class GraphStatusManager:
         """Refresh ready metrics from a canonical snapshot without bumping generation."""
 
         current = self.require_ready()
+        if current.writer_lock_token is not None:
+            raise ValueError("cannot verify graph_status while writer lock is active")
         if snapshot.graph_generation_id != current.graph_generation_id:
             raise ValueError(
                 "snapshot graph_generation_id disagrees with current status: "
@@ -241,17 +251,18 @@ def _utc_now() -> datetime:
     return datetime.now(timezone.utc)
 
 
-def _copy_status_with_graph_status(
+def _copy_status_with_writer_lock(
     status: Neo4jGraphStatus,
-    graph_status: Literal["ready", "syncing", "rebuilding", "failed"],
+    writer_lock_token: str,
 ) -> Neo4jGraphStatus:
     return Neo4jGraphStatus(
-        graph_status=graph_status,
+        graph_status=status.graph_status,
         graph_generation_id=status.graph_generation_id,
         node_count=status.node_count,
         edge_count=status.edge_count,
         key_label_counts=dict(status.key_label_counts),
         checksum=status.checksum,
-        last_verified_at=None if graph_status != "ready" else status.last_verified_at,
+        last_verified_at=status.last_verified_at,
         last_reload_at=status.last_reload_at,
+        writer_lock_token=writer_lock_token,
     )

--- a/graph_engine/status/manager.py
+++ b/graph_engine/status/manager.py
@@ -187,6 +187,10 @@ class GraphStatusManager:
 
         current = self.store.read_current_status()
         current_state = current.graph_status if current is not None else None
+        if current is not None and current.writer_lock_token is not None:
+            raise ValueError(
+                "cannot transition graph_status with active writer lock to 'failed'",
+            )
         if current_state not in {"rebuilding", "ready"}:
             raise ValueError(
                 "cannot transition graph_status from "

--- a/graph_engine/status/store.py
+++ b/graph_engine/status/store.py
@@ -13,6 +13,8 @@ from typing import Any, Protocol
 
 from graph_engine.models import Neo4jGraphStatus
 
+_GRAPH_STATUS_CHECK_CONSTRAINT = "neo4j_graph_status_graph_status_check"
+
 
 class StatusStore(Protocol):
     """Persistence boundary for the singleton Neo4j graph status row."""
@@ -131,6 +133,8 @@ ADD COLUMN IF NOT EXISTS writer_lock_token text NULL CHECK (
 )
 """,
                     )
+                    self._normalize_legacy_syncing_status(cursor)
+                    self._recreate_graph_status_check_constraint(cursor)
             self._bootstrapped = True
 
     def ensure_schema(self) -> None:
@@ -276,6 +280,47 @@ RETURNING status_key
         if self._auto_bootstrap and not self._bootstrapped:
             self.bootstrap()
 
+    def _normalize_legacy_syncing_status(self, cursor: Any) -> None:
+        cursor.execute(
+            f"""
+UPDATE {self._table_name}
+SET graph_status = 'failed',
+    writer_lock_token = NULL,
+    last_verified_at = NULL,
+    checksum = CASE WHEN checksum = '' THEN 'failed' ELSE checksum END,
+    updated_at = now()
+WHERE graph_status = 'syncing'
+""",
+        )
+
+    def _recreate_graph_status_check_constraint(self, cursor: Any) -> None:
+        cursor.execute(
+            """
+SELECT conname
+FROM pg_constraint
+WHERE conrelid = %s::regclass
+  AND contype = 'c'
+  AND pg_get_constraintdef(oid) ILIKE '%%graph_status%%'
+""",
+            (self._table_name,),
+        )
+        constraint_names = [str(row[0]) for row in cursor.fetchall()]
+        for constraint_name in constraint_names:
+            cursor.execute(
+                f"""
+ALTER TABLE {self._table_name}
+DROP CONSTRAINT IF EXISTS {_quote_identifier(constraint_name)}
+""",
+            )
+
+        cursor.execute(
+            f"""
+ALTER TABLE {self._table_name}
+ADD CONSTRAINT {_quote_identifier(_GRAPH_STATUS_CHECK_CONSTRAINT)}
+CHECK (graph_status IN ('ready', 'rebuilding', 'failed'))
+""",
+        )
+
     @contextmanager
     def _transaction(self) -> Iterator[Any]:
         connection = self._connection_factory()
@@ -315,6 +360,12 @@ def _quote_qualified_identifier(identifier: str) -> str:
     if not parts or any(_IDENTIFIER_RE.fullmatch(part) is None for part in parts):
         raise ValueError(f"invalid PostgreSQL identifier: {identifier!r}")
     return ".".join(f'"{part}"' for part in parts)
+
+
+def _quote_identifier(identifier: str) -> str:
+    if _IDENTIFIER_RE.fullmatch(identifier) is None:
+        raise ValueError(f"invalid PostgreSQL identifier: {identifier!r}")
+    return f'"{identifier}"'
 
 
 def _status_write_values(status: Neo4jGraphStatus) -> tuple[Any, ...]:

--- a/graph_engine/status/store.py
+++ b/graph_engine/status/store.py
@@ -107,7 +107,7 @@ class PostgreSQLStatusStore:
 CREATE TABLE IF NOT EXISTS {self._table_name} (
     status_key text PRIMARY KEY,
     graph_status text NOT NULL CHECK (
-        graph_status IN ('ready', 'syncing', 'rebuilding', 'failed')
+        graph_status IN ('ready', 'rebuilding', 'failed')
     ),
     graph_generation_id bigint NOT NULL CHECK (graph_generation_id >= 0),
     node_count bigint NOT NULL CHECK (node_count >= 0),
@@ -116,7 +116,18 @@ CREATE TABLE IF NOT EXISTS {self._table_name} (
     checksum text NOT NULL CHECK (checksum <> ''),
     last_verified_at timestamptz NULL,
     last_reload_at timestamptz NULL,
+    writer_lock_token text NULL CHECK (
+        writer_lock_token IS NULL OR writer_lock_token <> ''
+    ),
     updated_at timestamptz NOT NULL DEFAULT now()
+)
+""",
+                    )
+                    cursor.execute(
+                        f"""
+ALTER TABLE {self._table_name}
+ADD COLUMN IF NOT EXISTS writer_lock_token text NULL CHECK (
+    writer_lock_token IS NULL OR writer_lock_token <> ''
 )
 """,
                     )
@@ -142,7 +153,8 @@ SELECT graph_status,
        key_label_counts,
        checksum,
        last_verified_at,
-       last_reload_at
+       last_reload_at,
+       writer_lock_token
 FROM {self._table_name}
 WHERE status_key = %s
 """,
@@ -171,9 +183,10 @@ INSERT INTO {self._table_name} (
     key_label_counts,
     checksum,
     last_verified_at,
-    last_reload_at
+    last_reload_at,
+    writer_lock_token
 )
-VALUES (%s, %s, %s, %s, %s, %s::jsonb, %s, %s, %s)
+VALUES (%s, %s, %s, %s, %s, %s::jsonb, %s, %s, %s, %s)
 ON CONFLICT (status_key) DO UPDATE SET
     graph_status = EXCLUDED.graph_status,
     graph_generation_id = EXCLUDED.graph_generation_id,
@@ -183,6 +196,7 @@ ON CONFLICT (status_key) DO UPDATE SET
     checksum = EXCLUDED.checksum,
     last_verified_at = EXCLUDED.last_verified_at,
     last_reload_at = EXCLUDED.last_reload_at,
+    writer_lock_token = EXCLUDED.writer_lock_token,
     updated_at = now()
 """,
                     (self._status_key, *values),
@@ -215,6 +229,7 @@ SET graph_status = %s,
     checksum = %s,
     last_verified_at = %s,
     last_reload_at = %s,
+    writer_lock_token = %s,
     updated_at = now()
 WHERE status_key = %s
   AND graph_status = %s
@@ -225,6 +240,7 @@ WHERE status_key = %s
   AND checksum = %s
   AND last_verified_at IS NOT DISTINCT FROM %s
   AND last_reload_at IS NOT DISTINCT FROM %s
+  AND writer_lock_token IS NOT DISTINCT FROM %s
 RETURNING status_key
 """,
                     (*next_values, self._status_key, *expected_values),
@@ -245,9 +261,10 @@ INSERT INTO {self._table_name} (
     key_label_counts,
     checksum,
     last_verified_at,
-    last_reload_at
+    last_reload_at,
+    writer_lock_token
 )
-VALUES (%s, %s, %s, %s, %s, %s::jsonb, %s, %s, %s)
+VALUES (%s, %s, %s, %s, %s, %s::jsonb, %s, %s, %s, %s)
 ON CONFLICT (status_key) DO NOTHING
 RETURNING status_key
 """,
@@ -310,6 +327,7 @@ def _status_write_values(status: Neo4jGraphStatus) -> tuple[Any, ...]:
         status.checksum,
         status.last_verified_at,
         status.last_reload_at,
+        status.writer_lock_token,
     )
 
 
@@ -323,6 +341,7 @@ def _status_from_row(row: Any) -> Neo4jGraphStatus:
         checksum,
         last_verified_at,
         last_reload_at,
+        writer_lock_token,
     ) = row
     if isinstance(key_label_counts, str):
         key_label_counts = json.loads(key_label_counts)
@@ -336,4 +355,5 @@ def _status_from_row(row: Any) -> Neo4jGraphStatus:
         checksum=checksum,
         last_verified_at=last_verified_at,
         last_reload_at=last_reload_at,
+        writer_lock_token=writer_lock_token,
     )

--- a/tests/integration/test_postgresql_status_store.py
+++ b/tests/integration/test_postgresql_status_store.py
@@ -97,6 +97,37 @@ def test_postgresql_status_store_rejects_competing_reload_and_sync_transitions()
         _drop_table(database_url, table_name)
 
 
+def test_postgresql_status_store_bootstrap_migrates_legacy_syncing_status() -> None:
+    psycopg = pytest.importorskip("psycopg")
+
+    database_url = _database_url()
+    table_name = _table_name()
+    _create_legacy_syncing_status_row(psycopg, database_url, table_name)
+    store = PostgreSQLStatusStore(database_url, table_name=table_name)
+
+    try:
+        store.bootstrap()
+
+        status = store.read_current_status()
+        assert status is not None
+        assert status.graph_status == "failed"
+        assert status.writer_lock_token is None
+        assert status.last_verified_at is None
+
+        with pytest.raises(Exception):
+            with psycopg.connect(database_url) as connection:
+                with connection.cursor() as cursor:
+                    cursor.execute(
+                        f"""
+UPDATE "{table_name}"
+SET graph_status = 'syncing'
+WHERE status_key = 'current'
+""",
+                    )
+    finally:
+        _drop_table(database_url, table_name)
+
+
 def _begin_sync(database_url: str, table_name: str, barrier: Barrier) -> str:
     store = BarrierStatusStore(database_url, table_name=table_name, barrier=barrier)
     manager = GraphStatusManager(store, clock=lambda: NOW)
@@ -149,3 +180,58 @@ def _drop_table(database_url: str, table_name: str) -> None:
     with psycopg.connect(database_url) as connection:
         with connection.cursor() as cursor:
             cursor.execute(f'DROP TABLE IF EXISTS "{table_name}"')
+
+
+def _create_legacy_syncing_status_row(
+    psycopg: Any,
+    database_url: str,
+    table_name: str,
+) -> None:
+    with psycopg.connect(database_url) as connection:
+        with connection.cursor() as cursor:
+            cursor.execute(f'DROP TABLE IF EXISTS "{table_name}"')
+            cursor.execute(
+                f"""
+CREATE TABLE "{table_name}" (
+    status_key text PRIMARY KEY,
+    graph_status text NOT NULL CHECK (
+        graph_status IN ('ready', 'rebuilding', 'failed', 'syncing')
+    ),
+    graph_generation_id bigint NOT NULL CHECK (graph_generation_id >= 0),
+    node_count bigint NOT NULL CHECK (node_count >= 0),
+    edge_count bigint NOT NULL CHECK (edge_count >= 0),
+    key_label_counts jsonb NOT NULL CHECK (jsonb_typeof(key_label_counts) = 'object'),
+    checksum text NOT NULL CHECK (checksum <> ''),
+    last_verified_at timestamptz NULL,
+    last_reload_at timestamptz NULL,
+    updated_at timestamptz NOT NULL DEFAULT now()
+)
+""",
+            )
+            cursor.execute(
+                f"""
+INSERT INTO "{table_name}" (
+    status_key,
+    graph_status,
+    graph_generation_id,
+    node_count,
+    edge_count,
+    key_label_counts,
+    checksum,
+    last_verified_at,
+    last_reload_at
+)
+VALUES (
+    'current',
+    'syncing',
+    8,
+    2,
+    1,
+    '{{"Entity": 2}}'::jsonb,
+    'legacy-syncing',
+    %s,
+    NULL
+)
+""",
+                (NOW,),
+            )

--- a/tests/integration/test_postgresql_status_store.py
+++ b/tests/integration/test_postgresql_status_store.py
@@ -28,7 +28,11 @@ class BarrierStatusStore(PostgreSQLStatusStore):
 
     def read_current_status(self) -> Neo4jGraphStatus | None:
         status = super().read_current_status()
-        if status is not None and status.graph_status == "ready":
+        if (
+            status is not None
+            and status.graph_status == "ready"
+            and status.writer_lock_token is None
+        ):
             self._barrier.wait(timeout=10)
         return status
 
@@ -82,10 +86,13 @@ def test_postgresql_status_store_rejects_competing_reload_and_sync_transitions()
             outcomes = [future.result(timeout=20) for future in futures]
 
         assert outcomes.count("stale") == 1
-        assert outcomes.count("syncing") + outcomes.count("rebuilding") == 1
+        assert outcomes.count("locked") + outcomes.count("rebuilding") == 1
         final_status = store.read_current_status()
         assert final_status is not None
-        assert final_status.graph_status in {"syncing", "rebuilding"}
+        assert final_status.graph_status == "rebuilding" or (
+            final_status.graph_status == "ready"
+            and final_status.writer_lock_token is not None
+        )
     finally:
         _drop_table(database_url, table_name)
 
@@ -98,7 +105,9 @@ def _begin_sync(database_url: str, table_name: str, barrier: Barrier) -> str:
     except RuntimeError as exc:
         assert "stale graph_status transition" in str(exc)
         return "stale"
-    return status.graph_status
+    assert status.graph_status == "ready"
+    assert status.writer_lock_token is not None
+    return "locked"
 
 
 def _mark_rebuilding(database_url: str, table_name: str, barrier: Barrier) -> str:

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -234,6 +234,35 @@ def test_candidate_delta_rejects_invalid_delta_type() -> None:
         )
 
 
+def test_neo4j_graph_status_rejects_syncing_public_state() -> None:
+    with pytest.raises(ValidationError):
+        Neo4jGraphStatus(
+            graph_status="syncing",
+            graph_generation_id=1,
+            node_count=10,
+            edge_count=12,
+            key_label_counts={"Entity": 10},
+            checksum="abc123",
+            last_verified_at=NOW,
+            last_reload_at=None,
+        )
+
+
+def test_neo4j_graph_status_writer_lock_requires_ready_state() -> None:
+    with pytest.raises(ValidationError, match="writer_lock_token"):
+        Neo4jGraphStatus(
+            graph_status="rebuilding",
+            graph_generation_id=1,
+            node_count=10,
+            edge_count=12,
+            key_label_counts={"Entity": 10},
+            checksum="abc123",
+            last_verified_at=None,
+            last_reload_at=None,
+            writer_lock_token="incremental-sync",
+        )
+
+
 def test_assertion_confidence_is_bounded() -> None:
     with pytest.raises(ValidationError):
         GraphAssertionRecord(

--- a/tests/unit/test_promotion.py
+++ b/tests/unit/test_promotion.py
@@ -108,7 +108,7 @@ class RebuildAfterSyncAcquireStore(InMemoryStatusStore):
             result
             and expected_status is not None
             and expected_status.graph_status == "ready"
-            and next_status.graph_status == "syncing"
+            and next_status.writer_lock_token is not None
         ):
             self.status = _status(graph_status="rebuilding")
         return result
@@ -238,10 +238,14 @@ def test_promote_graph_deltas_writes_canonical_before_live_graph(
 
     assert calls == ["canonical", "sync"]
     assert writer.plans == [plan]
-    assert store.compare_calls == [
-        (_status(), _status(graph_status="syncing")),
-        (_status(graph_status="syncing"), _status()),
-    ]
+    assert len(store.compare_calls) == 2
+    expected_ready, locked_status = store.compare_calls[0]
+    finish_expected, finish_ready = store.compare_calls[1]
+    assert expected_ready == _status()
+    assert locked_status.graph_status == "ready"
+    assert locked_status.writer_lock_token is not None
+    assert finish_expected == locked_status
+    assert finish_ready == _status()
     assert store.status == _status()
 
 
@@ -445,6 +449,7 @@ def _status_manager(
 def _status(
     *,
     graph_status: str = "ready",
+    writer_lock_token: str | None = None,
 ) -> Neo4jGraphStatus:
     return Neo4jGraphStatus(
         graph_status=graph_status,
@@ -455,6 +460,7 @@ def _status(
         checksum="abc123",
         last_verified_at=NOW if graph_status == "ready" else None,
         last_reload_at=None,
+        writer_lock_token=writer_lock_token,
     )
 
 

--- a/tests/unit/test_status.py
+++ b/tests/unit/test_status.py
@@ -159,16 +159,18 @@ def test_mark_rebuilding_rejects_existing_rebuilding_state() -> None:
         manager.mark_rebuilding()
 
 
-def test_mark_rebuilding_rejects_active_syncing_state() -> None:
-    manager = GraphStatusManager(InMemoryStatusStore(_status(graph_status="syncing")))
+def test_mark_rebuilding_rejects_active_writer_lock() -> None:
+    manager = GraphStatusManager(
+        InMemoryStatusStore(_status(graph_status="ready", writer_lock_token="sync-1")),
+    )
 
-    with pytest.raises(ValueError, match="syncing"):
+    with pytest.raises(ValueError, match="writer lock"):
         manager.mark_rebuilding()
 
 
-@pytest.mark.parametrize("source_status", ["ready", "syncing", "failed"])
+@pytest.mark.parametrize("source_status", ["ready", "failed"])
 def test_mark_ready_only_allows_rebuilding(
-    source_status: Literal["ready", "syncing", "failed"],
+    source_status: Literal["ready", "failed"],
 ) -> None:
     manager = GraphStatusManager(InMemoryStatusStore(_status(graph_status=source_status)))
 
@@ -269,16 +271,17 @@ def test_sync_writer_token_blocks_rebuilding_until_released() -> None:
     store = InMemoryStatusStore(_status(graph_status="ready", graph_generation_id=8))
     manager = GraphStatusManager(store, clock=lambda: NOW)
 
-    ready_status, syncing_status = manager.begin_sync()
+    ready_status, locked_status = manager.begin_sync()
 
     assert ready_status == _status(graph_status="ready", graph_generation_id=8)
-    assert store.status == syncing_status
-    assert syncing_status.graph_status == "syncing"
-    with pytest.raises(ValueError, match="syncing"):
+    assert store.status == locked_status
+    assert locked_status.graph_status == "ready"
+    assert locked_status.writer_lock_token is not None
+    with pytest.raises(ValueError, match="writer lock"):
         manager.mark_rebuilding()
 
     released = manager.finish_sync(
-        expected_status=syncing_status,
+        expected_status=locked_status,
         ready_status=ready_status,
     )
 
@@ -289,16 +292,17 @@ def test_sync_writer_token_blocks_rebuilding_until_released() -> None:
 def test_sync_writer_token_failure_marks_status_failed() -> None:
     store = InMemoryStatusStore(_status(graph_status="ready", graph_generation_id=8))
     manager = GraphStatusManager(store, clock=lambda: NOW)
-    _, syncing_status = manager.begin_sync()
+    _, locked_status = manager.begin_sync()
 
     failed = manager.mark_sync_failed(
-        expected_status=syncing_status,
+        expected_status=locked_status,
         checksum="sync-failed",
     )
 
     assert failed.graph_status == "failed"
-    assert failed.graph_generation_id == syncing_status.graph_generation_id
+    assert failed.graph_generation_id == locked_status.graph_generation_id
     assert failed.checksum == "sync-failed"
+    assert failed.writer_lock_token is None
     assert store.status == failed
 
 
@@ -317,9 +321,9 @@ def test_mark_rebuilding_rejects_stale_ready_status_before_write() -> None:
     assert store.compare_calls == 1
 
 
-@pytest.mark.parametrize("source_status", ["ready", "syncing", "rebuilding"])
-def test_mark_failed_allows_ready_syncing_and_rebuilding(
-    source_status: Literal["ready", "syncing", "rebuilding"],
+@pytest.mark.parametrize("source_status", ["ready", "rebuilding"])
+def test_mark_failed_allows_ready_and_rebuilding(
+    source_status: Literal["ready", "rebuilding"],
 ) -> None:
     store = InMemoryStatusStore(_status(graph_status=source_status, graph_generation_id=6))
 
@@ -375,9 +379,9 @@ def test_require_ready_returns_ready_status() -> None:
     assert GraphStatusManager(InMemoryStatusStore(ready_status)).require_ready() is ready_status
 
 
-@pytest.mark.parametrize("graph_status", ["syncing", "rebuilding", "failed"])
+@pytest.mark.parametrize("graph_status", ["rebuilding", "failed"])
 def test_require_ready_rejects_non_ready_status(
-    graph_status: Literal["syncing", "rebuilding", "failed"],
+    graph_status: Literal["rebuilding", "failed"],
 ) -> None:
     status = _status(graph_status=graph_status)
 
@@ -595,12 +599,13 @@ def test_check_live_graph_consistency_malformed_client_result_fails_closed() -> 
 
 def _status(
     *,
-    graph_status: Literal["ready", "syncing", "rebuilding", "failed"] = "ready",
+    graph_status: Literal["ready", "rebuilding", "failed"] = "ready",
     graph_generation_id: int = 3,
     node_count: int = 2,
     edge_count: int = 1,
     key_label_counts: dict[str, int] | None = None,
     checksum: str = "abc123",
+    writer_lock_token: str | None = None,
 ) -> Neo4jGraphStatus:
     return Neo4jGraphStatus(
         graph_status=graph_status,
@@ -611,6 +616,7 @@ def _status(
         checksum=checksum,
         last_verified_at=NOW if graph_status == "ready" else None,
         last_reload_at=None,
+        writer_lock_token=writer_lock_token,
     )
 
 

--- a/tests/unit/test_status.py
+++ b/tests/unit/test_status.py
@@ -350,6 +350,21 @@ def test_mark_failed_rejects_failed_state() -> None:
         manager.mark_failed()
 
 
+def test_mark_failed_rejects_active_writer_lock() -> None:
+    store = InMemoryStatusStore(
+        _status(graph_status="ready", writer_lock_token="incremental-sync"),
+    )
+
+    with pytest.raises(ValueError, match="writer lock"):
+        GraphStatusManager(store, clock=lambda: NOW).mark_failed()
+
+    assert store.writes == []
+    assert store.status == _status(
+        graph_status="ready",
+        writer_lock_token="incremental-sync",
+    )
+
+
 def test_mark_failed_rejects_missing_status() -> None:
     manager = GraphStatusManager(InMemoryStatusStore())
 


### PR DESCRIPTION
Closes #28

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `benchmarks/artifacts/lite_target_100k_800k.json`, `benchmarks/generate_synthetic.py`, `benchmarks/run_benchmark.py`, `cross-cutting`, `graph_engine/__pycache__/__init__.cpython-314.pyc`, `graph_engine/live_metrics.py`, `graph_engine/query/__init__.py`, `graph_engine/reload/service.py`, `graph_engine/snapshots/generator.py`, `graph_engine/status/consistency.py`


---
## 背景与目标
Milestone review for milestone-2 发现阻塞性问题，必须在进入下一阶段前修复。

## 问题描述
The project contract documents graph_status as ready/rebuilding/failed, but the milestone adds syncing to Neo4jGraphStatus and persists it through begin_sync. Because Neo4jGraphStatus is the PostgreSQL current-state contract consumed by other services, this mixes an internal writer lock with externally visible graph health and can break consumers or contract tests that only accept the documented enum.

## 实现范围
- 修改文件: `graph_engine/models.py`
- Keep graph_status limited to the documented states and model incremental-writer exclusion with a separate lock/lease/version field, or explicitly update the shared contract, docs, stores, and all consumers to treat syncing as a non-ready public state.

## 验收标准
- [ ] 原始 P0 问题已修复
- [ ] 新增回归测试覆盖该场景
- [ ] 构建通过

## 验证命令
```bash
/Users/fanjie/Desktop/Cowork/project-ult/graph-engine/.venv/bin/python -m pytest
```
