### PR TITLE
feat(#30): [milestone-2 review] P0: Ready gate is not integrated across all Neo4j read paths

### DIFF
--- a/graph_engine/__init__.py
+++ b/graph_engine/__init__.py
@@ -14,7 +14,9 @@ from graph_engine.models import (
     PropagationContext,
     PropagationResult,
     PromotionPlan,
+    ReadonlySimulationRequest,
 )
+from graph_engine.query import query_subgraph, simulate_readonly_impact
 from graph_engine.reload import (
     CanonicalReader,
     ColdReloadTimeoutError,
@@ -35,6 +37,7 @@ from graph_engine.status import (
     PostgresStatusStore,
     StatusStore,
     check_live_graph_consistency,
+    require_ready_read,
     require_ready_status,
 )
 
@@ -61,6 +64,7 @@ __all__ = [
     "PromotionPlan",
     "PropagationContext",
     "PropagationResult",
+    "ReadonlySimulationRequest",
     "RelationshipType",
     "SchemaManager",
     "StatusStore",
@@ -70,6 +74,9 @@ __all__ = [
     "get_constraint_statements",
     "get_index_statements",
     "load_config_from_env",
+    "query_subgraph",
     "rebuild_gds_projection",
+    "require_ready_read",
     "require_ready_status",
+    "simulate_readonly_impact",
 ]

--- a/graph_engine/models.py
+++ b/graph_engine/models.py
@@ -114,6 +114,18 @@ class PropagationResult(BaseModel):
     channel_breakdown: dict[str, Any]
 
 
+class ReadonlySimulationRequest(BaseModel):
+    """Runtime request for one read-only local impact simulation."""
+
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+    cycle_id: str = Field(min_length=1)
+    world_state_ref: str = Field(min_length=1)
+    graph_generation_id: int = Field(ge=0)
+    depth: int = Field(default=1, ge=0)
+    result_limit: int = Field(default=100, ge=1)
+
+
 class GraphSnapshot(BaseModel):
     """Structural snapshot of the promoted graph for a cycle."""
 

--- a/graph_engine/propagation/fundamental.py
+++ b/graph_engine/propagation/fundamental.py
@@ -25,7 +25,7 @@ def run_fundamental_propagation(
     context: PropagationContext,
     client: Neo4jClient,
     *,
-    status_manager: GraphStatusManager | None = None,
+    status_manager: GraphStatusManager,
     graph_name: str | None = None,
     max_iterations: int = 20,
     result_limit: int = 100,

--- a/graph_engine/propagation/fundamental.py
+++ b/graph_engine/propagation/fundamental.py
@@ -10,6 +10,7 @@ from graph_engine.client import Neo4jClient
 from graph_engine.models import PropagationContext, PropagationResult
 from graph_engine.propagation.scoring import build_score_explanation
 from graph_engine.schema.definitions import RelationshipType
+from graph_engine.status import GraphStatusManager, require_ready_read
 
 FUNDAMENTAL_RELATIONSHIP_TYPES = (
     RelationshipType.SUPPLY_CHAIN.value,
@@ -24,6 +25,7 @@ def run_fundamental_propagation(
     context: PropagationContext,
     client: Neo4jClient,
     *,
+    status_manager: GraphStatusManager | None = None,
     graph_name: str | None = None,
     max_iterations: int = 20,
     result_limit: int = 100,
@@ -36,6 +38,14 @@ def run_fundamental_propagation(
         raise ValueError("max_iterations must be greater than zero")
     if result_limit < 1:
         raise ValueError("result_limit must be greater than zero")
+
+    ready_status = require_ready_read(status_manager, "fundamental propagation")
+    if ready_status.graph_generation_id != context.graph_generation_id:
+        raise ValueError(
+            "PropagationContext graph_generation_id disagrees with Neo4jGraphStatus: "
+            f"context={context.graph_generation_id}, "
+            f"status={ready_status.graph_generation_id}",
+        )
 
     projection_name = graph_name or _default_projection_name(context)
     _drop_projection_if_exists(client, projection_name)

--- a/graph_engine/query/__init__.py
+++ b/graph_engine/query/__init__.py
@@ -1,1 +1,186 @@
+"""Status-gated read APIs for live graph subgraph queries and local simulations."""
 
+from __future__ import annotations
+
+from typing import Any
+
+from graph_engine.client import Neo4jClient
+from graph_engine.models import ReadonlySimulationRequest
+from graph_engine.status import GraphStatusManager, require_ready_read
+
+MAX_QUERY_DEPTH = 10
+
+
+def query_subgraph(
+    seed_entities: list[str],
+    depth: int,
+    *,
+    client: Neo4jClient,
+    status_manager: GraphStatusManager | None = None,
+) -> dict[str, Any]:
+    """Return a bounded live subgraph after verifying the graph is ready."""
+
+    require_ready_read(status_manager, "subgraph query")
+    return _query_subgraph_after_ready(seed_entities, depth, client=client)
+
+
+def simulate_readonly_impact(
+    seed_entities: list[str],
+    context: ReadonlySimulationRequest,
+    *,
+    client: Neo4jClient,
+    status_manager: GraphStatusManager | None = None,
+) -> dict[str, Any]:
+    """Run a read-only local impact simulation without modifying live graph state."""
+
+    ready_status = require_ready_read(status_manager, "readonly impact simulation")
+    if ready_status.graph_generation_id != context.graph_generation_id:
+        raise ValueError(
+            "ReadonlySimulationRequest graph_generation_id disagrees with Neo4jGraphStatus: "
+            f"context={context.graph_generation_id}, "
+            f"status={ready_status.graph_generation_id}",
+        )
+
+    subgraph = _query_subgraph_after_ready(seed_entities, context.depth, client=client)
+    impacted_entities = _impacted_entities_from_subgraph(
+        subgraph,
+        set(seed_entities),
+        result_limit=context.result_limit,
+    )
+    return {
+        "cycle_id": context.cycle_id,
+        "world_state_ref": context.world_state_ref,
+        "graph_generation_id": ready_status.graph_generation_id,
+        "seed_entities": list(seed_entities),
+        "subgraph": subgraph,
+        "impacted_entities": impacted_entities,
+        "activated_paths": list(subgraph["relationships"]),
+        "channel_breakdown": {
+            "readonly": {
+                "depth": subgraph["depth"],
+                "node_count": len(subgraph["nodes"]),
+                "edge_count": len(subgraph["relationships"]),
+            },
+        },
+    }
+
+
+def _query_subgraph_after_ready(
+    seed_entities: list[str],
+    depth: int,
+    *,
+    client: Neo4jClient,
+) -> dict[str, Any]:
+    seed_list = _validated_seed_entities(seed_entities)
+    validated_depth = _validated_depth(depth)
+    rows = client.execute_read(
+        _subgraph_query(validated_depth),
+        {"seed_entities": seed_list},
+    )
+    row = rows[0] if isinstance(rows, list) and rows else {}
+    if not isinstance(row, dict):
+        row = {}
+    return {
+        "seed_entities": seed_list,
+        "depth": validated_depth,
+        "nodes": _dict_rows(row.get("nodes")),
+        "relationships": _dict_rows(row.get("relationships")),
+    }
+
+
+def _subgraph_query(depth: int) -> str:
+    return f"""
+MATCH (seed)
+WHERE seed.canonical_entity_id IN $seed_entities
+   OR seed.node_id IN $seed_entities
+OPTIONAL MATCH path = (seed)-[*0..{depth}]-(node)
+WITH collect(DISTINCT seed) + collect(DISTINCT node) AS raw_nodes,
+     collect(path) AS paths
+WITH [graph_node IN raw_nodes WHERE graph_node IS NOT NULL] AS raw_nodes,
+     paths
+UNWIND raw_nodes AS graph_node
+WITH collect(DISTINCT graph_node) AS nodes, paths
+CALL {{
+    WITH paths
+    UNWIND paths AS graph_path
+    WITH graph_path
+    WHERE graph_path IS NOT NULL
+    UNWIND relationships(graph_path) AS relationship
+    RETURN collect(DISTINCT relationship) AS relationships
+}}
+RETURN [graph_node IN nodes WHERE graph_node IS NOT NULL | {{
+           node_id: graph_node.node_id,
+           canonical_entity_id: graph_node.canonical_entity_id,
+           labels: labels(graph_node),
+           properties: properties(graph_node)
+       }}] AS nodes,
+       [relationship IN relationships WHERE relationship IS NOT NULL | {{
+           edge_id: relationship.edge_id,
+           relationship_type: type(relationship),
+           source_node_id: startNode(relationship).node_id,
+           target_node_id: endNode(relationship).node_id,
+           properties: properties(relationship)
+       }}] AS relationships
+"""
+
+
+def _validated_seed_entities(seed_entities: list[str]) -> list[str]:
+    if not seed_entities:
+        raise ValueError("seed_entities must not be empty")
+    normalized = [seed_entity.strip() for seed_entity in seed_entities]
+    if any(not seed_entity for seed_entity in normalized):
+        raise ValueError("seed_entities must contain non-empty ids")
+    return normalized
+
+
+def _validated_depth(depth: int) -> int:
+    if isinstance(depth, bool) or not isinstance(depth, int):
+        raise ValueError("depth must be an integer")
+    if depth < 0:
+        raise ValueError("depth must be greater than or equal to zero")
+    if depth > MAX_QUERY_DEPTH:
+        raise ValueError(f"depth must be less than or equal to {MAX_QUERY_DEPTH}")
+    return depth
+
+
+def _dict_rows(value: Any) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        return []
+    return [dict(item) for item in value if isinstance(item, dict)]
+
+
+def _impacted_entities_from_subgraph(
+    subgraph: dict[str, Any],
+    seed_entities: set[str],
+    *,
+    result_limit: int,
+) -> list[dict[str, Any]]:
+    impacted_entities: list[dict[str, Any]] = []
+    for node in subgraph["nodes"]:
+        node_id = node.get("node_id")
+        canonical_entity_id = node.get("canonical_entity_id")
+        is_seed = node_id in seed_entities or canonical_entity_id in seed_entities
+        impacted_entities.append(
+            {
+                "node_id": node_id,
+                "canonical_entity_id": canonical_entity_id,
+                "labels": sorted(str(label) for label in node.get("labels", [])),
+                "score": 1.0 if is_seed else 0.0,
+                "is_seed": is_seed,
+            }
+        )
+    impacted_entities.sort(
+        key=lambda entity: (
+            not bool(entity["is_seed"]),
+            str(entity.get("node_id") or ""),
+            str(entity.get("canonical_entity_id") or ""),
+        ),
+    )
+    return impacted_entities[:result_limit]
+
+
+__all__ = [
+    "MAX_QUERY_DEPTH",
+    "query_subgraph",
+    "simulate_readonly_impact",
+]

--- a/graph_engine/query/__init__.py
+++ b/graph_engine/query/__init__.py
@@ -16,7 +16,7 @@ def query_subgraph(
     depth: int,
     *,
     client: Neo4jClient,
-    status_manager: GraphStatusManager | None = None,
+    status_manager: GraphStatusManager,
 ) -> dict[str, Any]:
     """Return a bounded live subgraph after verifying the graph is ready."""
 
@@ -29,7 +29,7 @@ def simulate_readonly_impact(
     context: ReadonlySimulationRequest,
     *,
     client: Neo4jClient,
-    status_manager: GraphStatusManager | None = None,
+    status_manager: GraphStatusManager,
 ) -> dict[str, Any]:
     """Run a read-only local impact simulation without modifying live graph state."""
 

--- a/graph_engine/snapshots/__init__.py
+++ b/graph_engine/snapshots/__init__.py
@@ -1,7 +1,6 @@
 """Public snapshot generation entry points."""
 
 from graph_engine.snapshots.generator import (
-    GraphStatusReader,
     build_graph_impact_snapshot,
     build_graph_snapshot,
     compute_graph_snapshots,
@@ -9,7 +8,6 @@ from graph_engine.snapshots.generator import (
 from graph_engine.snapshots.writer import SnapshotWriter
 
 __all__ = [
-    "GraphStatusReader",
     "SnapshotWriter",
     "build_graph_impact_snapshot",
     "build_graph_snapshot",

--- a/graph_engine/snapshots/generator.py
+++ b/graph_engine/snapshots/generator.py
@@ -26,7 +26,7 @@ def build_graph_snapshot(
     graph_generation_id: int,
     client: Neo4jClient,
     *,
-    status_manager: GraphStatusManager | None = None,
+    status_manager: GraphStatusManager,
 ) -> GraphSnapshot:
     """Read live graph metrics and return a deterministic structural snapshot."""
 
@@ -77,7 +77,7 @@ def compute_graph_snapshots(
     graph_generation_id: int | None = None,
     regime_reader: RegimeContextReader,
     snapshot_writer: SnapshotWriter,
-    status_manager: GraphStatusManager | None = None,
+    status_manager: GraphStatusManager,
     graph_name: str | None = None,
 ) -> tuple[GraphSnapshot, GraphImpactSnapshot]:
     """Run fundamental propagation and write graph plus impact snapshots."""

--- a/graph_engine/snapshots/generator.py
+++ b/graph_engine/snapshots/generator.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from typing import Protocol
 
 from graph_engine.client import Neo4jClient
 from graph_engine.live_metrics import (
@@ -19,22 +18,20 @@ from graph_engine.models import (
 from graph_engine.propagation.context import RegimeContextReader, build_propagation_context
 from graph_engine.propagation.fundamental import run_fundamental_propagation
 from graph_engine.snapshots.writer import SnapshotWriter
-
-
-class GraphStatusReader(Protocol):
-    """Read the current live graph status from the status boundary."""
-
-    def read_graph_status(self) -> Neo4jGraphStatus:
-        """Return the current Neo4j graph status."""
+from graph_engine.status import GraphStatusManager, require_ready_read
 
 
 def build_graph_snapshot(
     cycle_id: str,
     graph_generation_id: int,
     client: Neo4jClient,
+    *,
+    status_manager: GraphStatusManager | None = None,
 ) -> GraphSnapshot:
     """Read live graph metrics and return a deterministic structural snapshot."""
 
+    ready_status = require_ready_read(status_manager, "graph snapshot generation")
+    _validate_generation_input(graph_generation_id, ready_status)
     node_count, edge_count, key_label_counts, checksum = _read_graph_metrics(client)
     return _graph_snapshot_from_metrics(
         cycle_id,
@@ -80,14 +77,12 @@ def compute_graph_snapshots(
     graph_generation_id: int | None = None,
     regime_reader: RegimeContextReader,
     snapshot_writer: SnapshotWriter,
-    graph_status: Neo4jGraphStatus | None = None,
-    status_reader: GraphStatusReader | None = None,
+    status_manager: GraphStatusManager | None = None,
     graph_name: str | None = None,
 ) -> tuple[GraphSnapshot, GraphImpactSnapshot]:
     """Run fundamental propagation and write graph plus impact snapshots."""
 
-    ready_status = _resolve_ready_graph_status(graph_status, status_reader)
-    _require_publication_status_reader(status_reader)
+    ready_status = require_ready_read(status_manager, "snapshot generation")
     _validate_generation_input(graph_generation_id, ready_status)
     node_count, edge_count, key_label_counts, checksum = _read_graph_metrics(client)
     _validate_status_metrics(
@@ -108,6 +103,7 @@ def compute_graph_snapshots(
     propagation_result = run_fundamental_propagation(
         context,
         client,
+        status_manager=status_manager,
         graph_name=graph_name,
     )
     graph_snapshot = _graph_snapshot_from_metrics(
@@ -125,40 +121,11 @@ def compute_graph_snapshots(
     )
     _validate_publication_status_and_metrics(
         ready_status,
-        status_reader,
+        status_manager,
         client,
     )
     snapshot_writer.write_snapshots(graph_snapshot, impact_snapshot)
     return graph_snapshot, impact_snapshot
-
-
-def _resolve_ready_graph_status(
-    graph_status: Neo4jGraphStatus | None,
-    status_reader: GraphStatusReader | None,
-) -> Neo4jGraphStatus:
-    if graph_status is None:
-        if status_reader is None:
-            raise ValueError(
-                "formal snapshot computation requires graph_status or status_reader",
-            )
-        graph_status = status_reader.read_graph_status()
-
-    if graph_status.graph_status != "ready":
-        raise PermissionError(
-            "snapshot computation requires graph_status='ready'; "
-            f"received {graph_status.graph_status!r}",
-        )
-    return graph_status
-
-
-def _require_publication_status_reader(
-    status_reader: GraphStatusReader | None,
-) -> None:
-    if status_reader is None:
-        raise ValueError(
-            "formal snapshot publication requires status_reader "
-            "for write-boundary validation",
-        )
 
 
 def _validate_generation_input(
@@ -210,20 +177,13 @@ def _validate_status_metrics(
 
 def _validate_publication_status_and_metrics(
     ready_status: Neo4jGraphStatus,
-    status_reader: GraphStatusReader | None,
+    status_manager: GraphStatusManager | None,
     client: Neo4jClient,
 ) -> None:
-    if status_reader is None:
-        raise ValueError(
-            "formal snapshot publication requires status_reader "
-            "for write-boundary validation",
-        )
-
-    current_status = status_reader.read_graph_status()
-    if current_status.graph_status != "ready":
-        raise RuntimeError(
-            "ready graph status changed before snapshot publication",
-        )
+    try:
+        current_status = require_ready_read(status_manager, "snapshot publication")
+    except PermissionError as exc:
+        raise RuntimeError("ready graph status changed before snapshot publication") from exc
     _validate_status_matches_ready_status(current_status, ready_status)
 
     node_count, edge_count, key_label_counts, checksum = _read_graph_metrics(client)

--- a/graph_engine/status/__init__.py
+++ b/graph_engine/status/__init__.py
@@ -4,7 +4,11 @@ from graph_engine.status.consistency import (
     CanonicalSnapshotReader,
     check_live_graph_consistency,
 )
-from graph_engine.status.manager import GraphStatusManager, require_ready_status
+from graph_engine.status.manager import (
+    GraphStatusManager,
+    require_ready_read,
+    require_ready_status,
+)
 from graph_engine.status.store import PostgreSQLStatusStore, PostgresStatusStore, StatusStore
 
 __all__ = [
@@ -14,5 +18,6 @@ __all__ = [
     "PostgresStatusStore",
     "StatusStore",
     "check_live_graph_consistency",
+    "require_ready_read",
     "require_ready_status",
 ]

--- a/graph_engine/status/manager.py
+++ b/graph_engine/status/manager.py
@@ -19,6 +19,8 @@ def require_ready_status(graph_status: Neo4jGraphStatus) -> Neo4jGraphStatus:
             "Neo4j live graph reads require graph_status='ready'; "
             f"received {graph_status.graph_status!r}",
         )
+    if graph_status.writer_lock_token is not None:
+        raise PermissionError("Neo4j live graph reads require no active writer lock")
     return graph_status
 
 

--- a/graph_engine/status/manager.py
+++ b/graph_engine/status/manager.py
@@ -251,6 +251,17 @@ class GraphStatusManager:
             )
 
 
+def require_ready_read(
+    status_manager: GraphStatusManager | None,
+    operation: str,
+) -> Neo4jGraphStatus:
+    """Return the ready status required before a public Neo4j read operation."""
+
+    if status_manager is None:
+        raise ValueError(f"{operation} requires status_manager")
+    return status_manager.require_ready()
+
+
 def _utc_now() -> datetime:
     return datetime.now(timezone.utc)
 

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -1,0 +1,42 @@
+"""Shared test fakes."""
+
+from __future__ import annotations
+
+from graph_engine.models import Neo4jGraphStatus
+
+
+class InMemoryStatusStore:
+    """In-memory StatusStore fake with write and CAS observability."""
+
+    def __init__(self, status: Neo4jGraphStatus | None = None) -> None:
+        self.status = status
+        self.writes: list[Neo4jGraphStatus] = []
+        self.compare_calls: list[tuple[Neo4jGraphStatus | None, Neo4jGraphStatus]] = []
+
+    @property
+    def graph_status(self) -> Neo4jGraphStatus | None:
+        return self.status
+
+    @graph_status.setter
+    def graph_status(self, status: Neo4jGraphStatus | None) -> None:
+        self.status = status
+
+    def read_current_status(self) -> Neo4jGraphStatus | None:
+        return self.status
+
+    def write_current_status(self, status: Neo4jGraphStatus) -> None:
+        self.status = status
+        self.writes.append(status)
+
+    def compare_and_write_current_status(
+        self,
+        *,
+        expected_status: Neo4jGraphStatus | None,
+        next_status: Neo4jGraphStatus,
+    ) -> bool:
+        if isinstance(self.compare_calls, list):
+            self.compare_calls.append((expected_status, next_status))
+        if self.status != expected_status:
+            return False
+        self.write_current_status(next_status)
+        return True

--- a/tests/integration/test_promotion_sync.py
+++ b/tests/integration/test_promotion_sync.py
@@ -21,6 +21,7 @@ from graph_engine.schema.definitions import NodeLabel, RelationshipType
 from graph_engine.schema.manager import SchemaManager
 from graph_engine.status import GraphStatusManager
 from graph_engine.sync import sync_live_graph
+from tests.fakes import InMemoryStatusStore
 
 pytestmark = pytest.mark.skipif(
     os.getenv("NEO4J_PASSWORD") is None,
@@ -56,28 +57,6 @@ class CapturingCanonicalWriter:
 
     def write_canonical_records(self, plan: PromotionPlan) -> None:
         self.plans.append(plan)
-
-
-class InMemoryStatusStore:
-    def __init__(self, status: Neo4jGraphStatus) -> None:
-        self.status = status
-
-    def read_current_status(self) -> Neo4jGraphStatus | None:
-        return self.status
-
-    def write_current_status(self, status: Neo4jGraphStatus) -> None:
-        self.status = status
-
-    def compare_and_write_current_status(
-        self,
-        *,
-        expected_status: Neo4jGraphStatus | None,
-        next_status: Neo4jGraphStatus,
-    ) -> bool:
-        if self.status != expected_status:
-            return False
-        self.write_current_status(next_status)
-        return True
 
 
 def test_repeated_promotion_sync_is_idempotent_in_live_graph() -> None:

--- a/tests/integration/test_propagation_snapshot.py
+++ b/tests/integration/test_propagation_snapshot.py
@@ -22,6 +22,7 @@ from graph_engine.schema.manager import SchemaManager
 from graph_engine.snapshots import build_graph_snapshot, compute_graph_snapshots
 from graph_engine.status import GraphStatusManager
 from graph_engine.sync import sync_live_graph
+from tests.fakes import InMemoryStatusStore
 
 pytestmark = pytest.mark.skipif(
     os.getenv("NEO4J_PASSWORD") is None,
@@ -51,28 +52,6 @@ class CapturingSnapshotWriter:
         impact_snapshot: GraphImpactSnapshot,
     ) -> None:
         self.calls.append((graph_snapshot, impact_snapshot))
-
-
-class InMemoryStatusStore:
-    def __init__(self, graph_status: Neo4jGraphStatus) -> None:
-        self.graph_status = graph_status
-
-    def read_current_status(self) -> Neo4jGraphStatus | None:
-        return self.graph_status
-
-    def write_current_status(self, status: Neo4jGraphStatus) -> None:
-        self.graph_status = status
-
-    def compare_and_write_current_status(
-        self,
-        *,
-        expected_status: Neo4jGraphStatus | None,
-        next_status: Neo4jGraphStatus,
-    ) -> bool:
-        if self.graph_status != expected_status:
-            return False
-        self.write_current_status(next_status)
-        return True
 
 
 def test_compute_graph_snapshots_runs_fundamental_pagerank_on_promoted_graph() -> None:

--- a/tests/integration/test_propagation_snapshot.py
+++ b/tests/integration/test_propagation_snapshot.py
@@ -20,6 +20,7 @@ from graph_engine.models import (
 from graph_engine.schema.definitions import NodeLabel, RelationshipType
 from graph_engine.schema.manager import SchemaManager
 from graph_engine.snapshots import build_graph_snapshot, compute_graph_snapshots
+from graph_engine.status import GraphStatusManager
 from graph_engine.sync import sync_live_graph
 
 pytestmark = pytest.mark.skipif(
@@ -52,12 +53,26 @@ class CapturingSnapshotWriter:
         self.calls.append((graph_snapshot, impact_snapshot))
 
 
-class StaticStatusReader:
+class InMemoryStatusStore:
     def __init__(self, graph_status: Neo4jGraphStatus) -> None:
         self.graph_status = graph_status
 
-    def read_graph_status(self) -> Neo4jGraphStatus:
+    def read_current_status(self) -> Neo4jGraphStatus | None:
         return self.graph_status
+
+    def write_current_status(self, status: Neo4jGraphStatus) -> None:
+        self.graph_status = status
+
+    def compare_and_write_current_status(
+        self,
+        *,
+        expected_status: Neo4jGraphStatus | None,
+        next_status: Neo4jGraphStatus,
+    ) -> bool:
+        if self.graph_status != expected_status:
+            return False
+        self.write_current_status(next_status)
+        return True
 
 
 def test_compute_graph_snapshots_runs_fundamental_pagerank_on_promoted_graph() -> None:
@@ -80,7 +95,14 @@ def test_compute_graph_snapshots_runs_fundamental_pagerank_on_promoted_graph() -
 
         try:
             sync_live_graph(_promotion_plan(source_node_id, target_node_id, edge_id), client)
-            live_snapshot = build_graph_snapshot("cycle-1", 1, client)
+            live_snapshot = build_graph_snapshot(
+                "cycle-1",
+                1,
+                client,
+                status_manager=GraphStatusManager(
+                    InMemoryStatusStore(_status_for_generation(1)),
+                ),
+            )
             graph_status = Neo4jGraphStatus(
                 graph_status="ready",
                 graph_generation_id=live_snapshot.graph_generation_id,
@@ -91,6 +113,7 @@ def test_compute_graph_snapshots_runs_fundamental_pagerank_on_promoted_graph() -
                 last_verified_at=NOW,
                 last_reload_at=None,
             )
+            status_manager = GraphStatusManager(InMemoryStatusStore(graph_status))
 
             try:
                 graph_snapshot, impact_snapshot = compute_graph_snapshots(
@@ -100,7 +123,7 @@ def test_compute_graph_snapshots_runs_fundamental_pagerank_on_promoted_graph() -
                     graph_generation_id=1,
                     regime_reader=StaticRegimeReader(),
                     snapshot_writer=writer,
-                    status_reader=StaticStatusReader(graph_status),
+                    status_manager=status_manager,
                     graph_name=f"{prefix}-projection",
                 )
             except RuntimeError as exc:
@@ -137,6 +160,19 @@ def _promotion_plan(
         edge_records=[_edge_record(source_node_id, target_node_id, edge_id)],
         assertion_records=[],
         created_at=NOW,
+    )
+
+
+def _status_for_generation(graph_generation_id: int) -> Neo4jGraphStatus:
+    return Neo4jGraphStatus(
+        graph_status="ready",
+        graph_generation_id=graph_generation_id,
+        node_count=0,
+        edge_count=0,
+        key_label_counts={},
+        checksum="pending",
+        last_verified_at=NOW,
+        last_reload_at=None,
     )
 
 

--- a/tests/integration/test_reload.py
+++ b/tests/integration/test_reload.py
@@ -95,7 +95,14 @@ def test_cold_reload_rebuilds_live_graph_and_gds_projection() -> None:
 
         try:
             sync_live_graph(promotion_plan, client)
-            expected_snapshot = build_graph_snapshot("cycle-reload", 7, client)
+            expected_snapshot = build_graph_snapshot(
+                "cycle-reload",
+                7,
+                client,
+                status_manager=GraphStatusManager(
+                    InMemoryStatusStore(_status(graph_generation_id=7)),
+                ),
+            )
             plan = ColdReloadPlan(
                 snapshot_ref="snapshot-ref-reload",
                 cycle_id="cycle-reload",

--- a/tests/integration/test_reload.py
+++ b/tests/integration/test_reload.py
@@ -22,6 +22,7 @@ from graph_engine.schema.manager import DROP_ALL_CONFIRMATION_TOKEN, SchemaManag
 from graph_engine.snapshots import build_graph_snapshot
 from graph_engine.status import GraphStatusManager, check_live_graph_consistency
 from graph_engine.sync import sync_live_graph
+from tests.fakes import InMemoryStatusStore
 
 pytestmark = pytest.mark.skipif(
     os.getenv("NEO4J_PASSWORD") is None,
@@ -29,28 +30,6 @@ pytestmark = pytest.mark.skipif(
 )
 
 NOW = datetime(2026, 4, 17, 1, 2, 3, tzinfo=timezone.utc)
-
-
-class InMemoryStatusStore:
-    def __init__(self, status: Neo4jGraphStatus) -> None:
-        self.status = status
-
-    def read_current_status(self) -> Neo4jGraphStatus | None:
-        return self.status
-
-    def write_current_status(self, status: Neo4jGraphStatus) -> None:
-        self.status = status
-
-    def compare_and_write_current_status(
-        self,
-        *,
-        expected_status: Neo4jGraphStatus | None,
-        next_status: Neo4jGraphStatus,
-    ) -> bool:
-        if self.status != expected_status:
-            return False
-        self.write_current_status(next_status)
-        return True
 
 
 class StaticCanonicalReader:

--- a/tests/integration/test_status.py
+++ b/tests/integration/test_status.py
@@ -12,6 +12,7 @@ from graph_engine.models import GraphSnapshot, Neo4jGraphStatus
 from graph_engine.schema.manager import SchemaManager
 from graph_engine.snapshots import build_graph_snapshot
 from graph_engine.status import GraphStatusManager, check_live_graph_consistency
+from tests.fakes import InMemoryStatusStore
 
 pytestmark = pytest.mark.skipif(
     os.getenv("NEO4J_PASSWORD") is None,
@@ -19,28 +20,6 @@ pytestmark = pytest.mark.skipif(
 )
 
 NOW = datetime(2026, 4, 17, 1, 2, 3, tzinfo=timezone.utc)
-
-
-class InMemoryStatusStore:
-    def __init__(self, status: Neo4jGraphStatus) -> None:
-        self.status = status
-
-    def read_current_status(self) -> Neo4jGraphStatus | None:
-        return self.status
-
-    def write_current_status(self, status: Neo4jGraphStatus) -> None:
-        self.status = status
-
-    def compare_and_write_current_status(
-        self,
-        *,
-        expected_status: Neo4jGraphStatus | None,
-        next_status: Neo4jGraphStatus,
-    ) -> bool:
-        if self.status != expected_status:
-            return False
-        self.write_current_status(next_status)
-        return True
 
 
 class StaticSnapshotReader:

--- a/tests/integration/test_status.py
+++ b/tests/integration/test_status.py
@@ -97,7 +97,14 @@ CREATE (source)-[:SUPPLY_CHAIN {
                     "edge_id": edge_id,
                 },
             )
-            snapshot = build_graph_snapshot("cycle-status", 11, client)
+            snapshot = build_graph_snapshot(
+                "cycle-status",
+                11,
+                client,
+                status_manager=GraphStatusManager(
+                    InMemoryStatusStore(_status_for_generation(11)),
+                ),
+            )
             status_manager = GraphStatusManager(
                 InMemoryStatusStore(_status_from_snapshot(snapshot)),
                 clock=lambda: NOW,
@@ -143,6 +150,19 @@ def _status_from_snapshot(snapshot: GraphSnapshot) -> Neo4jGraphStatus:
         edge_count=snapshot.edge_count,
         key_label_counts=snapshot.key_label_counts,
         checksum=snapshot.checksum,
+        last_verified_at=NOW,
+        last_reload_at=None,
+    )
+
+
+def _status_for_generation(graph_generation_id: int) -> Neo4jGraphStatus:
+    return Neo4jGraphStatus(
+        graph_status="ready",
+        graph_generation_id=graph_generation_id,
+        node_count=0,
+        edge_count=0,
+        key_label_counts={},
+        checksum="pending",
         last_verified_at=NOW,
         last_reload_at=None,
     )

--- a/tests/unit/test_promotion.py
+++ b/tests/unit/test_promotion.py
@@ -14,6 +14,7 @@ from graph_engine.promotion import build_promotion_plan, promote_graph_deltas
 from graph_engine.promotion.planner import validate_entity_anchors
 from graph_engine.schema.definitions import NodeLabel, RelationshipType
 from graph_engine.status import GraphStatusManager
+from tests.fakes import InMemoryStatusStore
 
 NOW = datetime(2026, 4, 17, 1, 2, 3, tzinfo=timezone.utc)
 
@@ -53,30 +54,6 @@ class FakeCanonicalWriter:
         self.plans.append(plan)
         if self.fail:
             raise RuntimeError("canonical write failed")
-
-
-class InMemoryStatusStore:
-    def __init__(self, status: Neo4jGraphStatus | None = None) -> None:
-        self.status = status
-        self.compare_calls: list[tuple[Neo4jGraphStatus | None, Neo4jGraphStatus]] = []
-
-    def read_current_status(self) -> Neo4jGraphStatus | None:
-        return self.status
-
-    def write_current_status(self, status: Neo4jGraphStatus) -> None:
-        self.status = status
-
-    def compare_and_write_current_status(
-        self,
-        *,
-        expected_status: Neo4jGraphStatus | None,
-        next_status: Neo4jGraphStatus,
-    ) -> bool:
-        self.compare_calls.append((expected_status, next_status))
-        if self.status != expected_status:
-            return False
-        self.write_current_status(next_status)
-        return True
 
 
 class StaleBarrierStatusStore(InMemoryStatusStore):

--- a/tests/unit/test_propagation.py
+++ b/tests/unit/test_propagation.py
@@ -14,6 +14,7 @@ from graph_engine.propagation import (
     run_fundamental_propagation,
 )
 from graph_engine.status import GraphStatusManager
+from tests.fakes import InMemoryStatusStore
 
 NOW = datetime(2026, 4, 17, 1, 2, 3, tzinfo=timezone.utc)
 
@@ -131,28 +132,6 @@ class FakeGDSClient:
     ) -> list[dict[str, Any]]:
         self.write_calls.append((query, parameters or {}))
         return []
-
-
-class InMemoryStatusStore:
-    def __init__(self, status: Neo4jGraphStatus) -> None:
-        self.status = status
-
-    def read_current_status(self) -> Neo4jGraphStatus | None:
-        return self.status
-
-    def write_current_status(self, status: Neo4jGraphStatus) -> None:
-        self.status = status
-
-    def compare_and_write_current_status(
-        self,
-        *,
-        expected_status: Neo4jGraphStatus | None,
-        next_status: Neo4jGraphStatus,
-    ) -> bool:
-        if self.status != expected_status:
-            return False
-        self.write_current_status(next_status)
-        return True
 
 
 def test_compute_path_score_uses_documented_multiplication() -> None:
@@ -283,10 +262,25 @@ def test_run_fundamental_propagation_blocks_non_ready_before_neo4j_reads() -> No
     assert client.write_calls == []
 
 
+def test_run_fundamental_propagation_blocks_active_writer_lock_before_neo4j_reads() -> None:
+    client = FakeGDSClient()
+
+    with pytest.raises(PermissionError, match="writer lock"):
+        run_fundamental_propagation(
+            _context(),
+            client,  # type: ignore[arg-type]
+            status_manager=_status_manager(writer_lock_token="incremental-sync"),
+            graph_name="unit-fundamental",
+        )
+
+    assert client.read_calls == []
+    assert client.write_calls == []
+
+
 def test_run_fundamental_propagation_requires_status_manager_before_neo4j_reads() -> None:
     client = FakeGDSClient()
 
-    with pytest.raises(ValueError, match="status_manager"):
+    with pytest.raises(TypeError, match="status_manager"):
         run_fundamental_propagation(
             _context(),
             client,  # type: ignore[arg-type]
@@ -478,6 +472,7 @@ def _status_manager(
     *,
     graph_status: str = "ready",
     graph_generation_id: int = 1,
+    writer_lock_token: str | None = None,
 ) -> GraphStatusManager:
     return GraphStatusManager(
         InMemoryStatusStore(
@@ -490,6 +485,7 @@ def _status_manager(
                 checksum="abc123" if graph_status == "ready" else graph_status,
                 last_verified_at=NOW if graph_status == "ready" else None,
                 last_reload_at=None,
+                writer_lock_token=writer_lock_token,
             ),
         ),
     )

--- a/tests/unit/test_propagation.py
+++ b/tests/unit/test_propagation.py
@@ -13,6 +13,7 @@ from graph_engine.propagation import (
     compute_path_score,
     run_fundamental_propagation,
 )
+from graph_engine.status import GraphStatusManager
 
 NOW = datetime(2026, 4, 17, 1, 2, 3, tzinfo=timezone.utc)
 
@@ -132,6 +133,28 @@ class FakeGDSClient:
         return []
 
 
+class InMemoryStatusStore:
+    def __init__(self, status: Neo4jGraphStatus) -> None:
+        self.status = status
+
+    def read_current_status(self) -> Neo4jGraphStatus | None:
+        return self.status
+
+    def write_current_status(self, status: Neo4jGraphStatus) -> None:
+        self.status = status
+
+    def compare_and_write_current_status(
+        self,
+        *,
+        expected_status: Neo4jGraphStatus | None,
+        next_status: Neo4jGraphStatus,
+    ) -> bool:
+        if self.status != expected_status:
+            return False
+        self.write_current_status(next_status)
+        return True
+
+
 def test_compute_path_score_uses_documented_multiplication() -> None:
     assert compute_path_score(
         relation_weight=0.8,
@@ -197,6 +220,7 @@ def test_run_fundamental_propagation_uses_gds_projection_and_explains_paths() ->
     result = run_fundamental_propagation(
         context,
         client,  # type: ignore[arg-type]
+        status_manager=_status_manager(),
         graph_name="unit-fundamental",
         max_iterations=5,
         result_limit=10,
@@ -244,12 +268,49 @@ def test_run_fundamental_propagation_uses_gds_projection_and_explains_paths() ->
     assert result.channel_breakdown["fundamental"]["path_count"] == 2
 
 
+def test_run_fundamental_propagation_blocks_non_ready_before_neo4j_reads() -> None:
+    client = FakeGDSClient()
+
+    with pytest.raises(PermissionError, match="ready"):
+        run_fundamental_propagation(
+            _context(),
+            client,  # type: ignore[arg-type]
+            status_manager=_status_manager(graph_status="rebuilding"),
+            graph_name="unit-fundamental",
+        )
+
+    assert client.read_calls == []
+    assert client.write_calls == []
+
+
+def test_run_fundamental_propagation_requires_status_manager_before_neo4j_reads() -> None:
+    client = FakeGDSClient()
+
+    with pytest.raises(ValueError, match="status_manager"):
+        run_fundamental_propagation(
+            _context(),
+            client,  # type: ignore[arg-type]
+            graph_name="unit-fundamental",
+        )
+
+    assert client.read_calls == []
+    assert client.write_calls == []
+
+
 def test_run_fundamental_propagation_generates_unique_default_projection_names() -> None:
     first_client = FakeGDSClient()
     second_client = FakeGDSClient()
 
-    run_fundamental_propagation(_context(), first_client)  # type: ignore[arg-type]
-    run_fundamental_propagation(_context(), second_client)  # type: ignore[arg-type]
+    run_fundamental_propagation(  # type: ignore[arg-type]
+        _context(),
+        first_client,
+        status_manager=_status_manager(),
+    )
+    run_fundamental_propagation(  # type: ignore[arg-type]
+        _context(),
+        second_client,
+        status_manager=_status_manager(),
+    )
 
     first_project = next(
         params["graph_name"]
@@ -302,6 +363,7 @@ def test_impacted_entities_use_five_factor_path_scores() -> None:
     result = run_fundamental_propagation(
         _context(),
         client,  # type: ignore[arg-type]
+        status_manager=_status_manager(),
         graph_name="unit-fundamental",
     )
 
@@ -361,6 +423,7 @@ def test_activated_paths_limit_applies_after_five_factor_scoring() -> None:
     result = run_fundamental_propagation(
         _context(),
         client,  # type: ignore[arg-type]
+        status_manager=_status_manager(),
         graph_name="unit-fundamental",
         result_limit=2,
     )
@@ -389,6 +452,7 @@ def test_run_fundamental_propagation_cleans_up_projection_on_exception() -> None
         run_fundamental_propagation(
             _context(),
             client,  # type: ignore[arg-type]
+            status_manager=_status_manager(),
             graph_name="unit-fundamental",
         )
 
@@ -407,6 +471,27 @@ def _context() -> PropagationContext:
         regime_multipliers={"fundamental": 0.5},
         decay_policy={},
         regime_context={},
+    )
+
+
+def _status_manager(
+    *,
+    graph_status: str = "ready",
+    graph_generation_id: int = 1,
+) -> GraphStatusManager:
+    return GraphStatusManager(
+        InMemoryStatusStore(
+            Neo4jGraphStatus(
+                graph_status=graph_status,  # type: ignore[arg-type]
+                graph_generation_id=graph_generation_id,
+                node_count=2,
+                edge_count=1,
+                key_label_counts={"Entity": 2},
+                checksum="abc123" if graph_status == "ready" else graph_status,
+                last_verified_at=NOW if graph_status == "ready" else None,
+                last_reload_at=None,
+            ),
+        ),
     )
 
 

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -8,30 +8,9 @@ import pytest
 from graph_engine.models import Neo4jGraphStatus, ReadonlySimulationRequest
 from graph_engine.query import MAX_QUERY_DEPTH, query_subgraph, simulate_readonly_impact
 from graph_engine.status import GraphStatusManager
+from tests.fakes import InMemoryStatusStore
 
 NOW = datetime(2026, 4, 17, 1, 2, 3, tzinfo=timezone.utc)
-
-
-class InMemoryStatusStore:
-    def __init__(self, status: Neo4jGraphStatus) -> None:
-        self.status = status
-
-    def read_current_status(self) -> Neo4jGraphStatus | None:
-        return self.status
-
-    def write_current_status(self, status: Neo4jGraphStatus) -> None:
-        self.status = status
-
-    def compare_and_write_current_status(
-        self,
-        *,
-        expected_status: Neo4jGraphStatus | None,
-        next_status: Neo4jGraphStatus,
-    ) -> bool:
-        if self.status != expected_status:
-            return False
-        self.write_current_status(next_status)
-        return True
 
 
 class FakeQueryClient:
@@ -90,8 +69,22 @@ def test_query_subgraph_blocks_non_ready_before_neo4j_reads(
 def test_query_subgraph_requires_status_manager_before_neo4j_reads() -> None:
     client = FakeQueryClient()
 
-    with pytest.raises(ValueError, match="status_manager"):
+    with pytest.raises(TypeError, match="status_manager"):
         query_subgraph(["entity-a"], 1, client=client)  # type: ignore[arg-type]
+
+    assert client.read_calls == []
+
+
+def test_query_subgraph_blocks_active_writer_lock_before_neo4j_reads() -> None:
+    client = FakeQueryClient()
+
+    with pytest.raises(PermissionError, match="writer lock"):
+        query_subgraph(
+            ["entity-a"],
+            1,
+            client=client,  # type: ignore[arg-type]
+            status_manager=_status_manager(writer_lock_token="incremental-sync"),
+        )
 
     assert client.read_calls == []
 
@@ -146,6 +139,20 @@ def test_simulate_readonly_impact_blocks_non_ready_before_neo4j_reads(
     assert client.read_calls == []
 
 
+def test_simulate_readonly_impact_blocks_active_writer_lock_before_neo4j_reads() -> None:
+    client = FakeQueryClient()
+
+    with pytest.raises(PermissionError, match="writer lock"):
+        simulate_readonly_impact(
+            ["entity-a"],
+            _simulation_request(),
+            client=client,  # type: ignore[arg-type]
+            status_manager=_status_manager(writer_lock_token="incremental-sync"),
+        )
+
+    assert client.read_calls == []
+
+
 def test_simulate_readonly_impact_reads_after_ready_gate() -> None:
     client = FakeQueryClient()
 
@@ -174,6 +181,7 @@ def _status_manager(
     *,
     graph_status: Literal["ready", "rebuilding", "failed"] = "ready",
     graph_generation_id: int = 1,
+    writer_lock_token: str | None = None,
 ) -> GraphStatusManager:
     return GraphStatusManager(
         InMemoryStatusStore(
@@ -186,6 +194,7 @@ def _status_manager(
                 checksum="abc123" if graph_status == "ready" else graph_status,
                 last_verified_at=NOW if graph_status == "ready" else None,
                 last_reload_at=None,
+                writer_lock_token=writer_lock_token,
             )
         )
     )

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Literal
+
+import pytest
+
+from graph_engine.models import Neo4jGraphStatus, ReadonlySimulationRequest
+from graph_engine.query import MAX_QUERY_DEPTH, query_subgraph, simulate_readonly_impact
+from graph_engine.status import GraphStatusManager
+
+NOW = datetime(2026, 4, 17, 1, 2, 3, tzinfo=timezone.utc)
+
+
+class InMemoryStatusStore:
+    def __init__(self, status: Neo4jGraphStatus) -> None:
+        self.status = status
+
+    def read_current_status(self) -> Neo4jGraphStatus | None:
+        return self.status
+
+    def write_current_status(self, status: Neo4jGraphStatus) -> None:
+        self.status = status
+
+    def compare_and_write_current_status(
+        self,
+        *,
+        expected_status: Neo4jGraphStatus | None,
+        next_status: Neo4jGraphStatus,
+    ) -> bool:
+        if self.status != expected_status:
+            return False
+        self.write_current_status(next_status)
+        return True
+
+
+class FakeQueryClient:
+    def __init__(self) -> None:
+        self.read_calls: list[tuple[str, dict[str, Any]]] = []
+
+    def execute_read(
+        self,
+        query: str,
+        parameters: dict[str, Any] | None = None,
+    ) -> list[dict[str, Any]]:
+        self.read_calls.append((query, parameters or {}))
+        return [
+            {
+                "nodes": [
+                    {
+                        "node_id": "node-a",
+                        "canonical_entity_id": "entity-a",
+                        "labels": ["Entity"],
+                    },
+                    {
+                        "node_id": "node-b",
+                        "canonical_entity_id": "entity-b",
+                        "labels": ["Entity"],
+                    },
+                ],
+                "relationships": [
+                    {
+                        "edge_id": "edge-1",
+                        "relationship_type": "SUPPLY_CHAIN",
+                        "source_node_id": "node-a",
+                        "target_node_id": "node-b",
+                    }
+                ],
+            }
+        ]
+
+
+@pytest.mark.parametrize("graph_status", ["rebuilding", "failed"])
+def test_query_subgraph_blocks_non_ready_before_neo4j_reads(
+    graph_status: Literal["rebuilding", "failed"],
+) -> None:
+    client = FakeQueryClient()
+
+    with pytest.raises(PermissionError, match="ready"):
+        query_subgraph(
+            ["entity-a"],
+            1,
+            client=client,  # type: ignore[arg-type]
+            status_manager=_status_manager(graph_status=graph_status),
+        )
+
+    assert client.read_calls == []
+
+
+def test_query_subgraph_requires_status_manager_before_neo4j_reads() -> None:
+    client = FakeQueryClient()
+
+    with pytest.raises(ValueError, match="status_manager"):
+        query_subgraph(["entity-a"], 1, client=client)  # type: ignore[arg-type]
+
+    assert client.read_calls == []
+
+
+def test_query_subgraph_rejects_depth_above_supported_bound_before_reading() -> None:
+    client = FakeQueryClient()
+
+    with pytest.raises(ValueError, match="depth"):
+        query_subgraph(
+            ["entity-a"],
+            MAX_QUERY_DEPTH + 1,
+            client=client,  # type: ignore[arg-type]
+            status_manager=_status_manager(),
+        )
+
+    assert client.read_calls == []
+
+
+def test_query_subgraph_reads_after_ready_gate() -> None:
+    client = FakeQueryClient()
+
+    result = query_subgraph(
+        ["entity-a"],
+        2,
+        client=client,  # type: ignore[arg-type]
+        status_manager=_status_manager(),
+    )
+
+    assert result["seed_entities"] == ["entity-a"]
+    assert result["depth"] == 2
+    assert [node["node_id"] for node in result["nodes"]] == ["node-a", "node-b"]
+    assert len(result["relationships"]) == 1
+    assert len(client.read_calls) == 1
+    assert "*0..2" in client.read_calls[0][0]
+    assert client.read_calls[0][1] == {"seed_entities": ["entity-a"]}
+
+
+@pytest.mark.parametrize("graph_status", ["rebuilding", "failed"])
+def test_simulate_readonly_impact_blocks_non_ready_before_neo4j_reads(
+    graph_status: Literal["rebuilding", "failed"],
+) -> None:
+    client = FakeQueryClient()
+
+    with pytest.raises(PermissionError, match="ready"):
+        simulate_readonly_impact(
+            ["entity-a"],
+            _simulation_request(),
+            client=client,  # type: ignore[arg-type]
+            status_manager=_status_manager(graph_status=graph_status),
+        )
+
+    assert client.read_calls == []
+
+
+def test_simulate_readonly_impact_reads_after_ready_gate() -> None:
+    client = FakeQueryClient()
+
+    result = simulate_readonly_impact(
+        ["entity-a"],
+        _simulation_request(depth=1, result_limit=1),
+        client=client,  # type: ignore[arg-type]
+        status_manager=_status_manager(),
+    )
+
+    assert result["graph_generation_id"] == 1
+    assert result["subgraph"]["depth"] == 1
+    assert result["impacted_entities"] == [
+        {
+            "node_id": "node-a",
+            "canonical_entity_id": "entity-a",
+            "labels": ["Entity"],
+            "score": 1.0,
+            "is_seed": True,
+        }
+    ]
+    assert len(client.read_calls) == 1
+
+
+def _status_manager(
+    *,
+    graph_status: Literal["ready", "rebuilding", "failed"] = "ready",
+    graph_generation_id: int = 1,
+) -> GraphStatusManager:
+    return GraphStatusManager(
+        InMemoryStatusStore(
+            Neo4jGraphStatus(
+                graph_status=graph_status,
+                graph_generation_id=graph_generation_id,
+                node_count=2,
+                edge_count=1,
+                key_label_counts={"Entity": 2},
+                checksum="abc123" if graph_status == "ready" else graph_status,
+                last_verified_at=NOW if graph_status == "ready" else None,
+                last_reload_at=None,
+            )
+        )
+    )
+
+
+def _simulation_request(
+    *,
+    depth: int = 1,
+    result_limit: int = 100,
+) -> ReadonlySimulationRequest:
+    return ReadonlySimulationRequest(
+        cycle_id="cycle-1",
+        world_state_ref="world-state-1",
+        graph_generation_id=1,
+        depth=depth,
+        result_limit=result_limit,
+    )

--- a/tests/unit/test_reload.py
+++ b/tests/unit/test_reload.py
@@ -21,32 +21,9 @@ from graph_engine.reload.projection import rebuild_gds_projection
 from graph_engine.schema.definitions import NodeLabel, RelationshipType
 from graph_engine.schema.manager import DROP_ALL_CONFIRMATION_TOKEN
 from graph_engine.status import GraphStatusManager
+from tests.fakes import InMemoryStatusStore
 
 NOW = datetime(2026, 4, 17, 1, 2, 3, tzinfo=timezone.utc)
-
-
-class InMemoryStatusStore:
-    def __init__(self, status: Neo4jGraphStatus | None = None) -> None:
-        self.status = status
-        self.writes: list[Neo4jGraphStatus] = []
-
-    def read_current_status(self) -> Neo4jGraphStatus | None:
-        return self.status
-
-    def write_current_status(self, status: Neo4jGraphStatus) -> None:
-        self.status = status
-        self.writes.append(status)
-
-    def compare_and_write_current_status(
-        self,
-        *,
-        expected_status: Neo4jGraphStatus | None,
-        next_status: Neo4jGraphStatus,
-    ) -> bool:
-        if self.status != expected_status:
-            return False
-        self.write_current_status(next_status)
-        return True
 
 
 class RecordingStatusManager(GraphStatusManager):

--- a/tests/unit/test_snapshots.py
+++ b/tests/unit/test_snapshots.py
@@ -19,6 +19,7 @@ from graph_engine.snapshots import (
     build_graph_snapshot,
     compute_graph_snapshots,
 )
+from graph_engine.status import GraphStatusManager
 
 NOW = datetime(2026, 4, 17, 1, 2, 3, tzinfo=timezone.utc)
 
@@ -93,7 +94,7 @@ class RaisingSnapshotWriter:
         raise RuntimeError("writer failed")
 
 
-class StaticStatusReader:
+class SequentialStatusStore:
     def __init__(
         self,
         graph_status: Neo4jGraphStatus | list[Neo4jGraphStatus],
@@ -104,10 +105,24 @@ class StaticStatusReader:
             self.graph_statuses = [graph_status]
         self.calls = 0
 
-    def read_graph_status(self) -> Neo4jGraphStatus:
+    def read_current_status(self) -> Neo4jGraphStatus:
         self.calls += 1
         index = min(self.calls - 1, len(self.graph_statuses) - 1)
         return self.graph_statuses[index]
+
+    def write_current_status(self, status: Neo4jGraphStatus) -> None:
+        self.graph_statuses = [status]
+
+    def compare_and_write_current_status(
+        self,
+        *,
+        expected_status: Neo4jGraphStatus | None,
+        next_status: Neo4jGraphStatus,
+    ) -> bool:
+        if self.graph_statuses[-1] != expected_status:
+            return False
+        self.write_current_status(next_status)
+        return True
 
 
 def test_build_graph_snapshot_reads_metrics_and_stable_checksum() -> None:
@@ -136,9 +151,20 @@ def test_build_graph_snapshot_reads_metrics_and_stable_checksum() -> None:
             }
         ],
     )
+    status_manager, _ = _status_manager(_ready_status(graph_generation_id=3))
 
-    first = build_graph_snapshot("cycle-1", 3, client)  # type: ignore[arg-type]
-    second = build_graph_snapshot("cycle-1", 3, client)  # type: ignore[arg-type]
+    first = build_graph_snapshot(  # type: ignore[arg-type]
+        "cycle-1",
+        3,
+        client,
+        status_manager=status_manager,
+    )
+    second = build_graph_snapshot(  # type: ignore[arg-type]
+        "cycle-1",
+        3,
+        client,
+        status_manager=status_manager,
+    )
 
     assert first.node_count == 2
     assert first.edge_count == 1
@@ -151,9 +177,29 @@ def test_build_graph_snapshot_reads_metrics_and_stable_checksum() -> None:
         **client.relationships[0],
         "properties": {"weight": 0.9},
     }
-    changed = build_graph_snapshot("cycle-1", 3, client)  # type: ignore[arg-type]
+    changed = build_graph_snapshot(  # type: ignore[arg-type]
+        "cycle-1",
+        3,
+        client,
+        status_manager=status_manager,
+    )
     assert changed.checksum != first.checksum
     assert len(client.read_calls) == 3
+
+
+def test_build_graph_snapshot_blocks_non_ready_before_reading() -> None:
+    client = MagicMock()
+    status_manager, _ = _status_manager(_ready_status(graph_status="failed"))
+
+    with pytest.raises(PermissionError, match="ready"):
+        build_graph_snapshot(
+            "cycle-1",
+            1,
+            client,
+            status_manager=status_manager,
+        )
+
+    client.execute_read.assert_not_called()
 
 
 def test_build_graph_impact_snapshot_preserves_propagation_payload() -> None:
@@ -176,7 +222,7 @@ def test_compute_graph_snapshots_requires_status_source_without_side_effects() -
     reader = StaticRegimeReader()
     writer = RecordingSnapshotWriter()
 
-    with pytest.raises(ValueError, match="graph_status or status_reader"):
+    with pytest.raises(ValueError, match="status_manager"):
         compute_graph_snapshots(
             "cycle-1",
             "world-state-1",
@@ -196,6 +242,15 @@ def test_compute_graph_snapshots_rejects_non_ready_status_without_side_effects()
     client = MagicMock()
     reader = StaticRegimeReader()
     writer = RecordingSnapshotWriter()
+    status_manager, _ = _status_manager(
+        _ready_status(
+            graph_status="failed",
+            node_count=0,
+            edge_count=0,
+            key_label_counts={},
+            checksum="failed",
+        ),
+    )
 
     with pytest.raises(PermissionError, match="ready"):
         compute_graph_snapshots(
@@ -205,13 +260,7 @@ def test_compute_graph_snapshots_rejects_non_ready_status_without_side_effects()
             graph_generation_id=1,
             regime_reader=reader,
             snapshot_writer=writer,
-            graph_status=_ready_status(
-                graph_status="failed",
-                node_count=0,
-                edge_count=0,
-                key_label_counts={},
-                checksum="failed",
-            ),
+            status_manager=status_manager,
         )
 
     assert reader.calls == []
@@ -220,11 +269,11 @@ def test_compute_graph_snapshots_rejects_non_ready_status_without_side_effects()
     client.execute_write.assert_not_called()
 
 
-def test_compute_graph_snapshots_uses_status_reader_and_derives_generation(
+def test_compute_graph_snapshots_uses_status_manager_and_derives_generation(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     events: list[str] = []
-    status_reader = StaticStatusReader(_ready_status(graph_generation_id=7))
+    status_manager, status_store = _status_manager(_ready_status(graph_generation_id=7))
     writer = RecordingSnapshotWriter(events)
 
     _patch_metrics(monkeypatch, events)
@@ -255,10 +304,10 @@ def test_compute_graph_snapshots_uses_status_reader_and_derives_generation(
         client=MagicMock(),
         regime_reader=StaticRegimeReader(),
         snapshot_writer=writer,
-        status_reader=status_reader,
+        status_manager=status_manager,
     )
 
-    assert status_reader.calls == 2
+    assert status_store.calls == 2
     assert graph_snapshot.graph_generation_id == 7
     assert graph_snapshot.node_count == 2
     assert graph_snapshot.edge_count == 1
@@ -290,6 +339,7 @@ def test_compute_graph_snapshots_rejects_status_disagreements_before_propagation
     reader = StaticRegimeReader()
     writer = RecordingSnapshotWriter()
     graph_status = _ready_status(**status_updates)
+    status_manager, _ = _status_manager(graph_status)
 
     _patch_metrics(monkeypatch, events)
 
@@ -307,35 +357,10 @@ def test_compute_graph_snapshots_rejects_status_disagreements_before_propagation
             graph_generation_id=graph_generation_id,
             regime_reader=reader,
             snapshot_writer=writer,
-            status_reader=StaticStatusReader(graph_status),
+            status_manager=status_manager,
         )
 
     assert events == expected_events
-    assert reader.calls == []
-    assert writer.calls == []
-
-
-def test_compute_graph_snapshots_rejects_direct_ready_status_without_reader(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    events: list[str] = []
-    reader = StaticRegimeReader()
-    writer = RecordingSnapshotWriter()
-
-    _patch_metrics(monkeypatch, events)
-
-    with pytest.raises(ValueError, match="status_reader"):
-        compute_graph_snapshots(
-            "cycle-1",
-            "world-state-1",
-            client=MagicMock(),
-            graph_generation_id=1,
-            regime_reader=reader,
-            snapshot_writer=writer,
-            graph_status=_ready_status(),
-        )
-
-    assert events == []
     assert reader.calls == []
     assert writer.calls == []
 
@@ -363,6 +388,7 @@ def test_compute_graph_snapshots_writes_once_after_both_snapshots(
         lambda *args, **kwargs: events.append("impact") or impact_snapshot,
     )
     writer = RecordingSnapshotWriter(events)
+    status_manager, _ = _status_manager(_ready_status())
 
     result = compute_graph_snapshots(
         "cycle-1",
@@ -371,7 +397,7 @@ def test_compute_graph_snapshots_writes_once_after_both_snapshots(
         graph_generation_id=1,
         regime_reader=StaticRegimeReader(),
         snapshot_writer=writer,
-        status_reader=StaticStatusReader(_ready_status()),
+        status_manager=status_manager,
     )
 
     graph_snapshot = result[0]
@@ -389,7 +415,7 @@ def test_compute_graph_snapshots_rechecks_status_before_write(
     events: list[str] = []
     ready_status = _ready_status()
     rebuilding_status = _ready_status(graph_status="rebuilding")
-    status_reader = StaticStatusReader([ready_status, rebuilding_status])
+    status_manager, status_store = _status_manager([ready_status, rebuilding_status])
     writer = RecordingSnapshotWriter(events)
 
     _patch_metrics(monkeypatch, events)
@@ -417,10 +443,10 @@ def test_compute_graph_snapshots_rechecks_status_before_write(
             graph_generation_id=1,
             regime_reader=StaticRegimeReader(),
             snapshot_writer=writer,
-            status_reader=status_reader,
+            status_manager=status_manager,
         )
 
-    assert status_reader.calls == 2
+    assert status_store.calls == 2
     assert events == ["metrics", "context", "propagation", "impact"]
     assert writer.calls == []
 
@@ -454,6 +480,7 @@ def test_compute_graph_snapshots_rechecks_live_metrics_before_write(
         "build_graph_impact_snapshot",
         lambda *args, **kwargs: events.append("impact") or _impact_snapshot(),
     )
+    status_manager, _ = _status_manager(_ready_status())
 
     with pytest.raises(ValueError, match="live graph metrics disagree"):
         compute_graph_snapshots(
@@ -463,7 +490,7 @@ def test_compute_graph_snapshots_rechecks_live_metrics_before_write(
             graph_generation_id=1,
             regime_reader=StaticRegimeReader(),
             snapshot_writer=writer,
-            status_reader=StaticStatusReader(_ready_status()),
+            status_manager=status_manager,
         )
 
     assert events == ["metrics", "context", "propagation", "impact", "metrics"]
@@ -495,6 +522,7 @@ def test_compute_graph_snapshots_does_not_write_if_snapshot_build_fails(
         "build_graph_impact_snapshot",
         raise_impact_error,
     )
+    status_manager, _ = _status_manager(_ready_status())
 
     with pytest.raises(ValueError, match="impact failed"):
         compute_graph_snapshots(
@@ -504,7 +532,7 @@ def test_compute_graph_snapshots_does_not_write_if_snapshot_build_fails(
             graph_generation_id=1,
             regime_reader=StaticRegimeReader(),
             snapshot_writer=writer,
-            status_reader=StaticStatusReader(_ready_status()),
+            status_manager=status_manager,
         )
 
     assert writer.calls == []
@@ -529,6 +557,7 @@ def test_compute_graph_snapshots_surfaces_writer_errors(
         "build_graph_impact_snapshot",
         lambda *args, **kwargs: _impact_snapshot(),
     )
+    status_manager, _ = _status_manager(_ready_status())
 
     with pytest.raises(RuntimeError, match="writer failed"):
         compute_graph_snapshots(
@@ -538,7 +567,7 @@ def test_compute_graph_snapshots_surfaces_writer_errors(
             graph_generation_id=1,
             regime_reader=StaticRegimeReader(),
             snapshot_writer=RaisingSnapshotWriter(),
-            status_reader=StaticStatusReader(_ready_status()),
+            status_manager=status_manager,
         )
 
 
@@ -559,6 +588,13 @@ def _patch_metrics(
         return metrics[index]
 
     monkeypatch.setattr(snapshot_generator, "_read_graph_metrics", read_metrics)
+
+
+def _status_manager(
+    graph_status: Neo4jGraphStatus | list[Neo4jGraphStatus],
+) -> tuple[GraphStatusManager, SequentialStatusStore]:
+    store = SequentialStatusStore(graph_status)
+    return GraphStatusManager(store), store
 
 
 def _ready_status(

--- a/tests/unit/test_snapshots.py
+++ b/tests/unit/test_snapshots.py
@@ -202,6 +202,23 @@ def test_build_graph_snapshot_blocks_non_ready_before_reading() -> None:
     client.execute_read.assert_not_called()
 
 
+def test_build_graph_snapshot_blocks_active_writer_lock_before_reading() -> None:
+    client = MagicMock()
+    status_manager, _ = _status_manager(
+        _ready_status(writer_lock_token="incremental-sync"),
+    )
+
+    with pytest.raises(PermissionError, match="writer lock"):
+        build_graph_snapshot(
+            "cycle-1",
+            1,
+            client,
+            status_manager=status_manager,
+        )
+
+    client.execute_read.assert_not_called()
+
+
 def test_build_graph_impact_snapshot_preserves_propagation_payload() -> None:
     propagation_result = _propagation_result()
 
@@ -222,7 +239,7 @@ def test_compute_graph_snapshots_requires_status_source_without_side_effects() -
     reader = StaticRegimeReader()
     writer = RecordingSnapshotWriter()
 
-    with pytest.raises(ValueError, match="status_manager"):
+    with pytest.raises(TypeError, match="status_manager"):
         compute_graph_snapshots(
             "cycle-1",
             "world-state-1",
@@ -253,6 +270,31 @@ def test_compute_graph_snapshots_rejects_non_ready_status_without_side_effects()
     )
 
     with pytest.raises(PermissionError, match="ready"):
+        compute_graph_snapshots(
+            "cycle-1",
+            "world-state-1",
+            client=client,
+            graph_generation_id=1,
+            regime_reader=reader,
+            snapshot_writer=writer,
+            status_manager=status_manager,
+        )
+
+    assert reader.calls == []
+    assert writer.calls == []
+    client.execute_read.assert_not_called()
+    client.execute_write.assert_not_called()
+
+
+def test_compute_graph_snapshots_rejects_active_writer_lock_without_side_effects() -> None:
+    client = MagicMock()
+    reader = StaticRegimeReader()
+    writer = RecordingSnapshotWriter()
+    status_manager, _ = _status_manager(
+        _ready_status(writer_lock_token="incremental-sync"),
+    )
+
+    with pytest.raises(PermissionError, match="writer lock"):
         compute_graph_snapshots(
             "cycle-1",
             "world-state-1",
@@ -605,6 +647,7 @@ def _ready_status(
     edge_count: int = 1,
     key_label_counts: dict[str, int] | None = None,
     checksum: str = "abc123",
+    writer_lock_token: str | None = None,
 ) -> Neo4jGraphStatus:
     return Neo4jGraphStatus(
         graph_status=graph_status,
@@ -615,6 +658,7 @@ def _ready_status(
         checksum=checksum,
         last_verified_at=NOW,
         last_reload_at=None,
+        writer_lock_token=writer_lock_token,
     )
 
 

--- a/tests/unit/test_status.py
+++ b/tests/unit/test_status.py
@@ -14,33 +14,10 @@ from graph_engine.status import (
     require_ready_status,
 )
 from graph_engine.status.consistency import _read_live_graph_metrics
+from tests.fakes import InMemoryStatusStore
 
 NOW = datetime(2026, 4, 17, 1, 2, 3, tzinfo=timezone.utc)
 SNAPSHOT_CREATED_AT = datetime(2026, 4, 17, 1, 0, 0, tzinfo=timezone.utc)
-
-
-class InMemoryStatusStore:
-    def __init__(self, status: Neo4jGraphStatus | None = None) -> None:
-        self.status = status
-        self.writes: list[Neo4jGraphStatus] = []
-
-    def read_current_status(self) -> Neo4jGraphStatus | None:
-        return self.status
-
-    def write_current_status(self, status: Neo4jGraphStatus) -> None:
-        self.status = status
-        self.writes.append(status)
-
-    def compare_and_write_current_status(
-        self,
-        *,
-        expected_status: Neo4jGraphStatus | None,
-        next_status: Neo4jGraphStatus,
-    ) -> bool:
-        if self.status != expected_status:
-            return False
-        self.write_current_status(next_status)
-        return True
 
 
 class InterleavingStatusStore(InMemoryStatusStore):
@@ -392,6 +369,15 @@ def test_require_ready_returns_ready_status() -> None:
 
     assert require_ready_status(ready_status) is ready_status
     assert GraphStatusManager(InMemoryStatusStore(ready_status)).require_ready() is ready_status
+
+
+def test_require_ready_rejects_active_writer_lock() -> None:
+    status = _status(graph_status="ready", writer_lock_token="incremental-sync")
+
+    with pytest.raises(PermissionError, match="writer lock"):
+        require_ready_status(status)
+    with pytest.raises(PermissionError, match="writer lock"):
+        GraphStatusManager(InMemoryStatusStore(status)).require_ready()
 
 
 @pytest.mark.parametrize("graph_status", ["rebuilding", "failed"])


### PR DESCRIPTION
Closes #30

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `benchmarks/artifacts/lite_target_100k_800k.json`, `benchmarks/generate_synthetic.py`, `benchmarks/run_benchmark.py`, `cross-cutting`, `graph_engine/__pycache__/__init__.cpython-314.pyc`, `graph_engine/live_metrics.py`, `graph_engine/query/__init__.py`, `graph_engine/reload/service.py`, `graph_engine/snapshots/generator.py`, `graph_engine/status/consistency.py`


---
## 背景与目标
Milestone review for milestone-2 发现阻塞性问题，必须在进入下一阶段前修复。

## 问题描述
The new ready gate is wired into consistency checks and promotion sync, but the milestone does not make it the common gate for all Neo4j reads. Snapshot generation still reads live metrics directly, and the combined diff does not show query, readonly simulation, or propagation read APIs being moved behind GraphStatusManager. This violates issue #6's goal that neo4j_graph_status be the shared gate for all Neo4j reads.

## 实现范围
- 修改文件: `cross-cutting`
- Introduce a status-gated read boundary or require GraphStatusManager on every public Neo4j read API, then add tests that non-ready states block snapshot, query, readonly simulation, and propagation reads.

## 验收标准
- [ ] 原始 P0 问题已修复
- [ ] 新增回归测试覆盖该场景
- [ ] 构建通过

## 验证命令
```bash
/Users/fanjie/Desktop/Cowork/project-ult/graph-engine/.venv/bin/python -m pytest
```
