### PR TITLE
feat(#34): [follow-up from PR #31] StatusStore TOCTOU at persistence boundary

### DIFF
--- a/graph_engine/__init__.py
+++ b/graph_engine/__init__.py
@@ -37,6 +37,7 @@ from graph_engine.status import (
     PostgresStatusStore,
     StatusStore,
     check_live_graph_consistency,
+    ready_read,
     require_ready_read,
     require_ready_status,
 )
@@ -75,6 +76,7 @@ __all__ = [
     "get_index_statements",
     "load_config_from_env",
     "query_subgraph",
+    "ready_read",
     "rebuild_gds_projection",
     "require_ready_read",
     "require_ready_status",

--- a/graph_engine/propagation/fundamental.py
+++ b/graph_engine/propagation/fundamental.py
@@ -10,7 +10,7 @@ from graph_engine.client import Neo4jClient
 from graph_engine.models import PropagationContext, PropagationResult
 from graph_engine.propagation.scoring import build_score_explanation
 from graph_engine.schema.definitions import RelationshipType
-from graph_engine.status import GraphStatusManager, require_ready_read
+from graph_engine.status import GraphStatusManager, ready_read
 
 FUNDAMENTAL_RELATIONSHIP_TYPES = (
     RelationshipType.SUPPLY_CHAIN.value,
@@ -39,57 +39,57 @@ def run_fundamental_propagation(
     if result_limit < 1:
         raise ValueError("result_limit must be greater than zero")
 
-    ready_status = require_ready_read(status_manager, "fundamental propagation")
-    if ready_status.graph_generation_id != context.graph_generation_id:
-        raise ValueError(
-            "PropagationContext graph_generation_id disagrees with Neo4jGraphStatus: "
-            f"context={context.graph_generation_id}, "
-            f"status={ready_status.graph_generation_id}",
-        )
+    with ready_read(status_manager, "fundamental propagation") as ready_status:
+        if ready_status.graph_generation_id != context.graph_generation_id:
+            raise ValueError(
+                "PropagationContext graph_generation_id disagrees with Neo4jGraphStatus: "
+                f"context={context.graph_generation_id}, "
+                f"status={ready_status.graph_generation_id}",
+            )
 
-    projection_name = graph_name or _default_projection_name(context)
-    _drop_projection_if_exists(client, projection_name)
-    try:
-        _create_projection(client, projection_name)
-        pagerank_entities = _stream_pagerank(
-            client,
-            projection_name,
-            max_iterations=max_iterations,
-            result_limit=result_limit,
-        )
-        activated_paths = _read_activated_paths(
-            context,
-            client,
-            result_limit=result_limit,
-        )
-    finally:
+        projection_name = graph_name or _default_projection_name(context)
         _drop_projection_if_exists(client, projection_name)
+        try:
+            _create_projection(client, projection_name)
+            pagerank_entities = _stream_pagerank(
+                client,
+                projection_name,
+                max_iterations=max_iterations,
+                result_limit=result_limit,
+            )
+            activated_paths = _read_activated_paths(
+                context,
+                client,
+                result_limit=result_limit,
+            )
+        finally:
+            _drop_projection_if_exists(client, projection_name)
 
-    # Keep PageRank as the GDS topology pass, but rank persisted impacts by the
-    # documented five-factor path scores so the snapshot outputs stay coherent.
-    impacted_entities = _impacted_entities_from_paths(
-        activated_paths,
-        pagerank_entities,
-        result_limit=result_limit,
-    )
+        # Keep PageRank as the GDS topology pass, but rank persisted impacts by the
+        # documented five-factor path scores so the snapshot outputs stay coherent.
+        impacted_entities = _impacted_entities_from_paths(
+            activated_paths,
+            pagerank_entities,
+            result_limit=result_limit,
+        )
 
-    channel_breakdown: dict[str, Any] = {
-        _FUNDAMENTAL_CHANNEL: {
-            "relationship_types": list(FUNDAMENTAL_RELATIONSHIP_TYPES),
-            "path_count": len(activated_paths),
-            "impacted_entity_count": len(impacted_entities),
-            "total_path_score": sum(float(path["score"]) for path in activated_paths),
-            "channel_multiplier": _context_multiplier(context.channel_multipliers),
-            "regime_multiplier": _context_multiplier(context.regime_multipliers),
-        },
-    }
-    return PropagationResult(
-        cycle_id=context.cycle_id,
-        graph_generation_id=context.graph_generation_id,
-        activated_paths=activated_paths,
-        impacted_entities=impacted_entities,
-        channel_breakdown=channel_breakdown,
-    )
+        channel_breakdown: dict[str, Any] = {
+            _FUNDAMENTAL_CHANNEL: {
+                "relationship_types": list(FUNDAMENTAL_RELATIONSHIP_TYPES),
+                "path_count": len(activated_paths),
+                "impacted_entity_count": len(impacted_entities),
+                "total_path_score": sum(float(path["score"]) for path in activated_paths),
+                "channel_multiplier": _context_multiplier(context.channel_multipliers),
+                "regime_multiplier": _context_multiplier(context.regime_multipliers),
+            },
+        }
+        return PropagationResult(
+            cycle_id=context.cycle_id,
+            graph_generation_id=context.graph_generation_id,
+            activated_paths=activated_paths,
+            impacted_entities=impacted_entities,
+            channel_breakdown=channel_breakdown,
+        )
 
 
 def _drop_projection_if_exists(client: Neo4jClient, graph_name: str) -> None:

--- a/graph_engine/query/__init__.py
+++ b/graph_engine/query/__init__.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from graph_engine.client import Neo4jClient
 from graph_engine.models import ReadonlySimulationRequest
-from graph_engine.status import GraphStatusManager, require_ready_read
+from graph_engine.status import GraphStatusManager, ready_read
 
 MAX_QUERY_DEPTH = 10
 
@@ -20,8 +20,8 @@ def query_subgraph(
 ) -> dict[str, Any]:
     """Return a bounded live subgraph after verifying the graph is ready."""
 
-    require_ready_read(status_manager, "subgraph query")
-    return _query_subgraph_after_ready(seed_entities, depth, client=client)
+    with ready_read(status_manager, "subgraph query"):
+        return _query_subgraph_after_ready(seed_entities, depth, client=client)
 
 
 def simulate_readonly_impact(
@@ -33,36 +33,36 @@ def simulate_readonly_impact(
 ) -> dict[str, Any]:
     """Run a read-only local impact simulation without modifying live graph state."""
 
-    ready_status = require_ready_read(status_manager, "readonly impact simulation")
-    if ready_status.graph_generation_id != context.graph_generation_id:
-        raise ValueError(
-            "ReadonlySimulationRequest graph_generation_id disagrees with Neo4jGraphStatus: "
-            f"context={context.graph_generation_id}, "
-            f"status={ready_status.graph_generation_id}",
-        )
+    with ready_read(status_manager, "readonly impact simulation") as ready_status:
+        if ready_status.graph_generation_id != context.graph_generation_id:
+            raise ValueError(
+                "ReadonlySimulationRequest graph_generation_id disagrees with Neo4jGraphStatus: "
+                f"context={context.graph_generation_id}, "
+                f"status={ready_status.graph_generation_id}",
+            )
 
-    subgraph = _query_subgraph_after_ready(seed_entities, context.depth, client=client)
-    impacted_entities = _impacted_entities_from_subgraph(
-        subgraph,
-        set(seed_entities),
-        result_limit=context.result_limit,
-    )
-    return {
-        "cycle_id": context.cycle_id,
-        "world_state_ref": context.world_state_ref,
-        "graph_generation_id": ready_status.graph_generation_id,
-        "seed_entities": list(seed_entities),
-        "subgraph": subgraph,
-        "impacted_entities": impacted_entities,
-        "activated_paths": list(subgraph["relationships"]),
-        "channel_breakdown": {
-            "readonly": {
-                "depth": subgraph["depth"],
-                "node_count": len(subgraph["nodes"]),
-                "edge_count": len(subgraph["relationships"]),
+        subgraph = _query_subgraph_after_ready(seed_entities, context.depth, client=client)
+        impacted_entities = _impacted_entities_from_subgraph(
+            subgraph,
+            set(seed_entities),
+            result_limit=context.result_limit,
+        )
+        return {
+            "cycle_id": context.cycle_id,
+            "world_state_ref": context.world_state_ref,
+            "graph_generation_id": ready_status.graph_generation_id,
+            "seed_entities": list(seed_entities),
+            "subgraph": subgraph,
+            "impacted_entities": impacted_entities,
+            "activated_paths": list(subgraph["relationships"]),
+            "channel_breakdown": {
+                "readonly": {
+                    "depth": subgraph["depth"],
+                    "node_count": len(subgraph["nodes"]),
+                    "edge_count": len(subgraph["relationships"]),
+                },
             },
-        },
-    }
+        }
 
 
 def _query_subgraph_after_ready(

--- a/graph_engine/snapshots/generator.py
+++ b/graph_engine/snapshots/generator.py
@@ -18,7 +18,7 @@ from graph_engine.models import (
 from graph_engine.propagation.context import RegimeContextReader, build_propagation_context
 from graph_engine.propagation.fundamental import run_fundamental_propagation
 from graph_engine.snapshots.writer import SnapshotWriter
-from graph_engine.status import GraphStatusManager, require_ready_read
+from graph_engine.status import GraphStatusManager, ready_read
 
 
 def build_graph_snapshot(
@@ -30,17 +30,17 @@ def build_graph_snapshot(
 ) -> GraphSnapshot:
     """Read live graph metrics and return a deterministic structural snapshot."""
 
-    ready_status = require_ready_read(status_manager, "graph snapshot generation")
-    _validate_generation_input(graph_generation_id, ready_status)
-    node_count, edge_count, key_label_counts, checksum = _read_graph_metrics(client)
-    return _graph_snapshot_from_metrics(
-        cycle_id,
-        graph_generation_id,
-        node_count=node_count,
-        edge_count=edge_count,
-        key_label_counts=key_label_counts,
-        checksum=checksum,
-    )
+    with ready_read(status_manager, "graph snapshot generation") as ready_status:
+        _validate_generation_input(graph_generation_id, ready_status)
+        node_count, edge_count, key_label_counts, checksum = _read_graph_metrics(client)
+        return _graph_snapshot_from_metrics(
+            cycle_id,
+            graph_generation_id,
+            node_count=node_count,
+            edge_count=edge_count,
+            key_label_counts=key_label_counts,
+            checksum=checksum,
+        )
 
 
 def build_graph_impact_snapshot(
@@ -82,50 +82,50 @@ def compute_graph_snapshots(
 ) -> tuple[GraphSnapshot, GraphImpactSnapshot]:
     """Run fundamental propagation and write graph plus impact snapshots."""
 
-    ready_status = require_ready_read(status_manager, "snapshot generation")
-    _validate_generation_input(graph_generation_id, ready_status)
-    node_count, edge_count, key_label_counts, checksum = _read_graph_metrics(client)
-    _validate_status_metrics(
-        ready_status,
-        node_count=node_count,
-        edge_count=edge_count,
-        key_label_counts=key_label_counts,
-        checksum=checksum,
-    )
+    with ready_read(status_manager, "snapshot generation") as ready_status:
+        _validate_generation_input(graph_generation_id, ready_status)
+        node_count, edge_count, key_label_counts, checksum = _read_graph_metrics(client)
+        _validate_status_metrics(
+            ready_status,
+            node_count=node_count,
+            edge_count=edge_count,
+            key_label_counts=key_label_counts,
+            checksum=checksum,
+        )
 
-    context = build_propagation_context(
-        cycle_id,
-        world_state_ref,
-        ready_status.graph_generation_id,
-        regime_reader=regime_reader,
-        graph_status=ready_status,
-    )
-    propagation_result = run_fundamental_propagation(
-        context,
-        client,
-        status_manager=status_manager,
-        graph_name=graph_name,
-    )
-    graph_snapshot = _graph_snapshot_from_metrics(
-        cycle_id,
-        ready_status.graph_generation_id,
-        node_count=node_count,
-        edge_count=edge_count,
-        key_label_counts=key_label_counts,
-        checksum=checksum,
-    )
-    impact_snapshot = build_graph_impact_snapshot(
-        cycle_id,
-        world_state_ref,
-        propagation_result,
-    )
-    _validate_publication_status_and_metrics(
-        ready_status,
-        status_manager,
-        client,
-    )
-    snapshot_writer.write_snapshots(graph_snapshot, impact_snapshot)
-    return graph_snapshot, impact_snapshot
+        context = build_propagation_context(
+            cycle_id,
+            world_state_ref,
+            ready_status.graph_generation_id,
+            regime_reader=regime_reader,
+            graph_status=ready_status,
+        )
+        propagation_result = run_fundamental_propagation(
+            context,
+            client,
+            status_manager=status_manager,
+            graph_name=graph_name,
+        )
+        graph_snapshot = _graph_snapshot_from_metrics(
+            cycle_id,
+            ready_status.graph_generation_id,
+            node_count=node_count,
+            edge_count=edge_count,
+            key_label_counts=key_label_counts,
+            checksum=checksum,
+        )
+        impact_snapshot = build_graph_impact_snapshot(
+            cycle_id,
+            world_state_ref,
+            propagation_result,
+        )
+        _validate_publication_status_and_metrics(
+            ready_status,
+            status_manager,
+            client,
+        )
+        snapshot_writer.write_snapshots(graph_snapshot, impact_snapshot)
+        return graph_snapshot, impact_snapshot
 
 
 def _validate_generation_input(
@@ -181,19 +181,19 @@ def _validate_publication_status_and_metrics(
     client: Neo4jClient,
 ) -> None:
     try:
-        current_status = require_ready_read(status_manager, "snapshot publication")
+        with ready_read(status_manager, "snapshot publication") as current_status:
+            _validate_status_matches_ready_status(current_status, ready_status)
+
+            node_count, edge_count, key_label_counts, checksum = _read_graph_metrics(client)
+            _validate_status_metrics(
+                current_status,
+                node_count=node_count,
+                edge_count=edge_count,
+                key_label_counts=key_label_counts,
+                checksum=checksum,
+            )
     except PermissionError as exc:
         raise RuntimeError("ready graph status changed before snapshot publication") from exc
-    _validate_status_matches_ready_status(current_status, ready_status)
-
-    node_count, edge_count, key_label_counts, checksum = _read_graph_metrics(client)
-    _validate_status_metrics(
-        current_status,
-        node_count=node_count,
-        edge_count=edge_count,
-        key_label_counts=key_label_counts,
-        checksum=checksum,
-    )
 
 
 def _validate_status_matches_ready_status(

--- a/graph_engine/status/__init__.py
+++ b/graph_engine/status/__init__.py
@@ -6,6 +6,7 @@ from graph_engine.status.consistency import (
 )
 from graph_engine.status.manager import (
     GraphStatusManager,
+    ready_read,
     require_ready_read,
     require_ready_status,
 )
@@ -18,6 +19,7 @@ __all__ = [
     "PostgresStatusStore",
     "StatusStore",
     "check_live_graph_consistency",
+    "ready_read",
     "require_ready_read",
     "require_ready_status",
 ]

--- a/graph_engine/status/consistency.py
+++ b/graph_engine/status/consistency.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Iterator
+from contextlib import contextmanager
 from typing import Protocol
 
 from graph_engine.client import Neo4jClient
 from graph_engine.live_metrics import read_live_graph_metrics
 from graph_engine.models import GraphSnapshot, Neo4jGraphStatus
-from graph_engine.status.manager import GraphStatusManager
+from graph_engine.status.manager import GraphStatusManager, ready_read
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -30,77 +32,78 @@ def check_live_graph_consistency(
 ) -> bool:
     """Return whether live Neo4j metrics match the canonical graph snapshot."""
 
-    status = _resolve_status(status_manager, require_ready=require_ready)
+    with _status_read_context(status_manager, require_ready=require_ready) as status:
+        try:
+            snapshot = snapshot_reader.read_graph_snapshot(snapshot_ref)
+        except Exception:
+            _LOGGER.exception(
+                "live graph consistency snapshot read failed",
+                extra={"snapshot_ref": snapshot_ref, "failure_stage": "snapshot_read"},
+            )
+            return False
 
-    try:
-        snapshot = snapshot_reader.read_graph_snapshot(snapshot_ref)
-    except Exception:
-        _LOGGER.exception(
-            "live graph consistency snapshot read failed",
-            extra={"snapshot_ref": snapshot_ref, "failure_stage": "snapshot_read"},
-        )
-        return False
+        try:
+            node_count, edge_count, key_label_counts, checksum = _read_live_graph_metrics(client)
+        except Exception:
+            _LOGGER.exception(
+                "live graph consistency live graph read failed",
+                extra={"snapshot_ref": snapshot_ref, "failure_stage": "live_graph_read"},
+            )
+            return False
 
-    try:
-        node_count, edge_count, key_label_counts, checksum = _read_live_graph_metrics(client)
-    except Exception:
-        _LOGGER.exception(
-            "live graph consistency live graph read failed",
-            extra={"snapshot_ref": snapshot_ref, "failure_stage": "live_graph_read"},
-        )
-        return False
+        if status is not None and snapshot.graph_generation_id != status.graph_generation_id:
+            _LOGGER.warning(
+                "live graph consistency generation mismatch",
+                extra={
+                    "snapshot_ref": snapshot_ref,
+                    "failure_stage": "result_validation",
+                    "snapshot_generation_id": snapshot.graph_generation_id,
+                    "status_generation_id": status.graph_generation_id,
+                },
+            )
+            return False
 
-    if status is not None and snapshot.graph_generation_id != status.graph_generation_id:
-        _LOGGER.warning(
-            "live graph consistency generation mismatch",
-            extra={
-                "snapshot_ref": snapshot_ref,
-                "failure_stage": "result_validation",
-                "snapshot_generation_id": snapshot.graph_generation_id,
-                "status_generation_id": status.graph_generation_id,
-            },
-        )
-        return False
-
-    mismatches = [
-        field_name
-        for field_name, snapshot_value, live_value in (
-            ("node_count", snapshot.node_count, node_count),
-            ("edge_count", snapshot.edge_count, edge_count),
-            ("key_label_counts", snapshot.key_label_counts, key_label_counts),
-            ("checksum", snapshot.checksum, checksum),
-        )
-        if snapshot_value != live_value
-    ]
-    if mismatches:
-        _LOGGER.warning(
-            "live graph consistency metric mismatch",
-            extra={
-                "snapshot_ref": snapshot_ref,
-                "failure_stage": "result_validation",
-                "mismatches": mismatches,
-            },
-        )
-        return False
-    return True
+        mismatches = [
+            field_name
+            for field_name, snapshot_value, live_value in (
+                ("node_count", snapshot.node_count, node_count),
+                ("edge_count", snapshot.edge_count, edge_count),
+                ("key_label_counts", snapshot.key_label_counts, key_label_counts),
+                ("checksum", snapshot.checksum, checksum),
+            )
+            if snapshot_value != live_value
+        ]
+        if mismatches:
+            _LOGGER.warning(
+                "live graph consistency metric mismatch",
+                extra={
+                    "snapshot_ref": snapshot_ref,
+                    "failure_stage": "result_validation",
+                    "mismatches": mismatches,
+                },
+            )
+            return False
+        return True
 
 
-def _resolve_status(
+@contextmanager
+def _status_read_context(
     status_manager: GraphStatusManager | None,
     *,
     require_ready: bool,
-) -> Neo4jGraphStatus | None:
+) -> Iterator[Neo4jGraphStatus | None]:
     if require_ready:
-        if status_manager is None:
-            raise ValueError("status_manager is required when require_ready=True")
-        return status_manager.require_ready()
+        with ready_read(status_manager, "live graph consistency") as status:
+            yield status
+        return
 
     if status_manager is None:
-        return None
+        yield None
+        return
     try:
-        return status_manager.get_status()
+        yield status_manager.get_status()
     except LookupError:
-        return None
+        yield None
 
 
 def _read_live_graph_metrics(client: Neo4jClient) -> tuple[int, int, dict[str, int], str]:

--- a/graph_engine/status/manager.py
+++ b/graph_engine/status/manager.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
 from datetime import datetime, timezone
 
 from graph_engine.models import GraphSnapshot, Neo4jGraphStatus
@@ -47,7 +48,17 @@ class GraphStatusManager:
     def require_ready(self) -> Neo4jGraphStatus:
         """Return the current ready status or block non-ready graph reads."""
 
-        return require_ready_status(self.get_status())
+        with self.ready_read() as status:
+            return status
+
+    @contextmanager
+    def ready_read(self) -> Iterator[Neo4jGraphStatus]:
+        """Hold the store-shared ready-read barrier for a live graph read."""
+
+        with self.store.ready_read_current_status() as status:
+            if status is None:
+                raise LookupError("Neo4j graph status has not been initialized")
+            yield require_ready_status(status)
 
     def mark_rebuilding(self) -> Neo4jGraphStatus:
         """Move an empty, ready, or failed status into rebuilding."""
@@ -259,9 +270,21 @@ def require_ready_read(
 ) -> Neo4jGraphStatus:
     """Return the ready status required before a public Neo4j read operation."""
 
+    with ready_read(status_manager, operation) as status:
+        return status
+
+
+@contextmanager
+def ready_read(
+    status_manager: GraphStatusManager | None,
+    operation: str,
+) -> Iterator[Neo4jGraphStatus]:
+    """Hold the ready status barrier required for a public Neo4j read operation."""
+
     if status_manager is None:
         raise ValueError(f"{operation} requires status_manager")
-    return status_manager.require_ready()
+    with status_manager.ready_read() as status:
+        yield status
 
 
 def _utc_now() -> datetime:

--- a/graph_engine/status/store.py
+++ b/graph_engine/status/store.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
-import json
 import importlib
+import json
 import os
 import re
 from collections.abc import Callable, Iterator, Mapping
-from contextlib import contextmanager
+from contextlib import AbstractContextManager, contextmanager
 from threading import Lock
 from typing import Any, Protocol
 
@@ -22,8 +22,18 @@ class StatusStore(Protocol):
     def read_current_status(self) -> Neo4jGraphStatus | None:
         """Return the current status row, or None before bootstrap."""
 
+    def ready_read_current_status(self) -> AbstractContextManager[Neo4jGraphStatus | None]:
+        """Hold a shared persistence barrier for a ready-gated live graph read.
+
+        Production stores must coordinate this barrier across every store
+        instance backed by the same status row.  Status writes must take the
+        matching exclusive barrier before changing the persisted status so a
+        writer cannot begin mutating the live graph after a ready check but
+        before the protected read has completed.
+        """
+
     def write_current_status(self, status: Neo4jGraphStatus) -> None:
-        """Persist the current status row."""
+        """Persist the current status row under the exclusive status barrier."""
 
     def compare_and_write_current_status(
         self,
@@ -31,7 +41,11 @@ class StatusStore(Protocol):
         expected_status: Neo4jGraphStatus | None,
         next_status: Neo4jGraphStatus,
     ) -> bool:
-        """Atomically persist next_status only if the current row still matches."""
+        """Atomically persist next_status only if the current row still matches.
+
+        The compare-and-write must acquire the same exclusive status barrier
+        used by write_current_status before checking and writing the row.
+        """
 
 
 class PostgreSQLStatusStore:
@@ -148,26 +162,21 @@ ADD COLUMN IF NOT EXISTS writer_lock_token text NULL CHECK (
         self._ensure_bootstrap()
         with self._transaction() as connection:
             with connection.cursor() as cursor:
-                cursor.execute(
-                    f"""
-SELECT graph_status,
-       graph_generation_id,
-       node_count,
-       edge_count,
-       key_label_counts,
-       checksum,
-       last_verified_at,
-       last_reload_at,
-       writer_lock_token
-FROM {self._table_name}
-WHERE status_key = %s
-""",
-                    (self._status_key,),
-                )
-                row = cursor.fetchone()
+                row = self._read_current_status_row(cursor)
         if row is None:
             return None
         return _status_from_row(row)
+
+    @contextmanager
+    def ready_read_current_status(self) -> Iterator[Neo4jGraphStatus | None]:
+        """Return current status while holding a shared transaction advisory lock."""
+
+        self._ensure_bootstrap()
+        with self._transaction() as connection:
+            with connection.cursor() as cursor:
+                self._acquire_ready_read_lock(cursor)
+                row = self._read_current_status_row(cursor)
+            yield None if row is None else _status_from_row(row)
 
     def write_current_status(self, status: Neo4jGraphStatus) -> None:
         """Persist the current status row without comparing the previous value."""
@@ -176,6 +185,7 @@ WHERE status_key = %s
         values = _status_write_values(status)
         with self._transaction() as connection:
             with connection.cursor() as cursor:
+                self._acquire_status_write_lock(cursor)
                 cursor.execute(
                     f"""
 INSERT INTO {self._table_name} (
@@ -222,6 +232,7 @@ ON CONFLICT (status_key) DO UPDATE SET
         expected_values = _status_write_values(expected_status)
         with self._transaction() as connection:
             with connection.cursor() as cursor:
+                self._acquire_status_write_lock(cursor)
                 cursor.execute(
                     f"""
 UPDATE {self._table_name}
@@ -254,6 +265,7 @@ RETURNING status_key
     def _insert_if_missing(self, next_values: tuple[Any, ...]) -> bool:
         with self._transaction() as connection:
             with connection.cursor() as cursor:
+                self._acquire_status_write_lock(cursor)
                 cursor.execute(
                     f"""
 INSERT INTO {self._table_name} (
@@ -275,6 +287,45 @@ RETURNING status_key
                     (self._status_key, *next_values),
                 )
                 return cursor.fetchone() is not None
+
+    def _read_current_status_row(self, cursor: Any) -> Any:
+        cursor.execute(
+            f"""
+SELECT graph_status,
+       graph_generation_id,
+       node_count,
+       edge_count,
+       key_label_counts,
+       checksum,
+       last_verified_at,
+       last_reload_at,
+       writer_lock_token
+FROM {self._table_name}
+WHERE status_key = %s
+""",
+            (self._status_key,),
+        )
+        return cursor.fetchone()
+
+    def _acquire_ready_read_lock(self, cursor: Any) -> None:
+        cursor.execute(
+            """
+SELECT pg_advisory_xact_lock_shared(
+    hashtextextended((%s::regclass)::oid::text || ':' || %s, 0::bigint)
+)
+""",
+            (self._table_name, self._status_key),
+        )
+
+    def _acquire_status_write_lock(self, cursor: Any) -> None:
+        cursor.execute(
+            """
+SELECT pg_advisory_xact_lock(
+    hashtextextended((%s::regclass)::oid::text || ':' || %s, 0::bigint)
+)
+""",
+            (self._table_name, self._status_key),
+        )
 
     def _ensure_bootstrap(self) -> None:
         if self._auto_bootstrap and not self._bootstrapped:

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator
+from contextlib import contextmanager
+
 from graph_engine.models import Neo4jGraphStatus
 
 
@@ -23,6 +26,10 @@ class InMemoryStatusStore:
 
     def read_current_status(self) -> Neo4jGraphStatus | None:
         return self.status
+
+    @contextmanager
+    def ready_read_current_status(self) -> Iterator[Neo4jGraphStatus | None]:
+        yield self.read_current_status()
 
     def write_current_status(self, status: Neo4jGraphStatus) -> None:
         self.status = status

--- a/tests/integration/test_postgresql_status_store.py
+++ b/tests/integration/test_postgresql_status_store.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import os
+from collections.abc import Iterator
 from concurrent.futures import ThreadPoolExecutor
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from threading import Barrier
 from typing import Any
@@ -28,13 +30,22 @@ class BarrierStatusStore(PostgreSQLStatusStore):
 
     def read_current_status(self) -> Neo4jGraphStatus | None:
         status = super().read_current_status()
+        self._wait_if_ready(status)
+        return status
+
+    @contextmanager
+    def ready_read_current_status(self) -> Iterator[Neo4jGraphStatus | None]:
+        with super().ready_read_current_status() as status:
+            self._wait_if_ready(status)
+            yield status
+
+    def _wait_if_ready(self, status: Neo4jGraphStatus | None) -> None:
         if (
             status is not None
             and status.graph_status == "ready"
             and status.writer_lock_token is None
         ):
             self._barrier.wait(timeout=10)
-        return status
 
 
 def test_postgresql_status_store_bootstraps_empty_row_and_persists_transitions() -> None:

--- a/tests/unit/test_snapshots.py
+++ b/tests/unit/test_snapshots.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Iterator
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from typing import Any, Literal
 from unittest.mock import MagicMock
@@ -109,6 +111,10 @@ class SequentialStatusStore:
         self.calls += 1
         index = min(self.calls - 1, len(self.graph_statuses) - 1)
         return self.graph_statuses[index]
+
+    @contextmanager
+    def ready_read_current_status(self) -> Iterator[Neo4jGraphStatus]:
+        yield self.read_current_status()
 
     def write_current_status(self, status: Neo4jGraphStatus) -> None:
         self.graph_statuses = [status]

--- a/tests/unit/test_status.py
+++ b/tests/unit/test_status.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Iterator
+from concurrent.futures import ThreadPoolExecutor
+from contextlib import contextmanager
 from datetime import datetime, timezone
+from threading import Condition, Event
 from typing import Any, Literal
 from unittest.mock import MagicMock
 
@@ -42,6 +46,74 @@ class InterleavingStatusStore(InMemoryStatusStore):
             expected_status=expected_status,
             next_status=next_status,
         )
+
+
+class SharedStatusBoundary:
+    def __init__(self, status: Neo4jGraphStatus) -> None:
+        self.status = status
+        self.writer_waiting = Event()
+        self._condition = Condition()
+        self._active_readers = 0
+        self._writer_active = False
+
+    @contextmanager
+    def ready_read(self) -> Iterator[Neo4jGraphStatus]:
+        with self._condition:
+            while self._writer_active:
+                self._condition.wait()
+            self._active_readers += 1
+        try:
+            yield self.status
+        finally:
+            with self._condition:
+                self._active_readers -= 1
+                self._condition.notify_all()
+
+    @contextmanager
+    def status_write(self) -> Iterator[None]:
+        with self._condition:
+            self.writer_waiting.set()
+            while self._writer_active or self._active_readers > 0:
+                self._condition.wait()
+            self._writer_active = True
+        try:
+            yield
+        finally:
+            with self._condition:
+                self._writer_active = False
+                self._condition.notify_all()
+
+
+class SharedBoundaryStatusStore:
+    def __init__(self, boundary: SharedStatusBoundary) -> None:
+        self.boundary = boundary
+        self.writes: list[Neo4jGraphStatus] = []
+
+    def read_current_status(self) -> Neo4jGraphStatus:
+        return self.boundary.status
+
+    @contextmanager
+    def ready_read_current_status(self) -> Iterator[Neo4jGraphStatus]:
+        with self.boundary.ready_read() as status:
+            yield status
+
+    def write_current_status(self, status: Neo4jGraphStatus) -> None:
+        with self.boundary.status_write():
+            self.boundary.status = status
+            self.writes.append(status)
+
+    def compare_and_write_current_status(
+        self,
+        *,
+        expected_status: Neo4jGraphStatus | None,
+        next_status: Neo4jGraphStatus,
+    ) -> bool:
+        with self.boundary.status_write():
+            if self.boundary.status != expected_status:
+                return False
+            self.boundary.status = next_status
+            self.writes.append(next_status)
+            return True
 
 
 class StaticSnapshotReader:
@@ -390,6 +462,28 @@ def test_require_ready_rejects_non_ready_status(
         require_ready_status(status)
     with pytest.raises(PermissionError, match="ready"):
         GraphStatusManager(InMemoryStatusStore(status)).require_ready()
+
+
+def test_ready_read_barrier_is_shared_by_distinct_status_store_instances() -> None:
+    boundary = SharedStatusBoundary(_status(graph_status="ready", graph_generation_id=8))
+    reader_manager = GraphStatusManager(SharedBoundaryStatusStore(boundary))
+    writer_manager = GraphStatusManager(SharedBoundaryStatusStore(boundary))
+    executor = ThreadPoolExecutor(max_workers=1)
+    try:
+        with reader_manager.ready_read() as ready_status:
+            future = executor.submit(writer_manager.mark_rebuilding)
+
+            assert ready_status.graph_status == "ready"
+            assert boundary.writer_waiting.wait(timeout=1.0)
+            assert not future.done()
+            assert boundary.status == ready_status
+
+        rebuilt_status = future.result(timeout=1.0)
+    finally:
+        executor.shutdown(wait=True)
+
+    assert rebuilt_status.graph_status == "rebuilding"
+    assert boundary.status == rebuilt_status
 
 
 def test_mark_verified_updates_metrics_without_bumping_generation() -> None:


### PR DESCRIPTION
Closes #34

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `benchmarks/artifacts/lite_target_100k_800k.json`, `benchmarks/generate_synthetic.py`, `benchmarks/run_benchmark.py`, `cross-cutting`, `graph_engine/__pycache__/__init__.cpython-314.pyc`, `graph_engine/live_metrics.py`, `graph_engine/query/__init__.py`, `graph_engine/reload/service.py`, `graph_engine/status/consistency.py`, `graph_engine/status/store.py`


---
Tracked from PR #31 codex re-review. Latent issue: `_ReadyReadBarrier` is keyed by Python object identity. Two distinct StatusStore instances backed by the same persistence row would receive independent barriers, preserving the original TOCTOU race at the persistence boundary.

Currently latent: no production StatusStore implementation exists; test doubles use one-store-per-manager wiring. Becomes exploitable once a real DB-backed store is introduced.

**Action**: Before shipping a production StatusStore, move the barrier into the shared persistence boundary (e.g., DB advisory lock, transactional status-lock protocol in StatusStore contract).

**Source**: codex re-review of PR #31 round 3, confidence 0.90, source graph_engine/status/manager.py:311.

This was downgraded from P0 to follow-up because reviewer itself stated 'P0 is architecturally valid but low immediacy — recommend addressing before any production StatusStore implementation lands.'