### PR TITLE
feat(#8): Event 与 Reflexive 传播通道实现

### DIFF
--- a/graph_engine/models.py
+++ b/graph_engine/models.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any, Literal, Self
+from typing import Any, Literal, Self, get_args
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+PropagationChannel = Literal["fundamental", "event", "reflexive"]
+_ALLOWED_PROPAGATION_CHANNELS: frozenset[str] = frozenset(get_args(PropagationChannel))
 
 
 class GraphNodeRecord(BaseModel):
@@ -85,7 +88,7 @@ class PropagationContext(BaseModel):
     cycle_id: str = Field(min_length=1)
     world_state_ref: str = Field(min_length=1)
     graph_generation_id: int = Field(ge=0)
-    enabled_channels: list[Literal["fundamental"]] = Field(min_length=1)
+    enabled_channels: list[PropagationChannel] = Field(min_length=1)
     channel_multipliers: dict[str, float]
     regime_multipliers: dict[str, float]
     decay_policy: dict[str, Any]
@@ -93,12 +96,19 @@ class PropagationContext(BaseModel):
 
     @field_validator("enabled_channels")
     @classmethod
-    def _requires_fundamental_channel(
+    def _validate_enabled_channels(
         cls,
-        enabled_channels: list[Literal["fundamental"]],
-    ) -> list[Literal["fundamental"]]:
-        if "fundamental" not in enabled_channels:
-            raise ValueError("enabled_channels must include 'fundamental'")
+        enabled_channels: list[PropagationChannel],
+    ) -> list[PropagationChannel]:
+        if not enabled_channels:
+            raise ValueError("enabled_channels must not be empty")
+        unknown_channels = [
+            channel for channel in enabled_channels if channel not in _ALLOWED_PROPAGATION_CHANNELS
+        ]
+        if unknown_channels:
+            raise ValueError(f"unknown propagation channels: {unknown_channels}")
+        if len(set(enabled_channels)) != len(enabled_channels):
+            raise ValueError("enabled_channels must not contain duplicates")
         return enabled_channels
 
 

--- a/graph_engine/propagation/__init__.py
+++ b/graph_engine/propagation/__init__.py
@@ -5,13 +5,18 @@ from graph_engine.propagation.fundamental import (
     FUNDAMENTAL_RELATIONSHIP_TYPES,
     run_fundamental_propagation,
 )
+from graph_engine.propagation.event import EVENT_RELATIONSHIP_TYPES, run_event_propagation
+from graph_engine.propagation.reflexive import run_reflexive_propagation
 from graph_engine.propagation.scoring import build_score_explanation, compute_path_score
 
 __all__ = [
+    "EVENT_RELATIONSHIP_TYPES",
     "FUNDAMENTAL_RELATIONSHIP_TYPES",
     "RegimeContextReader",
     "build_propagation_context",
     "build_score_explanation",
     "compute_path_score",
+    "run_event_propagation",
     "run_fundamental_propagation",
+    "run_reflexive_propagation",
 ]

--- a/graph_engine/propagation/_gds.py
+++ b/graph_engine/propagation/_gds.py
@@ -1,0 +1,58 @@
+"""Shared GDS projection helpers for propagation runners."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from graph_engine.client import Neo4jClient
+
+
+def drop_projection_if_exists(client: Neo4jClient, graph_name: str) -> None:
+    rows = execute_gds_read(
+        client,
+        "CALL gds.graph.exists($graph_name) YIELD exists RETURN exists",
+        {"graph_name": graph_name},
+    )
+    if rows and rows[0].get("exists") is True:
+        execute_gds_write(
+            client,
+            "CALL gds.graph.drop($graph_name) YIELD graphName RETURN graphName",
+            {"graph_name": graph_name},
+        )
+
+
+def execute_gds_read(
+    client: Neo4jClient,
+    query: str,
+    parameters: dict[str, Any],
+) -> list[dict[str, Any]]:
+    try:
+        return client.execute_read(query, parameters)
+    except Exception as exc:
+        if _is_missing_gds_error(exc):
+            raise RuntimeError("GDS plugin not available") from exc
+        raise
+
+
+def execute_gds_write(
+    client: Neo4jClient,
+    query: str,
+    parameters: dict[str, Any],
+) -> list[dict[str, Any]]:
+    try:
+        return client.execute_write(query, parameters)
+    except Exception as exc:
+        if _is_missing_gds_error(exc):
+            raise RuntimeError("GDS plugin not available") from exc
+        raise
+
+
+def _is_missing_gds_error(exc: Exception) -> bool:
+    message = str(exc).lower()
+    missing_markers = (
+        "no procedure",
+        "not registered",
+        "unknown procedure",
+        "procedure not found",
+    )
+    return "gds." in message and any(marker in message for marker in missing_markers)

--- a/graph_engine/propagation/context.py
+++ b/graph_engine/propagation/context.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
-from typing import Any, Literal, Protocol
+from collections.abc import Mapping, Sequence
+from typing import Any, Protocol
 
-from graph_engine.models import Neo4jGraphStatus, PropagationContext
+from graph_engine.models import Neo4jGraphStatus, PropagationChannel, PropagationContext
 
-_FUNDAMENTAL_CHANNEL: Literal["fundamental"] = "fundamental"
+_DEFAULT_ENABLED_CHANNELS: tuple[PropagationChannel, ...] = ("fundamental",)
 
 
 class RegimeContextReader(Protocol):
@@ -24,8 +24,9 @@ def build_propagation_context(
     *,
     regime_reader: RegimeContextReader,
     graph_status: Neo4jGraphStatus | None = None,
+    enabled_channels: Sequence[PropagationChannel] | None = None,
 ) -> PropagationContext:
-    """Build a single-channel propagation context without mutating world state."""
+    """Build a propagation context without mutating world state."""
 
     if graph_status is not None and graph_status.graph_status != "ready":
         raise PermissionError(
@@ -33,23 +34,28 @@ def build_propagation_context(
             f"received {graph_status.graph_status!r}",
         )
 
+    requested_channels = list(enabled_channels or _DEFAULT_ENABLED_CHANNELS)
     regime_context = dict(regime_reader.read_regime_context(world_state_ref))
     return PropagationContext(
         cycle_id=cycle_id,
         world_state_ref=world_state_ref,
         graph_generation_id=graph_generation_id,
-        enabled_channels=[_FUNDAMENTAL_CHANNEL],
+        enabled_channels=requested_channels,
         channel_multipliers={
-            _FUNDAMENTAL_CHANNEL: _context_multiplier(
+            channel: _context_multiplier(
                 regime_context,
                 "channel_multipliers",
-            ),
+                channel,
+            )
+            for channel in requested_channels
         },
         regime_multipliers={
-            _FUNDAMENTAL_CHANNEL: _context_multiplier(
+            channel: _context_multiplier(
                 regime_context,
                 "regime_multipliers",
-            ),
+                channel,
+            )
+            for channel in requested_channels
         },
         decay_policy=_context_mapping(regime_context, "decay_policy"),
         regime_context=regime_context,
@@ -59,12 +65,13 @@ def build_propagation_context(
 def _context_multiplier(
     regime_context: Mapping[str, Any],
     key: str,
+    channel: PropagationChannel,
 ) -> float:
     raw_multipliers = regime_context.get(key)
     if not isinstance(raw_multipliers, Mapping):
         return 1.0
     return _as_non_negative_float(
-        raw_multipliers.get(_FUNDAMENTAL_CHANNEL, 1.0),
+        raw_multipliers.get(channel, 1.0),
         key,
     )
 

--- a/graph_engine/propagation/event.py
+++ b/graph_engine/propagation/event.py
@@ -8,13 +8,14 @@ from uuid import uuid4
 
 from graph_engine.client import Neo4jClient
 from graph_engine.models import PropagationContext, PropagationResult
-from graph_engine.propagation.fundamental import (
-    _drop_projection_if_exists,
-    _execute_gds_read,
-    _execute_gds_write,
+from graph_engine.propagation._gds import (
+    drop_projection_if_exists,
+    execute_gds_read,
+    execute_gds_write,
 )
 from graph_engine.propagation.scoring import build_score_explanation
 from graph_engine.schema.definitions import RelationshipType
+from graph_engine.status import GraphStatusManager, require_ready_read
 
 EVENT_RELATIONSHIP_TYPES = (RelationshipType.EVENT_IMPACT.value,)
 _EVENT_CHANNEL = "event"
@@ -24,6 +25,7 @@ def run_event_propagation(
     context: PropagationContext,
     client: Neo4jClient,
     *,
+    status_manager: GraphStatusManager,
     graph_name: str | None = None,
     max_iterations: int = 20,
     result_limit: int = 100,
@@ -37,8 +39,16 @@ def run_event_propagation(
     if result_limit < 1:
         raise ValueError("result_limit must be greater than zero")
 
+    ready_status = require_ready_read(status_manager, "event propagation")
+    if ready_status.graph_generation_id != context.graph_generation_id:
+        raise ValueError(
+            "PropagationContext graph_generation_id disagrees with Neo4jGraphStatus: "
+            f"context={context.graph_generation_id}, "
+            f"status={ready_status.graph_generation_id}",
+        )
+
     projection_name = graph_name or _default_projection_name(context)
-    _drop_projection_if_exists(client, projection_name)
+    drop_projection_if_exists(client, projection_name)
     try:
         _create_projection(client, projection_name)
         pagerank_entities = _stream_pagerank(
@@ -53,7 +63,7 @@ def run_event_propagation(
             result_limit=result_limit,
         )
     finally:
-        _drop_projection_if_exists(client, projection_name)
+        drop_projection_if_exists(client, projection_name)
 
     impacted_entities = _impacted_entities_from_paths(
         activated_paths,
@@ -99,7 +109,7 @@ def _create_projection(client: Neo4jClient, graph_name: str) -> None:
         }
         for relationship_type in EVENT_RELATIONSHIP_TYPES
     }
-    _execute_gds_write(
+    execute_gds_write(
         client,
         """
 CALL gds.graph.project($graph_name, "*", $relationship_projection)
@@ -120,7 +130,7 @@ def _stream_pagerank(
     max_iterations: int,
     result_limit: int,
 ) -> list[dict[str, Any]]:
-    rows = _execute_gds_read(
+    rows = execute_gds_read(
         client,
         """
 CALL gds.pageRank.stream($graph_name, {

--- a/graph_engine/propagation/event.py
+++ b/graph_engine/propagation/event.py
@@ -1,0 +1,331 @@
+"""Event propagation over EVENT_IMPACT relationships."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+from uuid import uuid4
+
+from graph_engine.client import Neo4jClient
+from graph_engine.models import PropagationContext, PropagationResult
+from graph_engine.propagation.fundamental import (
+    _drop_projection_if_exists,
+    _execute_gds_read,
+    _execute_gds_write,
+)
+from graph_engine.propagation.scoring import build_score_explanation
+from graph_engine.schema.definitions import RelationshipType
+
+EVENT_RELATIONSHIP_TYPES = (RelationshipType.EVENT_IMPACT.value,)
+_EVENT_CHANNEL = "event"
+
+
+def run_event_propagation(
+    context: PropagationContext,
+    client: Neo4jClient,
+    *,
+    graph_name: str | None = None,
+    max_iterations: int = 20,
+    result_limit: int = 100,
+) -> PropagationResult:
+    """Run weighted PageRank for the event channel and explain event impact paths."""
+
+    if _EVENT_CHANNEL not in context.enabled_channels:
+        raise PermissionError("event propagation requires the event channel")
+    if max_iterations < 1:
+        raise ValueError("max_iterations must be greater than zero")
+    if result_limit < 1:
+        raise ValueError("result_limit must be greater than zero")
+
+    projection_name = graph_name or _default_projection_name(context)
+    _drop_projection_if_exists(client, projection_name)
+    try:
+        _create_projection(client, projection_name)
+        pagerank_entities = _stream_pagerank(
+            client,
+            projection_name,
+            max_iterations=max_iterations,
+            result_limit=result_limit,
+        )
+        activated_paths = _read_activated_paths(
+            context,
+            client,
+            result_limit=result_limit,
+        )
+    finally:
+        _drop_projection_if_exists(client, projection_name)
+
+    impacted_entities = _impacted_entities_from_paths(
+        activated_paths,
+        pagerank_entities,
+        result_limit=result_limit,
+    )
+    channel_breakdown: dict[str, Any] = {
+        _EVENT_CHANNEL: {
+            "relationship_types": list(EVENT_RELATIONSHIP_TYPES),
+            "path_count": len(activated_paths),
+            "impacted_entity_count": len(impacted_entities),
+            "total_path_score": sum(float(path["score"]) for path in activated_paths),
+            "channel_multiplier": _context_multiplier(context.channel_multipliers),
+            "regime_multiplier": _context_multiplier(context.regime_multipliers),
+        },
+    }
+    return PropagationResult(
+        cycle_id=context.cycle_id,
+        graph_generation_id=context.graph_generation_id,
+        activated_paths=activated_paths,
+        impacted_entities=impacted_entities,
+        channel_breakdown=channel_breakdown,
+    )
+
+
+def _default_projection_name(context: PropagationContext) -> str:
+    cycle_component = re.sub(r"[^A-Za-z0-9_]", "_", context.cycle_id).strip("_")
+    cycle_component = (cycle_component or "cycle")[:64]
+    return f"graph_engine_event_{cycle_component}_{uuid4().hex[:8]}"
+
+
+def _create_projection(client: Neo4jClient, graph_name: str) -> None:
+    relationship_projection = {
+        relationship_type: {
+            "type": relationship_type,
+            "orientation": "NATURAL",
+            "properties": {
+                "weight": {
+                    "property": "weight",
+                    "defaultValue": 1.0,
+                },
+            },
+        }
+        for relationship_type in EVENT_RELATIONSHIP_TYPES
+    }
+    _execute_gds_write(
+        client,
+        """
+CALL gds.graph.project($graph_name, "*", $relationship_projection)
+YIELD graphName, nodeCount, relationshipCount
+RETURN graphName, nodeCount, relationshipCount
+""",
+        {
+            "graph_name": graph_name,
+            "relationship_projection": relationship_projection,
+        },
+    )
+
+
+def _stream_pagerank(
+    client: Neo4jClient,
+    graph_name: str,
+    *,
+    max_iterations: int,
+    result_limit: int,
+) -> list[dict[str, Any]]:
+    rows = _execute_gds_read(
+        client,
+        """
+CALL gds.pageRank.stream($graph_name, {
+    maxIterations: $max_iterations,
+    relationshipWeightProperty: "weight"
+})
+YIELD nodeId, score
+WITH gds.util.asNode(nodeId) AS node, score
+WITH node,
+     score,
+     coalesce(node.node_id, elementId(node)) AS stable_node_id
+RETURN node.node_id AS node_id,
+       node.canonical_entity_id AS canonical_entity_id,
+       labels(node) AS labels,
+       stable_node_id,
+       score
+ORDER BY score DESC, stable_node_id ASC
+LIMIT $result_limit
+""",
+        {
+            "graph_name": graph_name,
+            "max_iterations": max_iterations,
+            "result_limit": result_limit,
+        },
+    )
+    impacted_entities = [_pagerank_entity(row) for row in rows]
+    impacted_entities.sort(
+        key=lambda entity: (-float(entity["score"]), str(entity["stable_node_id"])),
+    )
+    return impacted_entities[:result_limit]
+
+
+def _read_activated_paths(
+    context: PropagationContext,
+    client: Neo4jClient,
+    *,
+    result_limit: int,
+) -> list[dict[str, Any]]:
+    channel_multiplier = _context_multiplier(context.channel_multipliers)
+    regime_multiplier = _context_multiplier(context.regime_multipliers)
+    rows = client.execute_read(
+        """
+MATCH (source)-[relationship]->(target)
+WHERE type(relationship) IN $relationship_types
+WITH source,
+     relationship,
+     target,
+     coalesce(relationship.weight, 1.0) AS relation_weight,
+     coalesce(relationship.evidence_confidence, 1.0) AS evidence_confidence,
+     coalesce(relationship.recency_decay, 1.0) AS recency_decay
+WITH source,
+     relationship,
+     target,
+     relation_weight,
+     evidence_confidence,
+     recency_decay,
+     relation_weight
+         * evidence_confidence
+         * $channel_multiplier
+         * $regime_multiplier
+         * recency_decay AS path_score
+RETURN source.node_id AS source_node_id,
+       source.canonical_entity_id AS source_entity_id,
+       labels(source) AS source_labels,
+       target.node_id AS target_node_id,
+       target.canonical_entity_id AS target_entity_id,
+       labels(target) AS target_labels,
+       relationship.edge_id AS edge_id,
+       type(relationship) AS relationship_type,
+       relation_weight,
+       evidence_confidence,
+       recency_decay,
+       path_score
+ORDER BY path_score DESC,
+         source_node_id ASC,
+         relationship_type ASC,
+         target_node_id ASC,
+         edge_id ASC
+LIMIT $result_limit
+""",
+        {
+            "relationship_types": list(EVENT_RELATIONSHIP_TYPES),
+            "result_limit": result_limit,
+            "channel_multiplier": channel_multiplier,
+            "regime_multiplier": regime_multiplier,
+        },
+    )
+
+    activated_paths = [
+        _activated_path(row, channel_multiplier, regime_multiplier)
+        for row in rows
+    ]
+    activated_paths.sort(
+        key=lambda path: (
+            -float(path["score"]),
+            str(path["source_node_id"]),
+            str(path["relationship_type"]),
+            str(path["target_node_id"]),
+            str(path["edge_id"]),
+        ),
+    )
+    return activated_paths[:result_limit]
+
+
+def _activated_path(
+    row: dict[str, Any],
+    channel_multiplier: float,
+    regime_multiplier: float,
+) -> dict[str, Any]:
+    relation_weight = _float_value(row.get("relation_weight"), default=1.0)
+    evidence_confidence = _float_value(row.get("evidence_confidence"), default=1.0)
+    recency_decay = _float_value(row.get("recency_decay"), default=1.0)
+    explanation = build_score_explanation(
+        relation_weight=relation_weight,
+        evidence_confidence=evidence_confidence,
+        channel_multiplier=channel_multiplier,
+        regime_multiplier=regime_multiplier,
+        recency_decay=recency_decay,
+    )
+
+    return {
+        "channel": _EVENT_CHANNEL,
+        "source_node_id": row.get("source_node_id"),
+        "source_entity_id": row.get("source_entity_id"),
+        "source_labels": _string_list(row.get("source_labels")),
+        "target_node_id": row.get("target_node_id"),
+        "target_entity_id": row.get("target_entity_id"),
+        "target_labels": _string_list(row.get("target_labels")),
+        "edge_id": row.get("edge_id"),
+        "relationship_type": row.get("relationship_type"),
+        "score": explanation["score"],
+        "explanation": explanation,
+    }
+
+
+def _pagerank_entity(row: dict[str, Any]) -> dict[str, Any]:
+    stable_node_id = str(row.get("stable_node_id") or row.get("node_id") or "")
+    return {
+        "channel": _EVENT_CHANNEL,
+        "node_id": row.get("node_id"),
+        "canonical_entity_id": row.get("canonical_entity_id"),
+        "labels": _string_list(row.get("labels")),
+        "score": _float_value(row.get("score"), default=0.0),
+        "stable_node_id": stable_node_id,
+    }
+
+
+def _impacted_entities_from_paths(
+    activated_paths: list[dict[str, Any]],
+    pagerank_entities: list[dict[str, Any]],
+    *,
+    result_limit: int,
+) -> list[dict[str, Any]]:
+    pagerank_by_node_id = {
+        str(entity.get("node_id")): _float_value(entity.get("score"), default=0.0)
+        for entity in pagerank_entities
+        if entity.get("node_id") is not None
+    }
+    impacted_by_node_id: dict[str, dict[str, Any]] = {}
+    for path in activated_paths:
+        target_node_id = path.get("target_node_id")
+        if target_node_id is None:
+            continue
+
+        node_id = str(target_node_id)
+        impact = impacted_by_node_id.setdefault(
+            node_id,
+            {
+                "channel": _EVENT_CHANNEL,
+                "node_id": target_node_id,
+                "canonical_entity_id": path.get("target_entity_id"),
+                "labels": _string_list(path.get("target_labels")),
+                "score": 0.0,
+                "stable_node_id": node_id,
+                "pagerank_score": pagerank_by_node_id.get(node_id, 0.0),
+                "path_count": 0,
+            },
+        )
+        impact["score"] = float(impact["score"]) + _float_value(
+            path.get("score"),
+            default=0.0,
+        )
+        impact["path_count"] = int(impact["path_count"]) + 1
+
+    impacted_entities = list(impacted_by_node_id.values())
+    impacted_entities.sort(
+        key=lambda entity: (
+            -float(entity["score"]),
+            str(entity["stable_node_id"]),
+        ),
+    )
+    return impacted_entities[:result_limit]
+
+
+def _context_multiplier(multipliers: dict[str, float]) -> float:
+    return float(multipliers.get(_EVENT_CHANNEL, 1.0))
+
+
+def _float_value(value: Any, *, default: float) -> float:
+    if value is None:
+        return default
+    return float(value)
+
+
+def _string_list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return sorted(str(item) for item in value)

--- a/graph_engine/propagation/fundamental.py
+++ b/graph_engine/propagation/fundamental.py
@@ -8,6 +8,11 @@ from uuid import uuid4
 
 from graph_engine.client import Neo4jClient
 from graph_engine.models import PropagationContext, PropagationResult
+from graph_engine.propagation._gds import (
+    drop_projection_if_exists,
+    execute_gds_read,
+    execute_gds_write,
+)
 from graph_engine.propagation.scoring import build_score_explanation
 from graph_engine.schema.definitions import RelationshipType
 from graph_engine.status import GraphStatusManager, require_ready_read
@@ -48,7 +53,7 @@ def run_fundamental_propagation(
         )
 
     projection_name = graph_name or _default_projection_name(context)
-    _drop_projection_if_exists(client, projection_name)
+    drop_projection_if_exists(client, projection_name)
     try:
         _create_projection(client, projection_name)
         pagerank_entities = _stream_pagerank(
@@ -63,7 +68,7 @@ def run_fundamental_propagation(
             result_limit=result_limit,
         )
     finally:
-        _drop_projection_if_exists(client, projection_name)
+        drop_projection_if_exists(client, projection_name)
 
     # Keep PageRank as the GDS topology pass, but rank persisted impacts by the
     # documented five-factor path scores so the snapshot outputs stay coherent.
@@ -92,20 +97,6 @@ def run_fundamental_propagation(
     )
 
 
-def _drop_projection_if_exists(client: Neo4jClient, graph_name: str) -> None:
-    rows = _execute_gds_read(
-        client,
-        "CALL gds.graph.exists($graph_name) YIELD exists RETURN exists",
-        {"graph_name": graph_name},
-    )
-    if rows and rows[0].get("exists") is True:
-        _execute_gds_write(
-            client,
-            "CALL gds.graph.drop($graph_name) YIELD graphName RETURN graphName",
-            {"graph_name": graph_name},
-        )
-
-
 def _default_projection_name(context: PropagationContext) -> str:
     cycle_component = re.sub(r"[^A-Za-z0-9_]", "_", context.cycle_id).strip("_")
     cycle_component = (cycle_component or "cycle")[:64]
@@ -126,7 +117,7 @@ def _create_projection(client: Neo4jClient, graph_name: str) -> None:
         }
         for relationship_type in FUNDAMENTAL_RELATIONSHIP_TYPES
     }
-    _execute_gds_write(
+    execute_gds_write(
         client,
         """
 CALL gds.graph.project($graph_name, "*", $relationship_projection)
@@ -147,7 +138,7 @@ def _stream_pagerank(
     max_iterations: int,
     result_limit: int,
 ) -> list[dict[str, Any]]:
-    rows = _execute_gds_read(
+    rows = execute_gds_read(
         client,
         """
 CALL gds.pageRank.stream($graph_name, {
@@ -356,40 +347,3 @@ def _string_list(value: Any) -> list[str]:
     if not isinstance(value, list):
         return []
     return sorted(str(item) for item in value)
-
-
-def _execute_gds_read(
-    client: Neo4jClient,
-    query: str,
-    parameters: dict[str, Any],
-) -> list[dict[str, Any]]:
-    try:
-        return client.execute_read(query, parameters)
-    except Exception as exc:
-        if _is_missing_gds_error(exc):
-            raise RuntimeError("GDS plugin not available") from exc
-        raise
-
-
-def _execute_gds_write(
-    client: Neo4jClient,
-    query: str,
-    parameters: dict[str, Any],
-) -> list[dict[str, Any]]:
-    try:
-        return client.execute_write(query, parameters)
-    except Exception as exc:
-        if _is_missing_gds_error(exc):
-            raise RuntimeError("GDS plugin not available") from exc
-        raise
-
-
-def _is_missing_gds_error(exc: Exception) -> bool:
-    message = str(exc).lower()
-    missing_markers = (
-        "no procedure",
-        "not registered",
-        "unknown procedure",
-        "procedure not found",
-    )
-    return "gds." in message and any(marker in message for marker in missing_markers)

--- a/graph_engine/propagation/reflexive.py
+++ b/graph_engine/propagation/reflexive.py
@@ -1,0 +1,347 @@
+"""Reflexive propagation over reflexive-tagged relationships."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+from uuid import uuid4
+
+from graph_engine.client import Neo4jClient
+from graph_engine.models import PropagationContext, PropagationResult
+from graph_engine.propagation.fundamental import (
+    _drop_projection_if_exists,
+    _execute_gds_read,
+    _execute_gds_write,
+)
+from graph_engine.propagation.scoring import build_score_explanation
+
+_REFLEXIVE_CHANNEL = "reflexive"
+_REFLEXIVE_PATH_SELECTOR = (
+    'coalesce(relationship.propagation_channel, relationship.channel, '
+    'relationship.impact_channel) = "reflexive"'
+)
+
+
+def run_reflexive_propagation(
+    context: PropagationContext,
+    client: Neo4jClient,
+    *,
+    graph_name: str | None = None,
+    max_iterations: int = 20,
+    result_limit: int = 100,
+) -> PropagationResult:
+    """Run weighted PageRank for reflexive-tagged relationships."""
+
+    if _REFLEXIVE_CHANNEL not in context.enabled_channels:
+        raise PermissionError("reflexive propagation requires the reflexive channel")
+    if max_iterations < 1:
+        raise ValueError("max_iterations must be greater than zero")
+    if result_limit < 1:
+        raise ValueError("result_limit must be greater than zero")
+
+    projection_name = graph_name or _default_projection_name(context)
+    _drop_projection_if_exists(client, projection_name)
+    try:
+        if _count_reflexive_relationships(client) == 0:
+            pagerank_entities: list[dict[str, Any]] = []
+            activated_paths: list[dict[str, Any]] = []
+        else:
+            _create_projection(client, projection_name)
+            pagerank_entities = _stream_pagerank(
+                client,
+                projection_name,
+                max_iterations=max_iterations,
+                result_limit=result_limit,
+            )
+            activated_paths = _read_activated_paths(
+                context,
+                client,
+                result_limit=result_limit,
+            )
+    finally:
+        _drop_projection_if_exists(client, projection_name)
+
+    impacted_entities = _impacted_entities_from_paths(
+        activated_paths,
+        pagerank_entities,
+        result_limit=result_limit,
+    )
+    channel_breakdown: dict[str, Any] = {
+        _REFLEXIVE_CHANNEL: {
+            "path_selector": _REFLEXIVE_PATH_SELECTOR,
+            "path_count": len(activated_paths),
+            "impacted_entity_count": len(impacted_entities),
+            "total_path_score": sum(float(path["score"]) for path in activated_paths),
+            "channel_multiplier": _context_multiplier(context.channel_multipliers),
+            "regime_multiplier": _context_multiplier(context.regime_multipliers),
+        },
+    }
+    return PropagationResult(
+        cycle_id=context.cycle_id,
+        graph_generation_id=context.graph_generation_id,
+        activated_paths=activated_paths,
+        impacted_entities=impacted_entities,
+        channel_breakdown=channel_breakdown,
+    )
+
+
+def _default_projection_name(context: PropagationContext) -> str:
+    cycle_component = re.sub(r"[^A-Za-z0-9_]", "_", context.cycle_id).strip("_")
+    cycle_component = (cycle_component or "cycle")[:64]
+    return f"graph_engine_reflexive_{cycle_component}_{uuid4().hex[:8]}"
+
+
+def _count_reflexive_relationships(client: Neo4jClient) -> int:
+    rows = client.execute_read(
+        f"""
+MATCH ()-[relationship]->()
+WHERE {_REFLEXIVE_PATH_SELECTOR}
+RETURN count(relationship) AS relationship_count
+""",
+        {},
+    )
+    if not rows:
+        return 0
+    return int(rows[0].get("relationship_count") or 0)
+
+
+def _create_projection(client: Neo4jClient, graph_name: str) -> None:
+    _execute_gds_write(
+        client,
+        f"""
+MATCH (source)-[relationship]->(target)
+WHERE {_REFLEXIVE_PATH_SELECTOR}
+WITH gds.graph.project(
+    $graph_name,
+    source,
+    target,
+    {{
+        relationshipType: type(relationship),
+        relationshipProperties: {{
+            weight: coalesce(relationship.weight, 1.0)
+        }}
+    }}
+) AS projection
+RETURN projection.graphName AS graphName,
+       projection.nodeCount AS nodeCount,
+       projection.relationshipCount AS relationshipCount
+""",
+        {"graph_name": graph_name},
+    )
+
+
+def _stream_pagerank(
+    client: Neo4jClient,
+    graph_name: str,
+    *,
+    max_iterations: int,
+    result_limit: int,
+) -> list[dict[str, Any]]:
+    rows = _execute_gds_read(
+        client,
+        """
+CALL gds.pageRank.stream($graph_name, {
+    maxIterations: $max_iterations,
+    relationshipWeightProperty: "weight"
+})
+YIELD nodeId, score
+WITH gds.util.asNode(nodeId) AS node, score
+WITH node,
+     score,
+     coalesce(node.node_id, elementId(node)) AS stable_node_id
+RETURN node.node_id AS node_id,
+       node.canonical_entity_id AS canonical_entity_id,
+       labels(node) AS labels,
+       stable_node_id,
+       score
+ORDER BY score DESC, stable_node_id ASC
+LIMIT $result_limit
+""",
+        {
+            "graph_name": graph_name,
+            "max_iterations": max_iterations,
+            "result_limit": result_limit,
+        },
+    )
+    impacted_entities = [_pagerank_entity(row) for row in rows]
+    impacted_entities.sort(
+        key=lambda entity: (-float(entity["score"]), str(entity["stable_node_id"])),
+    )
+    return impacted_entities[:result_limit]
+
+
+def _read_activated_paths(
+    context: PropagationContext,
+    client: Neo4jClient,
+    *,
+    result_limit: int,
+) -> list[dict[str, Any]]:
+    channel_multiplier = _context_multiplier(context.channel_multipliers)
+    regime_multiplier = _context_multiplier(context.regime_multipliers)
+    rows = client.execute_read(
+        f"""
+MATCH (source)-[relationship]->(target)
+WHERE {_REFLEXIVE_PATH_SELECTOR}
+WITH source,
+     relationship,
+     target,
+     coalesce(relationship.weight, 1.0) AS relation_weight,
+     coalesce(relationship.evidence_confidence, 1.0) AS evidence_confidence,
+     coalesce(relationship.recency_decay, 1.0) AS recency_decay
+WITH source,
+     relationship,
+     target,
+     relation_weight,
+     evidence_confidence,
+     recency_decay,
+     relation_weight
+         * evidence_confidence
+         * $channel_multiplier
+         * $regime_multiplier
+         * recency_decay AS path_score
+RETURN source.node_id AS source_node_id,
+       source.canonical_entity_id AS source_entity_id,
+       labels(source) AS source_labels,
+       target.node_id AS target_node_id,
+       target.canonical_entity_id AS target_entity_id,
+       labels(target) AS target_labels,
+       relationship.edge_id AS edge_id,
+       type(relationship) AS relationship_type,
+       relation_weight,
+       evidence_confidence,
+       recency_decay,
+       path_score
+ORDER BY path_score DESC,
+         source_node_id ASC,
+         relationship_type ASC,
+         target_node_id ASC,
+         edge_id ASC
+LIMIT $result_limit
+""",
+        {
+            "result_limit": result_limit,
+            "channel_multiplier": channel_multiplier,
+            "regime_multiplier": regime_multiplier,
+        },
+    )
+
+    activated_paths = [
+        _activated_path(row, channel_multiplier, regime_multiplier)
+        for row in rows
+    ]
+    activated_paths.sort(
+        key=lambda path: (
+            -float(path["score"]),
+            str(path["source_node_id"]),
+            str(path["relationship_type"]),
+            str(path["target_node_id"]),
+            str(path["edge_id"]),
+        ),
+    )
+    return activated_paths[:result_limit]
+
+
+def _activated_path(
+    row: dict[str, Any],
+    channel_multiplier: float,
+    regime_multiplier: float,
+) -> dict[str, Any]:
+    relation_weight = _float_value(row.get("relation_weight"), default=1.0)
+    evidence_confidence = _float_value(row.get("evidence_confidence"), default=1.0)
+    recency_decay = _float_value(row.get("recency_decay"), default=1.0)
+    explanation = build_score_explanation(
+        relation_weight=relation_weight,
+        evidence_confidence=evidence_confidence,
+        channel_multiplier=channel_multiplier,
+        regime_multiplier=regime_multiplier,
+        recency_decay=recency_decay,
+    )
+
+    return {
+        "channel": _REFLEXIVE_CHANNEL,
+        "source_node_id": row.get("source_node_id"),
+        "source_entity_id": row.get("source_entity_id"),
+        "source_labels": _string_list(row.get("source_labels")),
+        "target_node_id": row.get("target_node_id"),
+        "target_entity_id": row.get("target_entity_id"),
+        "target_labels": _string_list(row.get("target_labels")),
+        "edge_id": row.get("edge_id"),
+        "relationship_type": row.get("relationship_type"),
+        "score": explanation["score"],
+        "explanation": explanation,
+    }
+
+
+def _pagerank_entity(row: dict[str, Any]) -> dict[str, Any]:
+    stable_node_id = str(row.get("stable_node_id") or row.get("node_id") or "")
+    return {
+        "channel": _REFLEXIVE_CHANNEL,
+        "node_id": row.get("node_id"),
+        "canonical_entity_id": row.get("canonical_entity_id"),
+        "labels": _string_list(row.get("labels")),
+        "score": _float_value(row.get("score"), default=0.0),
+        "stable_node_id": stable_node_id,
+    }
+
+
+def _impacted_entities_from_paths(
+    activated_paths: list[dict[str, Any]],
+    pagerank_entities: list[dict[str, Any]],
+    *,
+    result_limit: int,
+) -> list[dict[str, Any]]:
+    pagerank_by_node_id = {
+        str(entity.get("node_id")): _float_value(entity.get("score"), default=0.0)
+        for entity in pagerank_entities
+        if entity.get("node_id") is not None
+    }
+    impacted_by_node_id: dict[str, dict[str, Any]] = {}
+    for path in activated_paths:
+        target_node_id = path.get("target_node_id")
+        if target_node_id is None:
+            continue
+
+        node_id = str(target_node_id)
+        impact = impacted_by_node_id.setdefault(
+            node_id,
+            {
+                "channel": _REFLEXIVE_CHANNEL,
+                "node_id": target_node_id,
+                "canonical_entity_id": path.get("target_entity_id"),
+                "labels": _string_list(path.get("target_labels")),
+                "score": 0.0,
+                "stable_node_id": node_id,
+                "pagerank_score": pagerank_by_node_id.get(node_id, 0.0),
+                "path_count": 0,
+            },
+        )
+        impact["score"] = float(impact["score"]) + _float_value(
+            path.get("score"),
+            default=0.0,
+        )
+        impact["path_count"] = int(impact["path_count"]) + 1
+
+    impacted_entities = list(impacted_by_node_id.values())
+    impacted_entities.sort(
+        key=lambda entity: (
+            -float(entity["score"]),
+            str(entity["stable_node_id"]),
+        ),
+    )
+    return impacted_entities[:result_limit]
+
+
+def _context_multiplier(multipliers: dict[str, float]) -> float:
+    return float(multipliers.get(_REFLEXIVE_CHANNEL, 1.0))
+
+
+def _float_value(value: Any, *, default: float) -> float:
+    if value is None:
+        return default
+    return float(value)
+
+
+def _string_list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return sorted(str(item) for item in value)

--- a/graph_engine/propagation/reflexive.py
+++ b/graph_engine/propagation/reflexive.py
@@ -8,12 +8,13 @@ from uuid import uuid4
 
 from graph_engine.client import Neo4jClient
 from graph_engine.models import PropagationContext, PropagationResult
-from graph_engine.propagation.fundamental import (
-    _drop_projection_if_exists,
-    _execute_gds_read,
-    _execute_gds_write,
+from graph_engine.propagation._gds import (
+    drop_projection_if_exists,
+    execute_gds_read,
+    execute_gds_write,
 )
 from graph_engine.propagation.scoring import build_score_explanation
+from graph_engine.status import GraphStatusManager, require_ready_read
 
 _REFLEXIVE_CHANNEL = "reflexive"
 _REFLEXIVE_PATH_SELECTOR = (
@@ -26,6 +27,7 @@ def run_reflexive_propagation(
     context: PropagationContext,
     client: Neo4jClient,
     *,
+    status_manager: GraphStatusManager,
     graph_name: str | None = None,
     max_iterations: int = 20,
     result_limit: int = 100,
@@ -39,14 +41,22 @@ def run_reflexive_propagation(
     if result_limit < 1:
         raise ValueError("result_limit must be greater than zero")
 
+    ready_status = require_ready_read(status_manager, "reflexive propagation")
+    if ready_status.graph_generation_id != context.graph_generation_id:
+        raise ValueError(
+            "PropagationContext graph_generation_id disagrees with Neo4jGraphStatus: "
+            f"context={context.graph_generation_id}, "
+            f"status={ready_status.graph_generation_id}",
+        )
+
     projection_name = graph_name or _default_projection_name(context)
-    _drop_projection_if_exists(client, projection_name)
+    drop_projection_if_exists(client, projection_name)
     try:
-        if _count_reflexive_relationships(client) == 0:
+        relationship_count = _create_projection(client, projection_name)
+        if relationship_count == 0:
             pagerank_entities: list[dict[str, Any]] = []
             activated_paths: list[dict[str, Any]] = []
         else:
-            _create_projection(client, projection_name)
             pagerank_entities = _stream_pagerank(
                 client,
                 projection_name,
@@ -59,7 +69,7 @@ def run_reflexive_propagation(
                 result_limit=result_limit,
             )
     finally:
-        _drop_projection_if_exists(client, projection_name)
+        drop_projection_if_exists(client, projection_name)
 
     impacted_entities = _impacted_entities_from_paths(
         activated_paths,
@@ -91,22 +101,8 @@ def _default_projection_name(context: PropagationContext) -> str:
     return f"graph_engine_reflexive_{cycle_component}_{uuid4().hex[:8]}"
 
 
-def _count_reflexive_relationships(client: Neo4jClient) -> int:
-    rows = client.execute_read(
-        f"""
-MATCH ()-[relationship]->()
-WHERE {_REFLEXIVE_PATH_SELECTOR}
-RETURN count(relationship) AS relationship_count
-""",
-        {},
-    )
-    if not rows:
-        return 0
-    return int(rows[0].get("relationship_count") or 0)
-
-
-def _create_projection(client: Neo4jClient, graph_name: str) -> None:
-    _execute_gds_write(
+def _create_projection(client: Neo4jClient, graph_name: str) -> int:
+    rows = execute_gds_write(
         client,
         f"""
 MATCH (source)-[relationship]->(target)
@@ -128,6 +124,9 @@ RETURN projection.graphName AS graphName,
 """,
         {"graph_name": graph_name},
     )
+    if not rows:
+        return 0
+    return int(rows[0].get("relationshipCount") or 0)
 
 
 def _stream_pagerank(
@@ -137,7 +136,7 @@ def _stream_pagerank(
     max_iterations: int,
     result_limit: int,
 ) -> list[dict[str, Any]]:
-    rows = _execute_gds_read(
+    rows = execute_gds_read(
         client,
         """
 CALL gds.pageRank.stream($graph_name, {

--- a/tests/unit/test_propagation.py
+++ b/tests/unit/test_propagation.py
@@ -5,6 +5,7 @@ from datetime import datetime, timezone
 from typing import Any
 
 import pytest
+from pydantic import ValidationError
 
 from graph_engine.models import Neo4jGraphStatus, PropagationContext
 from graph_engine.propagation import (
@@ -161,10 +162,62 @@ def test_build_propagation_context_reads_regime_context_only() -> None:
     )
 
     assert reader.calls == ["world-state-1"]
+    assert context.enabled_channels == ["fundamental"]
     assert context.channel_multipliers == {"fundamental": 1.25}
     assert context.regime_multipliers == {"fundamental": 0.8}
     assert context.decay_policy == {"half_life_days": 30}
     assert "main_core" not in sys.modules
+
+
+def test_propagation_context_accepts_all_channels_and_rejects_duplicates() -> None:
+    context = PropagationContext(
+        cycle_id="cycle-1",
+        world_state_ref="world-state-1",
+        graph_generation_id=1,
+        enabled_channels=["fundamental", "event", "reflexive"],
+        channel_multipliers={"fundamental": 1.0, "event": 1.0, "reflexive": 1.0},
+        regime_multipliers={"fundamental": 1.0, "event": 1.0, "reflexive": 1.0},
+        decay_policy={},
+        regime_context={},
+    )
+
+    assert context.enabled_channels == ["fundamental", "event", "reflexive"]
+
+    with pytest.raises(ValidationError, match="duplicates"):
+        PropagationContext(
+            cycle_id="cycle-1",
+            world_state_ref="world-state-1",
+            graph_generation_id=1,
+            enabled_channels=["event", "event"],
+            channel_multipliers={"event": 1.0},
+            regime_multipliers={"event": 1.0},
+            decay_policy={},
+            regime_context={},
+        )
+
+
+def test_build_propagation_context_reads_multipliers_for_requested_channels() -> None:
+    reader = StaticRegimeReader(
+        {
+            "channel_multipliers": {"event": 2.5},
+            "regime_multipliers": {"reflexive": 0.25},
+            "decay_policy": {"half_life_days": 3},
+        }
+    )
+
+    context = build_propagation_context(
+        "cycle-1",
+        "world-state-1",
+        7,
+        regime_reader=reader,
+        enabled_channels=["event", "reflexive"],
+    )
+
+    assert reader.calls == ["world-state-1"]
+    assert context.enabled_channels == ["event", "reflexive"]
+    assert context.channel_multipliers == {"event": 2.5, "reflexive": 1.0}
+    assert context.regime_multipliers == {"event": 1.0, "reflexive": 0.25}
+    assert context.decay_policy == {"half_life_days": 3}
 
 
 def test_build_propagation_context_rejects_non_ready_status_before_reading() -> None:

--- a/tests/unit/test_propagation_event.py
+++ b/tests/unit/test_propagation_event.py
@@ -1,11 +1,16 @@
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from typing import Any
 
 import pytest
 
-from graph_engine.models import PropagationContext
+from graph_engine.models import Neo4jGraphStatus, PropagationContext
 from graph_engine.propagation import EVENT_RELATIONSHIP_TYPES, run_event_propagation
+from graph_engine.status import GraphStatusManager
+from tests.fakes import InMemoryStatusStore
+
+NOW = datetime(2026, 4, 17, 1, 2, 3, tzinfo=timezone.utc)
 
 
 class FakeEventGDSClient:
@@ -87,6 +92,40 @@ def test_run_event_propagation_requires_event_channel_before_neo4j_reads() -> No
         run_event_propagation(
             _context(enabled_channels=["fundamental"]),
             client,  # type: ignore[arg-type]
+            status_manager=_status_manager(),
+            graph_name="unit-event",
+        )
+
+    assert client.read_calls == []
+    assert client.write_calls == []
+
+
+@pytest.mark.parametrize("graph_status", ["rebuilding", "failed"])
+def test_run_event_propagation_blocks_non_ready_before_neo4j_reads(
+    graph_status: str,
+) -> None:
+    client = FakeEventGDSClient()
+
+    with pytest.raises(PermissionError, match="ready"):
+        run_event_propagation(
+            _context(),
+            client,  # type: ignore[arg-type]
+            status_manager=_status_manager(graph_status=graph_status),
+            graph_name="unit-event",
+        )
+
+    assert client.read_calls == []
+    assert client.write_calls == []
+
+
+def test_run_event_propagation_blocks_generation_mismatch_before_neo4j_reads() -> None:
+    client = FakeEventGDSClient()
+
+    with pytest.raises(ValueError, match="graph_generation_id"):
+        run_event_propagation(
+            _context(),
+            client,  # type: ignore[arg-type]
+            status_manager=_status_manager(graph_generation_id=2),
             graph_name="unit-event",
         )
 
@@ -128,6 +167,7 @@ def test_run_event_propagation_uses_projection_and_explains_paths() -> None:
     result = run_event_propagation(
         _context(),
         client,  # type: ignore[arg-type]
+        status_manager=_status_manager(),
         graph_name="unit-event",
         max_iterations=7,
         result_limit=2,
@@ -189,6 +229,7 @@ def test_run_event_propagation_cleans_up_projection_on_exception() -> None:
         run_event_propagation(
             _context(),
             client,  # type: ignore[arg-type]
+            status_manager=_status_manager(),
             graph_name="unit-event",
         )
 
@@ -204,6 +245,7 @@ def test_run_event_propagation_reports_missing_gds_consistently() -> None:
         run_event_propagation(
             _context(),
             client,  # type: ignore[arg-type]
+            status_manager=_status_manager(),
             graph_name="unit-event",
         )
 
@@ -218,6 +260,29 @@ def _context(*, enabled_channels: list[str] | None = None) -> PropagationContext
         regime_multipliers={"event": 0.5},
         decay_policy={},
         regime_context={},
+    )
+
+
+def _status_manager(
+    *,
+    graph_status: str = "ready",
+    graph_generation_id: int = 1,
+    writer_lock_token: str | None = None,
+) -> GraphStatusManager:
+    return GraphStatusManager(
+        InMemoryStatusStore(
+            Neo4jGraphStatus(
+                graph_status=graph_status,  # type: ignore[arg-type]
+                graph_generation_id=graph_generation_id,
+                node_count=2,
+                edge_count=1,
+                key_label_counts={"Entity": 2},
+                checksum="abc123" if graph_status == "ready" else graph_status,
+                last_verified_at=NOW if graph_status == "ready" else None,
+                last_reload_at=None,
+                writer_lock_token=writer_lock_token,
+            ),
+        ),
     )
 
 

--- a/tests/unit/test_propagation_event.py
+++ b/tests/unit/test_propagation_event.py
@@ -1,0 +1,261 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from graph_engine.models import PropagationContext
+from graph_engine.propagation import EVENT_RELATIONSHIP_TYPES, run_event_propagation
+
+
+class FakeEventGDSClient:
+    def __init__(
+        self,
+        *,
+        exists_results: list[bool] | None = None,
+        fail_on_gds_exists: bool = False,
+        fail_on_pagerank: bool = False,
+        path_rows: list[dict[str, Any]] | None = None,
+    ) -> None:
+        self.exists_results = exists_results or [False, True]
+        self.fail_on_gds_exists = fail_on_gds_exists
+        self.fail_on_pagerank = fail_on_pagerank
+        self.path_rows = path_rows or []
+        self.read_calls: list[tuple[str, dict[str, Any]]] = []
+        self.write_calls: list[tuple[str, dict[str, Any]]] = []
+
+    def execute_read(
+        self,
+        query: str,
+        parameters: dict[str, Any] | None = None,
+    ) -> list[dict[str, Any]]:
+        params = parameters or {}
+        self.read_calls.append((query, params))
+        if "gds.graph.exists" in query:
+            if self.fail_on_gds_exists:
+                raise RuntimeError(
+                    "There is no procedure with the name `gds.graph.exists` registered"
+                )
+            exists = self.exists_results.pop(0) if self.exists_results else False
+            return [{"exists": exists}]
+        if "gds.pageRank.stream" in query:
+            if self.fail_on_pagerank:
+                raise RuntimeError("pagerank failed")
+            return [
+                {
+                    "node_id": "node-c",
+                    "canonical_entity_id": "entity-c",
+                    "labels": ["Entity"],
+                    "stable_node_id": "node-c",
+                    "score": 0.7,
+                },
+                {
+                    "node_id": "node-b",
+                    "canonical_entity_id": "entity-b",
+                    "labels": ["Entity"],
+                    "stable_node_id": "node-b",
+                    "score": 0.3,
+                },
+            ]
+        if "MATCH (source)-[relationship]->(target)" in query:
+            rows = list(self.path_rows)
+            rows.sort(
+                key=lambda row: (
+                    -_path_score(row, params),
+                    str(row["source_node_id"]),
+                    str(row["relationship_type"]),
+                    str(row["target_node_id"]),
+                    str(row["edge_id"]),
+                ),
+            )
+            return rows[: int(params.get("result_limit", len(rows)))]
+        return []
+
+    def execute_write(
+        self,
+        query: str,
+        parameters: dict[str, Any] | None = None,
+    ) -> list[dict[str, Any]]:
+        self.write_calls.append((query, parameters or {}))
+        return []
+
+
+def test_run_event_propagation_requires_event_channel_before_neo4j_reads() -> None:
+    client = FakeEventGDSClient()
+
+    with pytest.raises(PermissionError, match="event channel"):
+        run_event_propagation(
+            _context(enabled_channels=["fundamental"]),
+            client,  # type: ignore[arg-type]
+            graph_name="unit-event",
+        )
+
+    assert client.read_calls == []
+    assert client.write_calls == []
+
+
+def test_run_event_propagation_uses_projection_and_explains_paths() -> None:
+    client = FakeEventGDSClient(
+        exists_results=[True, True],
+        path_rows=[
+            _path_row(
+                edge_id="edge-zero",
+                target_node_id="node-zero",
+                target_entity_id="entity-zero",
+                relation_weight=100.0,
+                evidence_confidence=0.0,
+                recency_decay=1.0,
+            ),
+            _path_row(
+                edge_id="edge-mid",
+                target_node_id="node-b",
+                target_entity_id="entity-b",
+                relation_weight=1.0,
+                evidence_confidence=0.5,
+                recency_decay=1.0,
+            ),
+            _path_row(
+                edge_id="edge-top",
+                target_node_id="node-c",
+                target_entity_id="entity-c",
+                relation_weight=2.0,
+                evidence_confidence=1.0,
+                recency_decay=1.0,
+            ),
+        ],
+    )
+
+    result = run_event_propagation(
+        _context(),
+        client,  # type: ignore[arg-type]
+        graph_name="unit-event",
+        max_iterations=7,
+        result_limit=2,
+    )
+
+    write_queries = [query for query, _ in client.write_calls]
+    assert "gds.graph.drop" in write_queries[0]
+    assert "gds.graph.project" in write_queries[1]
+    assert "gds.graph.drop" in write_queries[2]
+    assert all(" SET " not in query and " DELETE " not in query for query in write_queries)
+
+    projection_params = client.write_calls[1][1]
+    assert projection_params["graph_name"] == "unit-event"
+    assert set(projection_params["relationship_projection"]) == set(EVENT_RELATIONSHIP_TYPES)
+
+    pagerank_call = next(
+        (query, params)
+        for query, params in client.read_calls
+        if "gds.pageRank.stream" in query
+    )
+    assert pagerank_call[1]["max_iterations"] == 7
+    assert pagerank_call[1]["result_limit"] == 2
+
+    path_call = next(
+        (query, params)
+        for query, params in client.read_calls
+        if "MATCH (source)-[relationship]->(target)" in query
+    )
+    assert "ORDER BY path_score DESC" in path_call[0]
+    assert path_call[1]["relationship_types"] == list(EVENT_RELATIONSHIP_TYPES)
+
+    assert [path["edge_id"] for path in result.activated_paths] == ["edge-top", "edge-mid"]
+    assert result.activated_paths[0]["channel"] == "event"
+    assert result.activated_paths[0]["explanation"] == {
+        "relation_weight": 2.0,
+        "evidence_confidence": 1.0,
+        "channel_multiplier": 2.0,
+        "regime_multiplier": 0.5,
+        "recency_decay": 1.0,
+        "score": 2.0,
+    }
+    assert [entity["node_id"] for entity in result.impacted_entities] == ["node-c", "node-b"]
+    assert result.impacted_entities[0]["pagerank_score"] == pytest.approx(0.7)
+    assert result.impacted_entities[0]["path_count"] == 1
+    assert result.channel_breakdown["event"] == {
+        "relationship_types": list(EVENT_RELATIONSHIP_TYPES),
+        "path_count": 2,
+        "impacted_entity_count": 2,
+        "total_path_score": 2.5,
+        "channel_multiplier": 2.0,
+        "regime_multiplier": 0.5,
+    }
+
+
+def test_run_event_propagation_cleans_up_projection_on_exception() -> None:
+    client = FakeEventGDSClient(exists_results=[False, True], fail_on_pagerank=True)
+
+    with pytest.raises(RuntimeError, match="pagerank failed"):
+        run_event_propagation(
+            _context(),
+            client,  # type: ignore[arg-type]
+            graph_name="unit-event",
+        )
+
+    write_queries = [query for query, _ in client.write_calls]
+    assert any("gds.graph.project" in query for query in write_queries)
+    assert any("gds.graph.drop" in query for query in write_queries)
+
+
+def test_run_event_propagation_reports_missing_gds_consistently() -> None:
+    client = FakeEventGDSClient(fail_on_gds_exists=True)
+
+    with pytest.raises(RuntimeError, match="^GDS plugin not available$"):
+        run_event_propagation(
+            _context(),
+            client,  # type: ignore[arg-type]
+            graph_name="unit-event",
+        )
+
+
+def _context(*, enabled_channels: list[str] | None = None) -> PropagationContext:
+    return PropagationContext(
+        cycle_id="cycle-1",
+        world_state_ref="world-state-1",
+        graph_generation_id=1,
+        enabled_channels=enabled_channels or ["event"],  # type: ignore[arg-type]
+        channel_multipliers={"event": 2.0},
+        regime_multipliers={"event": 0.5},
+        decay_policy={},
+        regime_context={},
+    )
+
+
+def _path_row(
+    *,
+    edge_id: str,
+    target_node_id: str,
+    target_entity_id: str,
+    relation_weight: float,
+    evidence_confidence: float,
+    recency_decay: float,
+) -> dict[str, Any]:
+    return {
+        "source_node_id": "node-a",
+        "source_entity_id": "entity-a",
+        "source_labels": ["Entity"],
+        "target_node_id": target_node_id,
+        "target_entity_id": target_entity_id,
+        "target_labels": ["Entity"],
+        "edge_id": edge_id,
+        "relationship_type": EVENT_RELATIONSHIP_TYPES[0],
+        "relation_weight": relation_weight,
+        "evidence_confidence": evidence_confidence,
+        "recency_decay": recency_decay,
+    }
+
+
+def _path_score(row: dict[str, Any], params: dict[str, Any]) -> float:
+    return (
+        _float_or_default(row.get("relation_weight"))
+        * _float_or_default(row.get("evidence_confidence"))
+        * float(params.get("channel_multiplier", 1.0))
+        * float(params.get("regime_multiplier", 1.0))
+        * _float_or_default(row.get("recency_decay"))
+    )
+
+
+def _float_or_default(value: Any, default: float = 1.0) -> float:
+    if value is None:
+        return default
+    return float(value)

--- a/tests/unit/test_propagation_reflexive.py
+++ b/tests/unit/test_propagation_reflexive.py
@@ -1,0 +1,289 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from graph_engine.models import PropagationContext
+from graph_engine.propagation import run_reflexive_propagation
+
+
+class FakeReflexiveGDSClient:
+    def __init__(
+        self,
+        *,
+        exists_results: list[bool] | None = None,
+        fail_on_pagerank: bool = False,
+        path_rows: list[dict[str, Any]] | None = None,
+    ) -> None:
+        self.exists_results = exists_results or [False, True]
+        self.fail_on_pagerank = fail_on_pagerank
+        self.path_rows = path_rows or []
+        self.read_calls: list[tuple[str, dict[str, Any]]] = []
+        self.write_calls: list[tuple[str, dict[str, Any]]] = []
+
+    def execute_read(
+        self,
+        query: str,
+        parameters: dict[str, Any] | None = None,
+    ) -> list[dict[str, Any]]:
+        params = parameters or {}
+        self.read_calls.append((query, params))
+        if "gds.graph.exists" in query:
+            exists = self.exists_results.pop(0) if self.exists_results else False
+            return [{"exists": exists}]
+        if "RETURN count(relationship) AS relationship_count" in query:
+            return [{"relationship_count": len(self._reflexive_rows())}]
+        if "gds.pageRank.stream" in query:
+            if self.fail_on_pagerank:
+                raise RuntimeError("pagerank failed")
+            return [
+                {
+                    "node_id": "node-c",
+                    "canonical_entity_id": "entity-c",
+                    "labels": ["Entity"],
+                    "stable_node_id": "node-c",
+                    "score": 0.8,
+                },
+                {
+                    "node_id": "node-b",
+                    "canonical_entity_id": "entity-b",
+                    "labels": ["Entity"],
+                    "stable_node_id": "node-b",
+                    "score": 0.4,
+                },
+            ]
+        if "MATCH (source)-[relationship]->(target)" in query:
+            rows = self._reflexive_rows()
+            rows.sort(
+                key=lambda row: (
+                    -_path_score(row, params),
+                    str(row["source_node_id"]),
+                    str(row["relationship_type"]),
+                    str(row["target_node_id"]),
+                    str(row["edge_id"]),
+                ),
+            )
+            return rows[: int(params.get("result_limit", len(rows)))]
+        return []
+
+    def execute_write(
+        self,
+        query: str,
+        parameters: dict[str, Any] | None = None,
+    ) -> list[dict[str, Any]]:
+        self.write_calls.append((query, parameters or {}))
+        return []
+
+    def _reflexive_rows(self) -> list[dict[str, Any]]:
+        return [
+            row
+            for row in self.path_rows
+            if row.get("propagation_channel") == "reflexive"
+            or row.get("channel") == "reflexive"
+            or row.get("impact_channel") == "reflexive"
+        ]
+
+
+def test_run_reflexive_propagation_requires_reflexive_channel_before_neo4j_reads() -> None:
+    client = FakeReflexiveGDSClient()
+
+    with pytest.raises(PermissionError, match="reflexive channel"):
+        run_reflexive_propagation(
+            _context(enabled_channels=["event"]),
+            client,  # type: ignore[arg-type]
+            graph_name="unit-reflexive",
+        )
+
+    assert client.read_calls == []
+    assert client.write_calls == []
+
+
+def test_run_reflexive_propagation_filters_tagged_paths_and_explains_scores() -> None:
+    client = FakeReflexiveGDSClient(
+        exists_results=[True, True],
+        path_rows=[
+            _path_row(
+                edge_id="edge-untagged",
+                target_node_id="node-untagged",
+                target_entity_id="entity-untagged",
+                relation_weight=100.0,
+                evidence_confidence=1.0,
+                recency_decay=1.0,
+            ),
+            _path_row(
+                edge_id="edge-mid",
+                target_node_id="node-b",
+                target_entity_id="entity-b",
+                relation_weight=1.0,
+                evidence_confidence=0.5,
+                recency_decay=1.0,
+                channel="reflexive",
+            ),
+            _path_row(
+                edge_id="edge-top",
+                target_node_id="node-c",
+                target_entity_id="entity-c",
+                relation_weight=2.0,
+                evidence_confidence=1.0,
+                recency_decay=1.0,
+                impact_channel="reflexive",
+            ),
+        ],
+    )
+
+    result = run_reflexive_propagation(
+        _context(),
+        client,  # type: ignore[arg-type]
+        graph_name="unit-reflexive",
+        max_iterations=8,
+        result_limit=10,
+    )
+
+    write_queries = [query for query, _ in client.write_calls]
+    assert "gds.graph.drop" in write_queries[0]
+    assert "gds.graph.project" in write_queries[1]
+    assert "gds.graph.drop" in write_queries[2]
+    assert all(" SET " not in query and " DELETE " not in query for query in write_queries)
+    assert client.write_calls[1][1]["graph_name"] == "unit-reflexive"
+    assert "relationship.propagation_channel" in write_queries[1]
+    assert 'relationship.impact_channel) = "reflexive"' in write_queries[1]
+
+    path_query = next(
+        query
+        for query, _ in client.read_calls
+        if "MATCH (source)-[relationship]->(target)" in query
+    )
+    assert "coalesce(relationship.propagation_channel" in path_query
+    assert 'relationship.impact_channel) = "reflexive"' in path_query
+
+    pagerank_call = next(
+        (query, params)
+        for query, params in client.read_calls
+        if "gds.pageRank.stream" in query
+    )
+    assert pagerank_call[1]["max_iterations"] == 8
+
+    assert [path["edge_id"] for path in result.activated_paths] == ["edge-top", "edge-mid"]
+    assert {path["edge_id"] for path in result.activated_paths}.isdisjoint({"edge-untagged"})
+    assert result.activated_paths[0]["channel"] == "reflexive"
+    assert result.activated_paths[0]["explanation"] == {
+        "relation_weight": 2.0,
+        "evidence_confidence": 1.0,
+        "channel_multiplier": 2.0,
+        "regime_multiplier": 0.5,
+        "recency_decay": 1.0,
+        "score": 2.0,
+    }
+    assert [entity["node_id"] for entity in result.impacted_entities] == ["node-c", "node-b"]
+    assert result.impacted_entities[0]["pagerank_score"] == pytest.approx(0.8)
+    assert result.channel_breakdown["reflexive"]["path_count"] == 2
+    assert result.channel_breakdown["reflexive"]["impacted_entity_count"] == 2
+    assert result.channel_breakdown["reflexive"]["total_path_score"] == pytest.approx(2.5)
+    assert "path_selector" in result.channel_breakdown["reflexive"]
+
+
+def test_run_reflexive_propagation_returns_empty_result_for_empty_projection() -> None:
+    client = FakeReflexiveGDSClient(exists_results=[False, False], path_rows=[])
+
+    result = run_reflexive_propagation(
+        _context(),
+        client,  # type: ignore[arg-type]
+        graph_name="unit-reflexive",
+    )
+
+    assert result.activated_paths == []
+    assert result.impacted_entities == []
+    assert result.channel_breakdown["reflexive"]["path_count"] == 0
+    assert result.channel_breakdown["reflexive"]["impacted_entity_count"] == 0
+    assert result.channel_breakdown["reflexive"]["total_path_score"] == 0
+    assert not any("gds.pageRank.stream" in query for query, _ in client.read_calls)
+    assert not any("gds.graph.project" in query for query, _ in client.write_calls)
+
+
+def test_run_reflexive_propagation_cleans_up_projection_on_exception() -> None:
+    client = FakeReflexiveGDSClient(
+        exists_results=[False, True],
+        fail_on_pagerank=True,
+        path_rows=[
+            _path_row(
+                edge_id="edge-1",
+                target_node_id="node-b",
+                target_entity_id="entity-b",
+                relation_weight=1.0,
+                evidence_confidence=1.0,
+                recency_decay=1.0,
+                propagation_channel="reflexive",
+            ),
+        ],
+    )
+
+    with pytest.raises(RuntimeError, match="pagerank failed"):
+        run_reflexive_propagation(
+            _context(),
+            client,  # type: ignore[arg-type]
+            graph_name="unit-reflexive",
+        )
+
+    write_queries = [query for query, _ in client.write_calls]
+    assert any("gds.graph.project" in query for query in write_queries)
+    assert any("gds.graph.drop" in query for query in write_queries)
+
+
+def _context(*, enabled_channels: list[str] | None = None) -> PropagationContext:
+    return PropagationContext(
+        cycle_id="cycle-1",
+        world_state_ref="world-state-1",
+        graph_generation_id=1,
+        enabled_channels=enabled_channels or ["reflexive"],  # type: ignore[arg-type]
+        channel_multipliers={"reflexive": 2.0},
+        regime_multipliers={"reflexive": 0.5},
+        decay_policy={},
+        regime_context={},
+    )
+
+
+def _path_row(
+    *,
+    edge_id: str,
+    target_node_id: str,
+    target_entity_id: str,
+    relation_weight: float,
+    evidence_confidence: float,
+    recency_decay: float,
+    propagation_channel: str | None = None,
+    channel: str | None = None,
+    impact_channel: str | None = None,
+) -> dict[str, Any]:
+    return {
+        "source_node_id": "node-a",
+        "source_entity_id": "entity-a",
+        "source_labels": ["Entity"],
+        "target_node_id": target_node_id,
+        "target_entity_id": target_entity_id,
+        "target_labels": ["Entity"],
+        "edge_id": edge_id,
+        "relationship_type": "REFLEXIVE_SIGNAL",
+        "relation_weight": relation_weight,
+        "evidence_confidence": evidence_confidence,
+        "recency_decay": recency_decay,
+        "propagation_channel": propagation_channel,
+        "channel": channel,
+        "impact_channel": impact_channel,
+    }
+
+
+def _path_score(row: dict[str, Any], params: dict[str, Any]) -> float:
+    return (
+        _float_or_default(row.get("relation_weight"))
+        * _float_or_default(row.get("evidence_confidence"))
+        * float(params.get("channel_multiplier", 1.0))
+        * float(params.get("regime_multiplier", 1.0))
+        * _float_or_default(row.get("recency_decay"))
+    )
+
+
+def _float_or_default(value: Any, default: float = 1.0) -> float:
+    if value is None:
+        return default
+    return float(value)

--- a/tests/unit/test_propagation_reflexive.py
+++ b/tests/unit/test_propagation_reflexive.py
@@ -1,11 +1,16 @@
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from typing import Any
 
 import pytest
 
-from graph_engine.models import PropagationContext
+from graph_engine.models import Neo4jGraphStatus, PropagationContext
 from graph_engine.propagation import run_reflexive_propagation
+from graph_engine.status import GraphStatusManager
+from tests.fakes import InMemoryStatusStore
+
+NOW = datetime(2026, 4, 17, 1, 2, 3, tzinfo=timezone.utc)
 
 
 class FakeReflexiveGDSClient:
@@ -32,8 +37,6 @@ class FakeReflexiveGDSClient:
         if "gds.graph.exists" in query:
             exists = self.exists_results.pop(0) if self.exists_results else False
             return [{"exists": exists}]
-        if "RETURN count(relationship) AS relationship_count" in query:
-            return [{"relationship_count": len(self._reflexive_rows())}]
         if "gds.pageRank.stream" in query:
             if self.fail_on_pagerank:
                 raise RuntimeError("pagerank failed")
@@ -73,6 +76,14 @@ class FakeReflexiveGDSClient:
         parameters: dict[str, Any] | None = None,
     ) -> list[dict[str, Any]]:
         self.write_calls.append((query, parameters or {}))
+        if "gds.graph.project" in query:
+            return [
+                {
+                    "graphName": (parameters or {}).get("graph_name"),
+                    "nodeCount": 2 if self._reflexive_rows() else 0,
+                    "relationshipCount": len(self._reflexive_rows()),
+                }
+            ]
         return []
 
     def _reflexive_rows(self) -> list[dict[str, Any]]:
@@ -92,6 +103,40 @@ def test_run_reflexive_propagation_requires_reflexive_channel_before_neo4j_reads
         run_reflexive_propagation(
             _context(enabled_channels=["event"]),
             client,  # type: ignore[arg-type]
+            status_manager=_status_manager(),
+            graph_name="unit-reflexive",
+        )
+
+    assert client.read_calls == []
+    assert client.write_calls == []
+
+
+@pytest.mark.parametrize("graph_status", ["rebuilding", "failed"])
+def test_run_reflexive_propagation_blocks_non_ready_before_neo4j_reads(
+    graph_status: str,
+) -> None:
+    client = FakeReflexiveGDSClient()
+
+    with pytest.raises(PermissionError, match="ready"):
+        run_reflexive_propagation(
+            _context(),
+            client,  # type: ignore[arg-type]
+            status_manager=_status_manager(graph_status=graph_status),
+            graph_name="unit-reflexive",
+        )
+
+    assert client.read_calls == []
+    assert client.write_calls == []
+
+
+def test_run_reflexive_propagation_blocks_generation_mismatch_before_neo4j_reads() -> None:
+    client = FakeReflexiveGDSClient()
+
+    with pytest.raises(ValueError, match="graph_generation_id"):
+        run_reflexive_propagation(
+            _context(),
+            client,  # type: ignore[arg-type]
+            status_manager=_status_manager(graph_generation_id=2),
             graph_name="unit-reflexive",
         )
 
@@ -135,6 +180,7 @@ def test_run_reflexive_propagation_filters_tagged_paths_and_explains_scores() ->
     result = run_reflexive_propagation(
         _context(),
         client,  # type: ignore[arg-type]
+        status_manager=_status_manager(),
         graph_name="unit-reflexive",
         max_iterations=8,
         result_limit=10,
@@ -189,6 +235,7 @@ def test_run_reflexive_propagation_returns_empty_result_for_empty_projection() -
     result = run_reflexive_propagation(
         _context(),
         client,  # type: ignore[arg-type]
+        status_manager=_status_manager(),
         graph_name="unit-reflexive",
     )
 
@@ -198,7 +245,8 @@ def test_run_reflexive_propagation_returns_empty_result_for_empty_projection() -
     assert result.channel_breakdown["reflexive"]["impacted_entity_count"] == 0
     assert result.channel_breakdown["reflexive"]["total_path_score"] == 0
     assert not any("gds.pageRank.stream" in query for query, _ in client.read_calls)
-    assert not any("gds.graph.project" in query for query, _ in client.write_calls)
+    assert any("gds.graph.project" in query for query, _ in client.write_calls)
+    assert not any("RETURN count(relationship)" in query for query, _ in client.read_calls)
 
 
 def test_run_reflexive_propagation_cleans_up_projection_on_exception() -> None:
@@ -222,6 +270,7 @@ def test_run_reflexive_propagation_cleans_up_projection_on_exception() -> None:
         run_reflexive_propagation(
             _context(),
             client,  # type: ignore[arg-type]
+            status_manager=_status_manager(),
             graph_name="unit-reflexive",
         )
 
@@ -240,6 +289,29 @@ def _context(*, enabled_channels: list[str] | None = None) -> PropagationContext
         regime_multipliers={"reflexive": 0.5},
         decay_policy={},
         regime_context={},
+    )
+
+
+def _status_manager(
+    *,
+    graph_status: str = "ready",
+    graph_generation_id: int = 1,
+    writer_lock_token: str | None = None,
+) -> GraphStatusManager:
+    return GraphStatusManager(
+        InMemoryStatusStore(
+            Neo4jGraphStatus(
+                graph_status=graph_status,  # type: ignore[arg-type]
+                graph_generation_id=graph_generation_id,
+                node_count=2,
+                edge_count=1,
+                key_label_counts={"Entity": 2},
+                checksum="abc123" if graph_status == "ready" else graph_status,
+                last_verified_at=NOW if graph_status == "ready" else None,
+                last_reload_at=None,
+                writer_lock_token=writer_lock_token,
+            ),
+        ),
     )
 
 


### PR DESCRIPTION
Closes #8

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `benchmarks/artifacts/lite_target_100k_800k.json`, `benchmarks/generate_synthetic.py`, `benchmarks/run_benchmark.py`, `cross-cutting`, `graph_engine/__pycache__/__init__.cpython-314.pyc`, `graph_engine/live_metrics.py`, `graph_engine/reload/service.py`, `graph_engine/sync/live_graph.py`, `project_ult_graph_engine.egg-info/SOURCES.txt`, `pyproject.toml`


---
### 1. 背景与目标
项目文档 §11.3 要求 `fundamental` / `event` / `reflexive` 三类传播都使用可解释的五因子 `path_score`，但当前代码只有 `graph_engine/propagation/fundamental.py` 的单通道实现。现有 `PropagationContext.enabled_channels` 在 `graph_engine/models.py` 中被限制为 `Literal["fundamental"]`，`build_propagation_context()` 也只读取 fundamental 的 multiplier。本 issue 的目标是在不触碰 promotion/sync/snapshot merge 的前提下，补齐 event 与 reflexive 两个独立传播 runner，并保持与现有 `run_fundamental_propagation()`、`build_score_explanation()` 的风格一致。

### 2. 所属模块
**主要写入路径：**
- `graph_engine/models.py`（扩展 `PropagationContext` 的 channel 类型约束）
- `graph_engine/propagation/context.py`（构建多通道 context，但默认行为保持 fundamental）
- `graph_engine/propagation/event.py`（新增 event 通道 runner）
- `graph_engine/propagation/reflexive.py`（新增 reflexive 通道 runner）
- `graph_engine/propagation/__init__.py`（导出新增 public entry points）
- `tests/unit/test_propagation.py`（补充 context 回归）
- `tests/unit/test_propagation_event.py`（新增 event 通道单测）
- `tests/unit/test_propagation_reflexive.py`（新增 reflexive 通道单测）

**相邻只读 / 集成路径：**
- `graph_engine/client.py`（沿用 `Neo4jClient.execute_read/execute_write`）
- `graph_engine/propagation/fundamental.py`（作为 runner 模板，除必要共享常量外不重写）
- `graph_engine/propagation/scoring.py`（复用 `build_score_explanation()` / `compute_path_score()`）
- `graph_engine/schema/definitions.py`（读取 `RelationshipType.EVENT_IMPACT` 等现有 enum）
- `graph_engine/status/`（消费 milestone-2 已补齐的 ready gate 语义，不在本 issue 实现）

### 3. 实现范围
- 在 `graph_engine/models.py` 中新增或等价定义 `PropagationChannel = Literal["fundamental", "event", "reflexive"]`，并把 `PropagationContext.enabled_channels` 从 `list[Literal["fundamental"]]` 扩展为 `list[PropagationChannel]`；validator 需要拒绝空列表、未知通道和重复通道。
- 扩展 `graph_engine/propagation/context.py::build_propagation_context()`，新增 keyword-only 参数 `enabled_channels: Sequence[PropagationChannel] | None = None`；默认仍为 `["fundamental"]`，以保持 #5 现有调用兼容。
- 更新 context multiplier 读取逻辑：对每个 enabled channel 分别从只读 `regime_context["channel_multipliers"]` 与 `regime_context["regime_multipliers"]` 读取非负 nu