### PR TITLE
feat(#9): 三通道融合、Regime-aware 权重调整与完整 Impact Snapshot

### DIFF
--- a/graph_engine/propagation/__init__.py
+++ b/graph_engine/propagation/__init__.py
@@ -7,6 +7,8 @@ from graph_engine.propagation.fundamental import (
 )
 from graph_engine.propagation.event import EVENT_RELATIONSHIP_TYPES, run_event_propagation
 from graph_engine.propagation.reflexive import run_reflexive_propagation
+from graph_engine.propagation.merge import merge_propagation_results
+from graph_engine.propagation.pipeline import run_full_propagation
 from graph_engine.propagation.scoring import build_score_explanation, compute_path_score
 
 __all__ = [
@@ -16,7 +18,9 @@ __all__ = [
     "build_propagation_context",
     "build_score_explanation",
     "compute_path_score",
+    "merge_propagation_results",
     "run_event_propagation",
+    "run_full_propagation",
     "run_fundamental_propagation",
     "run_reflexive_propagation",
 ]

--- a/graph_engine/propagation/context.py
+++ b/graph_engine/propagation/context.py
@@ -34,7 +34,9 @@ def build_propagation_context(
             f"received {graph_status.graph_status!r}",
         )
 
-    requested_channels = list(enabled_channels or _DEFAULT_ENABLED_CHANNELS)
+    requested_channels = list(
+        _DEFAULT_ENABLED_CHANNELS if enabled_channels is None else enabled_channels
+    )
     regime_context = dict(regime_reader.read_regime_context(world_state_ref))
     return PropagationContext(
         cycle_id=cycle_id,

--- a/graph_engine/propagation/merge.py
+++ b/graph_engine/propagation/merge.py
@@ -1,0 +1,261 @@
+"""Merge explainable propagation results across channels."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+from graph_engine.models import PropagationResult
+
+_ALLOWED_CHANNELS = frozenset({"fundamental", "event", "reflexive"})
+_REQUIRED_EXPLANATION_KEYS = frozenset(
+    {
+        "relation_weight",
+        "evidence_confidence",
+        "channel_multiplier",
+        "regime_multiplier",
+        "recency_decay",
+        "score",
+    }
+)
+
+
+def merge_propagation_results(
+    results: Sequence[PropagationResult],
+    *,
+    result_limit: int = 100,
+) -> PropagationResult:
+    """Return one deterministic, auditable result from channel-specific results."""
+
+    if not results:
+        raise ValueError("results must not be empty")
+    if result_limit < 1:
+        raise ValueError("result_limit must be greater than zero")
+
+    cycle_id = results[0].cycle_id
+    graph_generation_id = results[0].graph_generation_id
+    for result in results:
+        if result.cycle_id != cycle_id:
+            raise ValueError("cannot merge propagation results from different cycle_id values")
+        if result.graph_generation_id != graph_generation_id:
+            raise ValueError(
+                "cannot merge propagation results from different graph_generation_id values"
+            )
+
+    all_paths: list[dict[str, Any]] = []
+    channel_breakdown: dict[str, Any] = {}
+    enabled_channels: set[str] = set()
+    entity_path_counts = _entity_path_counts(results)
+
+    for result in results:
+        result_channels = _result_channels(result)
+        enabled_channels.update(result_channels)
+        for channel in result_channels:
+            if channel not in result.channel_breakdown:
+                raise ValueError(f"channel_breakdown is missing channel {channel!r}")
+            channel_breakdown[channel] = result.channel_breakdown[channel]
+
+        for path in result.activated_paths:
+            _validate_path(path)
+            all_paths.append(dict(path))
+
+    activated_paths = sorted(all_paths, key=_path_sort_key)[:result_limit]
+    impacted_entities = _merge_impacted_entities(
+        results,
+        entity_path_counts=entity_path_counts,
+        result_limit=result_limit,
+    )
+
+    channel_breakdown["merged"] = {
+        "enabled_channels": sorted(enabled_channels),
+        "path_count": len(activated_paths),
+        "impacted_entity_count": len(impacted_entities),
+        "total_path_score": sum(_float_value(path.get("score")) for path in activated_paths),
+        "result_limit": result_limit,
+    }
+
+    return PropagationResult(
+        cycle_id=cycle_id,
+        graph_generation_id=graph_generation_id,
+        activated_paths=activated_paths,
+        impacted_entities=impacted_entities,
+        channel_breakdown=channel_breakdown,
+    )
+
+
+def _result_channels(result: PropagationResult) -> set[str]:
+    channels: set[str] = set()
+    for path in result.activated_paths:
+        channels.add(_payload_channel(path, "activated path"))
+    for entity in result.impacted_entities:
+        channels.add(_payload_channel(entity, "impacted entity"))
+
+    channels.update(
+        str(channel)
+        for channel in result.channel_breakdown
+        if channel in _ALLOWED_CHANNELS
+    )
+    if not channels:
+        raise ValueError("cannot determine propagation channel for result")
+    return channels
+
+
+def _validate_path(path: dict[str, Any]) -> None:
+    _payload_channel(path, "activated path")
+    explanation = path.get("explanation")
+    if not isinstance(explanation, dict):
+        raise ValueError("activated path explanation must be a mapping")
+    missing_keys = sorted(_REQUIRED_EXPLANATION_KEYS - set(explanation))
+    if missing_keys:
+        raise ValueError(f"activated path explanation is missing keys: {missing_keys}")
+
+
+def _payload_channel(payload: dict[str, Any], payload_name: str) -> str:
+    channel = payload.get("channel")
+    if not isinstance(channel, str) or not channel:
+        raise ValueError(f"{payload_name} payload is missing channel")
+    if channel not in _ALLOWED_CHANNELS:
+        raise ValueError(f"{payload_name} payload has unknown channel {channel!r}")
+    return channel
+
+
+def _path_sort_key(path: dict[str, Any]) -> tuple[float, str, str, str, str, str]:
+    return (
+        -_float_value(path.get("score")),
+        str(path.get("channel") or ""),
+        str(path.get("source_node_id") or ""),
+        str(path.get("relationship_type") or ""),
+        str(path.get("target_node_id") or ""),
+        str(path.get("edge_id") or ""),
+    )
+
+
+def _merge_impacted_entities(
+    results: Sequence[PropagationResult],
+    *,
+    entity_path_counts: dict[tuple[str, str], int],
+    result_limit: int,
+) -> list[dict[str, Any]]:
+    merged_by_key: dict[str, dict[str, Any]] = {}
+    for result in results:
+        for entity in result.impacted_entities:
+            channel = _payload_channel(entity, "impacted entity")
+            entity_key = _entity_key(
+                canonical_entity_id=entity.get("canonical_entity_id"),
+                node_id=entity.get("node_id"),
+            )
+            merged = merged_by_key.setdefault(
+                entity_key,
+                {
+                    "canonical_entity_id": entity.get("canonical_entity_id"),
+                    "node_id": entity.get("node_id"),
+                    "labels": [],
+                    "score": 0.0,
+                    "channel_scores": {},
+                    "channels": [],
+                    "path_count": 0,
+                },
+            )
+            _merge_identity(merged, entity)
+            merged["labels"] = sorted(
+                set(_string_list(merged.get("labels"))) | set(_string_list(entity.get("labels")))
+            )
+
+            channel_scores = dict(merged["channel_scores"])
+            channel_scores[channel] = channel_scores.get(channel, 0.0) + _float_value(
+                entity.get("score")
+            )
+            merged["channel_scores"] = channel_scores
+            merged["channels"] = sorted(channel_scores)
+            merged["score"] = sum(float(score) for score in channel_scores.values())
+            merged["path_count"] = int(merged["path_count"]) + _entity_path_count(
+                entity,
+                entity_key=entity_key,
+                channel=channel,
+                entity_path_counts=entity_path_counts,
+            )
+
+    impacted_entities = list(merged_by_key.values())
+    impacted_entities.sort(key=_entity_sort_key)
+    return impacted_entities[:result_limit]
+
+
+def _entity_path_counts(
+    results: Sequence[PropagationResult],
+) -> dict[tuple[str, str], int]:
+    counts: dict[tuple[str, str], int] = {}
+    for result in results:
+        for path in result.activated_paths:
+            channel = _payload_channel(path, "activated path")
+            entity_key = _path_entity_key(
+                canonical_entity_id=path.get("target_entity_id"),
+                node_id=path.get("target_node_id"),
+            )
+            if entity_key is None:
+                continue
+            counts[(entity_key, channel)] = counts.get((entity_key, channel), 0) + 1
+    return counts
+
+
+def _entity_path_count(
+    entity: dict[str, Any],
+    *,
+    entity_key: str,
+    channel: str,
+    entity_path_counts: dict[tuple[str, str], int],
+) -> int:
+    raw_path_count = entity.get("path_count")
+    if raw_path_count is not None:
+        return int(raw_path_count)
+    return entity_path_counts.get((entity_key, channel), 0)
+
+
+def _entity_key(*, canonical_entity_id: Any, node_id: Any) -> str:
+    if canonical_entity_id is not None:
+        canonical = str(canonical_entity_id)
+        if canonical:
+            return f"canonical:{canonical}"
+    if node_id is not None:
+        node = str(node_id)
+        if node:
+            return f"node:{node}"
+    raise ValueError("impacted entity payload is missing canonical_entity_id and node_id")
+
+
+def _path_entity_key(*, canonical_entity_id: Any, node_id: Any) -> str | None:
+    if canonical_entity_id is None and node_id is None:
+        return None
+    return _entity_key(canonical_entity_id=canonical_entity_id, node_id=node_id)
+
+
+def _merge_identity(merged: dict[str, Any], entity: dict[str, Any]) -> None:
+    canonical_entity_id = entity.get("canonical_entity_id")
+    if merged.get("canonical_entity_id") is None and canonical_entity_id is not None:
+        merged["canonical_entity_id"] = canonical_entity_id
+
+    node_id = entity.get("node_id")
+    current_node_id = merged.get("node_id")
+    if current_node_id is None:
+        merged["node_id"] = node_id
+    elif node_id is not None and str(node_id) < str(current_node_id):
+        merged["node_id"] = node_id
+
+
+def _entity_sort_key(entity: dict[str, Any]) -> tuple[float, str, str]:
+    return (
+        -_float_value(entity.get("score")),
+        str(entity.get("canonical_entity_id") or ""),
+        str(entity.get("node_id") or ""),
+    )
+
+
+def _float_value(value: Any) -> float:
+    if value is None:
+        return 0.0
+    return float(value)
+
+
+def _string_list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return sorted(str(item) for item in value)

--- a/graph_engine/propagation/pipeline.py
+++ b/graph_engine/propagation/pipeline.py
@@ -2,11 +2,10 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
 from typing import Protocol
 
 from graph_engine.client import Neo4jClient
-from graph_engine.models import Neo4jGraphStatus, PropagationContext, PropagationResult
+from graph_engine.models import PropagationContext, PropagationResult
 from graph_engine.propagation.event import run_event_propagation
 from graph_engine.propagation.fundamental import run_fundamental_propagation
 from graph_engine.propagation.merge import merge_propagation_results
@@ -32,10 +31,10 @@ def run_full_propagation(
     context: PropagationContext,
     client: Neo4jClient,
     *,
+    status_manager: GraphStatusManager,
     graph_name: str | None = None,
     max_iterations: int = 20,
     result_limit: int = 100,
-    status_manager: GraphStatusManager | None = None,
 ) -> PropagationResult:
     """Run all enabled propagation channels and merge the explainable results."""
 
@@ -44,7 +43,6 @@ def run_full_propagation(
     if result_limit < 1:
         raise ValueError("result_limit must be greater than zero")
 
-    resolved_status_manager = status_manager or _context_status_manager(context)
     enabled_channels = list(context.enabled_channels)
     results: list[PropagationResult] = []
     for channel in enabled_channels:
@@ -53,7 +51,7 @@ def run_full_propagation(
             runner(
                 context,
                 client,
-                status_manager=resolved_status_manager,
+                status_manager=status_manager,
                 graph_name=_projection_name(
                     graph_name,
                     channel=channel,
@@ -87,39 +85,3 @@ def _projection_name(
     if enabled_channel_count == 1:
         return graph_name
     return f"{graph_name}-{channel}"
-
-
-def _context_status_manager(context: PropagationContext) -> GraphStatusManager:
-    status = Neo4jGraphStatus(
-        graph_status="ready",
-        graph_generation_id=context.graph_generation_id,
-        node_count=0,
-        edge_count=0,
-        key_label_counts={},
-        checksum="context-ready",
-        last_verified_at=datetime.now(timezone.utc),
-        last_reload_at=None,
-    )
-    return GraphStatusManager(_StaticStatusStore(status))
-
-
-class _StaticStatusStore:
-    def __init__(self, status: Neo4jGraphStatus) -> None:
-        self.status = status
-
-    def read_current_status(self) -> Neo4jGraphStatus:
-        return self.status
-
-    def write_current_status(self, status: Neo4jGraphStatus) -> None:
-        self.status = status
-
-    def compare_and_write_current_status(
-        self,
-        *,
-        expected_status: Neo4jGraphStatus | None,
-        next_status: Neo4jGraphStatus,
-    ) -> bool:
-        if self.status != expected_status:
-            return False
-        self.status = next_status
-        return True

--- a/graph_engine/propagation/pipeline.py
+++ b/graph_engine/propagation/pipeline.py
@@ -1,0 +1,125 @@
+"""Full propagation orchestration across enabled channels."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Protocol
+
+from graph_engine.client import Neo4jClient
+from graph_engine.models import Neo4jGraphStatus, PropagationContext, PropagationResult
+from graph_engine.propagation.event import run_event_propagation
+from graph_engine.propagation.fundamental import run_fundamental_propagation
+from graph_engine.propagation.merge import merge_propagation_results
+from graph_engine.propagation.reflexive import run_reflexive_propagation
+from graph_engine.status import GraphStatusManager
+
+
+class _PropagationRunner(Protocol):
+    def __call__(
+        self,
+        context: PropagationContext,
+        client: Neo4jClient,
+        *,
+        status_manager: GraphStatusManager,
+        graph_name: str | None = None,
+        max_iterations: int = 20,
+        result_limit: int = 100,
+    ) -> PropagationResult:
+        ...
+
+
+def run_full_propagation(
+    context: PropagationContext,
+    client: Neo4jClient,
+    *,
+    graph_name: str | None = None,
+    max_iterations: int = 20,
+    result_limit: int = 100,
+    status_manager: GraphStatusManager | None = None,
+) -> PropagationResult:
+    """Run all enabled propagation channels and merge the explainable results."""
+
+    if max_iterations < 1:
+        raise ValueError("max_iterations must be greater than zero")
+    if result_limit < 1:
+        raise ValueError("result_limit must be greater than zero")
+
+    resolved_status_manager = status_manager or _context_status_manager(context)
+    enabled_channels = list(context.enabled_channels)
+    results: list[PropagationResult] = []
+    for channel in enabled_channels:
+        runner = _runner_for_channel(channel)
+        results.append(
+            runner(
+                context,
+                client,
+                status_manager=resolved_status_manager,
+                graph_name=_projection_name(
+                    graph_name,
+                    channel=channel,
+                    enabled_channel_count=len(enabled_channels),
+                ),
+                max_iterations=max_iterations,
+                result_limit=result_limit,
+            )
+        )
+    return merge_propagation_results(results, result_limit=result_limit)
+
+
+def _runner_for_channel(channel: str) -> _PropagationRunner:
+    if channel == "fundamental":
+        return run_fundamental_propagation
+    if channel == "event":
+        return run_event_propagation
+    if channel == "reflexive":
+        return run_reflexive_propagation
+    raise ValueError(f"unknown propagation channel: {channel!r}")
+
+
+def _projection_name(
+    graph_name: str | None,
+    *,
+    channel: str,
+    enabled_channel_count: int,
+) -> str | None:
+    if graph_name is None:
+        return None
+    if enabled_channel_count == 1:
+        return graph_name
+    return f"{graph_name}-{channel}"
+
+
+def _context_status_manager(context: PropagationContext) -> GraphStatusManager:
+    status = Neo4jGraphStatus(
+        graph_status="ready",
+        graph_generation_id=context.graph_generation_id,
+        node_count=0,
+        edge_count=0,
+        key_label_counts={},
+        checksum="context-ready",
+        last_verified_at=datetime.now(timezone.utc),
+        last_reload_at=None,
+    )
+    return GraphStatusManager(_StaticStatusStore(status))
+
+
+class _StaticStatusStore:
+    def __init__(self, status: Neo4jGraphStatus) -> None:
+        self.status = status
+
+    def read_current_status(self) -> Neo4jGraphStatus:
+        return self.status
+
+    def write_current_status(self, status: Neo4jGraphStatus) -> None:
+        self.status = status
+
+    def compare_and_write_current_status(
+        self,
+        *,
+        expected_status: Neo4jGraphStatus | None,
+        next_status: Neo4jGraphStatus,
+    ) -> bool:
+        if self.status != expected_status:
+            return False
+        self.status = next_status
+        return True

--- a/graph_engine/snapshots/generator.py
+++ b/graph_engine/snapshots/generator.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from datetime import datetime, timezone
+from typing import Any
 
 from graph_engine.client import Neo4jClient
 from graph_engine.live_metrics import (
@@ -13,12 +15,19 @@ from graph_engine.models import (
     GraphImpactSnapshot,
     GraphSnapshot,
     Neo4jGraphStatus,
+    PropagationChannel,
     PropagationResult,
 )
 from graph_engine.propagation.context import RegimeContextReader, build_propagation_context
-from graph_engine.propagation.fundamental import run_fundamental_propagation
+from graph_engine.propagation.pipeline import run_full_propagation
 from graph_engine.snapshots.writer import SnapshotWriter
-from graph_engine.status import GraphStatusManager, require_ready_read
+from graph_engine.status import GraphStatusManager, require_ready_read, require_ready_status
+
+_DEFAULT_SNAPSHOT_CHANNELS: tuple[PropagationChannel, ...] = (
+    "fundamental",
+    "event",
+    "reflexive",
+)
 
 
 def build_graph_snapshot(
@@ -50,13 +59,14 @@ def build_graph_impact_snapshot(
 ) -> GraphImpactSnapshot:
     """Build the downstream impact snapshot from a propagation result."""
 
+    channel_breakdown = _complete_channel_breakdown(propagation_result.channel_breakdown)
     payload = {
         "cycle_id": cycle_id,
         "graph_generation_id": propagation_result.graph_generation_id,
         "world_state_ref": world_state_ref,
         "activated_paths": propagation_result.activated_paths,
         "impacted_entities": propagation_result.impacted_entities,
-        "channel_breakdown": propagation_result.channel_breakdown,
+        "channel_breakdown": channel_breakdown,
     }
     impact_hash = _checksum_payload(payload)
     return GraphImpactSnapshot(
@@ -65,7 +75,7 @@ def build_graph_impact_snapshot(
         regime_context_ref=world_state_ref,
         activated_paths=propagation_result.activated_paths,
         impacted_entities=propagation_result.impacted_entities,
-        channel_breakdown=propagation_result.channel_breakdown,
+        channel_breakdown=channel_breakdown,
     )
 
 
@@ -77,42 +87,53 @@ def compute_graph_snapshots(
     graph_generation_id: int | None = None,
     regime_reader: RegimeContextReader,
     snapshot_writer: SnapshotWriter,
-    status_manager: GraphStatusManager,
+    status_manager: GraphStatusManager | None = None,
+    graph_status: Neo4jGraphStatus | None = None,
     graph_name: str | None = None,
+    enabled_channels: Sequence[PropagationChannel] | None = None,
+    max_iterations: int = 20,
+    result_limit: int = 100,
 ) -> tuple[GraphSnapshot, GraphImpactSnapshot]:
-    """Run fundamental propagation and write graph plus impact snapshots."""
+    """Run full propagation and write graph plus impact snapshots."""
 
-    ready_status = require_ready_read(status_manager, "snapshot generation")
-    _validate_generation_input(graph_generation_id, ready_status)
-    node_count, edge_count, key_label_counts, checksum = _read_graph_metrics(client)
-    _validate_status_metrics(
-        ready_status,
-        node_count=node_count,
-        edge_count=edge_count,
-        key_label_counts=key_label_counts,
-        checksum=checksum,
+    ready_status = _resolve_ready_status(
+        status_manager=status_manager,
+        graph_status=graph_status,
+        operation="snapshot generation",
     )
-
+    _validate_generation_input(graph_generation_id, ready_status)
+    read_status_manager = status_manager or _static_status_manager(ready_status)
+    requested_channels = list(
+        _DEFAULT_SNAPSHOT_CHANNELS if enabled_channels is None else enabled_channels
+    )
     context = build_propagation_context(
         cycle_id,
         world_state_ref,
         ready_status.graph_generation_id,
         regime_reader=regime_reader,
         graph_status=ready_status,
+        enabled_channels=requested_channels,
     )
-    propagation_result = run_fundamental_propagation(
+    propagation_result = run_full_propagation(
         context,
         client,
-        status_manager=status_manager,
+        status_manager=read_status_manager,
         graph_name=graph_name,
+        max_iterations=max_iterations,
+        result_limit=result_limit,
     )
-    graph_snapshot = _graph_snapshot_from_metrics(
+    graph_snapshot = build_graph_snapshot(
         cycle_id,
         ready_status.graph_generation_id,
-        node_count=node_count,
-        edge_count=edge_count,
-        key_label_counts=key_label_counts,
-        checksum=checksum,
+        client,
+        status_manager=read_status_manager,
+    )
+    _validate_status_metrics(
+        ready_status,
+        node_count=graph_snapshot.node_count,
+        edge_count=graph_snapshot.edge_count,
+        key_label_counts=graph_snapshot.key_label_counts,
+        checksum=graph_snapshot.checksum,
     )
     impact_snapshot = build_graph_impact_snapshot(
         cycle_id,
@@ -121,7 +142,7 @@ def compute_graph_snapshots(
     )
     _validate_publication_status_and_metrics(
         ready_status,
-        status_manager,
+        read_status_manager,
         client,
     )
     snapshot_writer.write_snapshots(graph_snapshot, impact_snapshot)
@@ -140,6 +161,57 @@ def _validate_generation_input(
             f"received {graph_generation_id}, "
             f"status has {graph_status.graph_generation_id}",
         )
+
+
+def _complete_channel_breakdown(channel_breakdown: dict[str, Any]) -> dict[str, Any]:
+    completed: dict[str, Any] = {
+        channel: channel_breakdown.get(channel, {})
+        for channel in _DEFAULT_SNAPSHOT_CHANNELS
+    }
+    for key, value in channel_breakdown.items():
+        if key not in completed and key != "merged":
+            completed[key] = value
+    completed["merged"] = channel_breakdown.get("merged", {})
+    return completed
+
+
+def _resolve_ready_status(
+    *,
+    status_manager: GraphStatusManager | None,
+    graph_status: Neo4jGraphStatus | None,
+    operation: str,
+) -> Neo4jGraphStatus:
+    if status_manager is not None:
+        return require_ready_read(status_manager, operation)
+    if graph_status is not None:
+        return require_ready_status(graph_status)
+    raise TypeError(f"{operation} requires status_manager or graph_status")
+
+
+def _static_status_manager(graph_status: Neo4jGraphStatus) -> GraphStatusManager:
+    return GraphStatusManager(_StaticStatusStore(graph_status))
+
+
+class _StaticStatusStore:
+    def __init__(self, graph_status: Neo4jGraphStatus) -> None:
+        self.graph_status = graph_status
+
+    def read_current_status(self) -> Neo4jGraphStatus:
+        return self.graph_status
+
+    def write_current_status(self, status: Neo4jGraphStatus) -> None:
+        self.graph_status = status
+
+    def compare_and_write_current_status(
+        self,
+        *,
+        expected_status: Neo4jGraphStatus | None,
+        next_status: Neo4jGraphStatus,
+    ) -> bool:
+        if self.graph_status != expected_status:
+            return False
+        self.graph_status = next_status
+        return True
 
 
 def _validate_status_metrics(
@@ -249,4 +321,4 @@ def _graph_snapshot_from_metrics(
 
 
 def _read_graph_metrics(client: Neo4jClient) -> tuple[int, int, dict[str, int], str]:
-    return read_live_graph_metrics(client, strict=False)
+    return read_live_graph_metrics(client, strict=True)

--- a/graph_engine/snapshots/generator.py
+++ b/graph_engine/snapshots/generator.py
@@ -87,7 +87,7 @@ def compute_graph_snapshots(
     graph_generation_id: int | None = None,
     regime_reader: RegimeContextReader,
     snapshot_writer: SnapshotWriter,
-    status_manager: GraphStatusManager | None = None,
+    status_manager: GraphStatusManager,
     graph_status: Neo4jGraphStatus | None = None,
     graph_name: str | None = None,
     enabled_channels: Sequence[PropagationChannel] | None = None,
@@ -102,7 +102,7 @@ def compute_graph_snapshots(
         operation="snapshot generation",
     )
     _validate_generation_input(graph_generation_id, ready_status)
-    read_status_manager = status_manager or _static_status_manager(ready_status)
+    _validate_pre_propagation_status_and_metrics(ready_status, client)
     requested_channels = list(
         _DEFAULT_SNAPSHOT_CHANNELS if enabled_channels is None else enabled_channels
     )
@@ -117,7 +117,7 @@ def compute_graph_snapshots(
     propagation_result = run_full_propagation(
         context,
         client,
-        status_manager=read_status_manager,
+        status_manager=status_manager,
         graph_name=graph_name,
         max_iterations=max_iterations,
         result_limit=result_limit,
@@ -126,7 +126,7 @@ def compute_graph_snapshots(
         cycle_id,
         ready_status.graph_generation_id,
         client,
-        status_manager=read_status_manager,
+        status_manager=status_manager,
     )
     _validate_status_metrics(
         ready_status,
@@ -142,7 +142,7 @@ def compute_graph_snapshots(
     )
     _validate_publication_status_and_metrics(
         ready_status,
-        read_status_manager,
+        status_manager,
         client,
     )
     snapshot_writer.write_snapshots(graph_snapshot, impact_snapshot)
@@ -181,37 +181,27 @@ def _resolve_ready_status(
     graph_status: Neo4jGraphStatus | None,
     operation: str,
 ) -> Neo4jGraphStatus:
-    if status_manager is not None:
-        return require_ready_read(status_manager, operation)
+    if status_manager is None:
+        raise TypeError(f"{operation} requires status_manager")
+    ready_status = require_ready_read(status_manager, operation)
     if graph_status is not None:
-        return require_ready_status(graph_status)
-    raise TypeError(f"{operation} requires status_manager or graph_status")
+        require_ready_status(graph_status)
+        _validate_status_matches_ready_status(ready_status, graph_status)
+    return ready_status
 
 
-def _static_status_manager(graph_status: Neo4jGraphStatus) -> GraphStatusManager:
-    return GraphStatusManager(_StaticStatusStore(graph_status))
-
-
-class _StaticStatusStore:
-    def __init__(self, graph_status: Neo4jGraphStatus) -> None:
-        self.graph_status = graph_status
-
-    def read_current_status(self) -> Neo4jGraphStatus:
-        return self.graph_status
-
-    def write_current_status(self, status: Neo4jGraphStatus) -> None:
-        self.graph_status = status
-
-    def compare_and_write_current_status(
-        self,
-        *,
-        expected_status: Neo4jGraphStatus | None,
-        next_status: Neo4jGraphStatus,
-    ) -> bool:
-        if self.graph_status != expected_status:
-            return False
-        self.graph_status = next_status
-        return True
+def _validate_pre_propagation_status_and_metrics(
+    ready_status: Neo4jGraphStatus,
+    client: Neo4jClient,
+) -> None:
+    node_count, edge_count, key_label_counts, checksum = _read_graph_metrics(client)
+    _validate_status_metrics(
+        ready_status,
+        node_count=node_count,
+        edge_count=edge_count,
+        key_label_counts=key_label_counts,
+        checksum=checksum,
+    )
 
 
 def _validate_status_metrics(
@@ -249,7 +239,7 @@ def _validate_status_metrics(
 
 def _validate_publication_status_and_metrics(
     ready_status: Neo4jGraphStatus,
-    status_manager: GraphStatusManager | None,
+    status_manager: GraphStatusManager,
     client: Neo4jClient,
 ) -> None:
     try:

--- a/tests/integration/test_full_propagation.py
+++ b/tests/integration/test_full_propagation.py
@@ -1,0 +1,265 @@
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+from typing import Any
+from uuid import uuid4
+
+import pytest
+
+from graph_engine.client import Neo4jClient
+from graph_engine.config import load_config_from_env
+from graph_engine.models import (
+    GraphEdgeRecord,
+    GraphImpactSnapshot,
+    GraphNodeRecord,
+    GraphSnapshot,
+    Neo4jGraphStatus,
+    PromotionPlan,
+)
+from graph_engine.schema.definitions import NodeLabel, RelationshipType
+from graph_engine.schema.manager import SchemaManager
+from graph_engine.snapshots import build_graph_snapshot, compute_graph_snapshots
+from graph_engine.status import GraphStatusManager
+from graph_engine.sync import sync_live_graph
+from tests.fakes import InMemoryStatusStore
+
+pytestmark = pytest.mark.skipif(
+    os.getenv("NEO4J_PASSWORD") is None,
+    reason="NEO4J_PASSWORD is not set; Neo4j full propagation integration tests require a database.",
+)
+
+NOW = datetime(2026, 4, 17, 1, 2, 3, tzinfo=timezone.utc)
+
+
+class StaticRegimeReader:
+    def read_regime_context(self, world_state_ref: str) -> dict[str, Any]:
+        return {
+            "world_state_ref": world_state_ref,
+            "channel_multipliers": {
+                "fundamental": 1.0,
+                "event": 1.0,
+                "reflexive": 1.0,
+            },
+            "regime_multipliers": {
+                "fundamental": 1.0,
+                "event": 1.0,
+                "reflexive": 1.0,
+            },
+            "decay_policy": {"default": 1.0},
+        }
+
+
+class CapturingSnapshotWriter:
+    def __init__(self) -> None:
+        self.calls: list[tuple[GraphSnapshot, GraphImpactSnapshot]] = []
+
+    def write_snapshots(
+        self,
+        graph_snapshot: GraphSnapshot,
+        impact_snapshot: GraphImpactSnapshot,
+    ) -> None:
+        self.calls.append((graph_snapshot, impact_snapshot))
+
+
+def test_compute_graph_snapshots_generates_three_channel_impact_snapshot() -> None:
+    pytest.importorskip("neo4j")
+
+    prefix = f"000-full-propagation-{uuid4().hex}"
+    source_node_id = f"{prefix}-source"
+    fundamental_target_id = f"{prefix}-fundamental-target"
+    event_target_id = f"{prefix}-event-target"
+    reflexive_target_id = f"{prefix}-reflexive-target"
+    supply_edge_id = f"{prefix}-supply-edge"
+    event_edge_id = f"{prefix}-event-edge"
+    reflexive_edge_id = f"{prefix}-reflexive-edge"
+    node_ids = [
+        source_node_id,
+        fundamental_target_id,
+        event_target_id,
+        reflexive_target_id,
+    ]
+    writer = CapturingSnapshotWriter()
+
+    with Neo4jClient(load_config_from_env()) as client:
+        if not client.verify_connectivity():
+            pytest.skip("Neo4j is not reachable with the configured environment.")
+
+        manager = SchemaManager(client)
+        manager.apply_schema()
+        assert manager.verify_schema() is True
+
+        try:
+            sync_live_graph(
+                _promotion_plan(
+                    source_node_id=source_node_id,
+                    fundamental_target_id=fundamental_target_id,
+                    event_target_id=event_target_id,
+                    reflexive_target_id=reflexive_target_id,
+                    supply_edge_id=supply_edge_id,
+                    event_edge_id=event_edge_id,
+                    reflexive_edge_id=reflexive_edge_id,
+                ),
+                client,
+            )
+            live_snapshot = build_graph_snapshot(
+                "cycle-1",
+                1,
+                client,
+                status_manager=GraphStatusManager(
+                    InMemoryStatusStore(_status_for_generation(1)),
+                ),
+            )
+            graph_status = Neo4jGraphStatus(
+                graph_status="ready",
+                graph_generation_id=live_snapshot.graph_generation_id,
+                node_count=live_snapshot.node_count,
+                edge_count=live_snapshot.edge_count,
+                key_label_counts=live_snapshot.key_label_counts,
+                checksum=live_snapshot.checksum,
+                last_verified_at=NOW,
+                last_reload_at=None,
+            )
+
+            try:
+                graph_snapshot, impact_snapshot = compute_graph_snapshots(
+                    "cycle-1",
+                    "world-state-1",
+                    client=client,
+                    graph_generation_id=1,
+                    regime_reader=StaticRegimeReader(),
+                    snapshot_writer=writer,
+                    status_manager=GraphStatusManager(InMemoryStatusStore(graph_status)),
+                    graph_name=f"{prefix}-projection",
+                    result_limit=20,
+                )
+            except RuntimeError as exc:
+                if str(exc) == "GDS plugin not available":
+                    pytest.skip("GDS plugin is not available in the configured Neo4j instance.")
+                raise
+        finally:
+            client.execute_write(
+                "MATCH (node) WHERE node.node_id IN $node_ids DETACH DELETE node",
+                {"node_ids": node_ids},
+            )
+
+    path_channels_by_edge = {
+        (path["edge_id"], path["channel"])
+        for path in impact_snapshot.activated_paths
+    }
+    assert (supply_edge_id, "fundamental") in path_channels_by_edge
+    assert (event_edge_id, "event") in path_channels_by_edge
+    assert (reflexive_edge_id, "reflexive") in path_channels_by_edge
+    assert set(impact_snapshot.channel_breakdown) == {
+        "fundamental",
+        "event",
+        "reflexive",
+        "merged",
+    }
+    assert impact_snapshot.channel_breakdown["merged"]["enabled_channels"] == [
+        "event",
+        "fundamental",
+        "reflexive",
+    ]
+    assert graph_snapshot.node_count >= 4
+    assert writer.calls == [(graph_snapshot, impact_snapshot)]
+
+
+def _promotion_plan(
+    *,
+    source_node_id: str,
+    fundamental_target_id: str,
+    event_target_id: str,
+    reflexive_target_id: str,
+    supply_edge_id: str,
+    event_edge_id: str,
+    reflexive_edge_id: str,
+) -> PromotionPlan:
+    return PromotionPlan(
+        cycle_id="cycle-1",
+        selection_ref="selection-1",
+        delta_ids=["delta-1", "delta-2", "delta-3"],
+        node_records=[
+            _node_record(source_node_id),
+            _node_record(fundamental_target_id),
+            _node_record(event_target_id),
+            _node_record(reflexive_target_id),
+        ],
+        edge_records=[
+            _edge_record(
+                source_node_id,
+                fundamental_target_id,
+                supply_edge_id,
+                RelationshipType.SUPPLY_CHAIN.value,
+                weight=2.0,
+            ),
+            _edge_record(
+                source_node_id,
+                event_target_id,
+                event_edge_id,
+                RelationshipType.EVENT_IMPACT.value,
+                weight=3.0,
+            ),
+            _edge_record(
+                source_node_id,
+                reflexive_target_id,
+                reflexive_edge_id,
+                RelationshipType.OWNERSHIP.value,
+                weight=4.0,
+                extra_properties={"propagation_channel": "reflexive"},
+            ),
+        ],
+        assertion_records=[],
+        created_at=NOW,
+    )
+
+
+def _status_for_generation(graph_generation_id: int) -> Neo4jGraphStatus:
+    return Neo4jGraphStatus(
+        graph_status="ready",
+        graph_generation_id=graph_generation_id,
+        node_count=0,
+        edge_count=0,
+        key_label_counts={},
+        checksum="pending",
+        last_verified_at=NOW,
+        last_reload_at=None,
+    )
+
+
+def _node_record(node_id: str) -> GraphNodeRecord:
+    return GraphNodeRecord(
+        node_id=node_id,
+        canonical_entity_id=f"{node_id}-entity",
+        label=NodeLabel.ENTITY.value,
+        properties={"integration_prefix": node_id},
+        created_at=NOW,
+        updated_at=NOW,
+    )
+
+
+def _edge_record(
+    source_node_id: str,
+    target_node_id: str,
+    edge_id: str,
+    relationship_type: str,
+    *,
+    weight: float,
+    extra_properties: dict[str, Any] | None = None,
+) -> GraphEdgeRecord:
+    properties = {
+        "integration_prefix": edge_id,
+        "evidence_confidence": 1.0,
+        "recency_decay": 1.0,
+    }
+    properties.update(extra_properties or {})
+    return GraphEdgeRecord(
+        edge_id=edge_id,
+        source_node_id=source_node_id,
+        target_node_id=target_node_id,
+        relationship_type=relationship_type,
+        properties=properties,
+        weight=weight,
+        created_at=NOW,
+        updated_at=NOW,
+    )

--- a/tests/unit/test_propagation.py
+++ b/tests/unit/test_propagation.py
@@ -220,6 +220,21 @@ def test_build_propagation_context_reads_multipliers_for_requested_channels() ->
     assert context.decay_policy == {"half_life_days": 3}
 
 
+def test_build_propagation_context_rejects_explicit_empty_channels() -> None:
+    reader = StaticRegimeReader({})
+
+    with pytest.raises(ValidationError, match="at least 1"):
+        build_propagation_context(
+            "cycle-1",
+            "world-state-1",
+            7,
+            regime_reader=reader,
+            enabled_channels=[],
+        )
+
+    assert reader.calls == ["world-state-1"]
+
+
 def test_build_propagation_context_rejects_non_ready_status_before_reading() -> None:
     reader = StaticRegimeReader({})
     graph_status = Neo4jGraphStatus(

--- a/tests/unit/test_propagation_merge.py
+++ b/tests/unit/test_propagation_merge.py
@@ -263,6 +263,14 @@ def test_run_full_propagation_reuses_projection_name_for_single_channel(
     assert calls == [("event", "unit-projection", 20, 100)]
 
 
+def test_run_full_propagation_requires_status_manager() -> None:
+    with pytest.raises(TypeError, match="status_manager"):
+        run_full_propagation(
+            _context(enabled_channels=["fundamental"]),
+            object(),  # type: ignore[arg-type]
+        )
+
+
 def _runner(channel: str, calls: list[tuple[str, str | None, int, int]]):
     def run_channel(
         context: PropagationContext,

--- a/tests/unit/test_propagation_merge.py
+++ b/tests/unit/test_propagation_merge.py
@@ -1,0 +1,385 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+
+import graph_engine.propagation.pipeline as propagation_pipeline
+from graph_engine.models import Neo4jGraphStatus, PropagationContext, PropagationResult
+from graph_engine.propagation import merge_propagation_results, run_full_propagation
+from graph_engine.status import GraphStatusManager
+from tests.fakes import InMemoryStatusStore
+
+NOW = datetime(2026, 4, 17, 1, 2, 3, tzinfo=timezone.utc)
+
+
+def test_merge_propagation_results_rejects_empty_results() -> None:
+    with pytest.raises(ValueError, match="empty"):
+        merge_propagation_results([])
+
+
+@pytest.mark.parametrize(
+    ("left_kwargs", "right_kwargs", "message"),
+    [
+        ({"cycle_id": "cycle-1"}, {"cycle_id": "cycle-2"}, "cycle_id"),
+        ({"graph_generation_id": 1}, {"graph_generation_id": 2}, "graph_generation_id"),
+    ],
+)
+def test_merge_propagation_results_rejects_incompatible_results(
+    left_kwargs: dict[str, Any],
+    right_kwargs: dict[str, Any],
+    message: str,
+) -> None:
+    left = _result("fundamental", **left_kwargs)
+    right = _result("event", **right_kwargs)
+
+    with pytest.raises(ValueError, match=message):
+        merge_propagation_results([left, right])
+
+
+def test_merge_propagation_results_validates_channel_payloads_and_explanations() -> None:
+    missing_path_channel = _result("fundamental")
+    missing_path_channel.activated_paths[0].pop("channel")
+
+    with pytest.raises(ValueError, match="activated path payload is missing channel"):
+        merge_propagation_results([missing_path_channel])
+
+    missing_entity_channel = _result("fundamental")
+    missing_entity_channel.impacted_entities[0].pop("channel")
+
+    with pytest.raises(ValueError, match="impacted entity payload is missing channel"):
+        merge_propagation_results([missing_entity_channel])
+
+    missing_explanation_key = _result("fundamental")
+    missing_explanation_key.activated_paths[0]["explanation"].pop("regime_multiplier")
+
+    with pytest.raises(ValueError, match="regime_multiplier"):
+        merge_propagation_results([missing_explanation_key])
+
+
+def test_merge_propagation_results_sorts_paths_after_merge_and_applies_limit() -> None:
+    fundamental = _result(
+        "fundamental",
+        paths=[
+            _path("fundamental", edge_id="edge-fund", score=1.0, source_node_id="node-a"),
+            _path("fundamental", edge_id="edge-fund-low", score=0.1),
+        ],
+        entities=[_entity("fundamental", node_id="node-fund", score=1.1)],
+    )
+    event = _result(
+        "event",
+        paths=[
+            _path("event", edge_id="edge-event", score=1.0, source_node_id="node-z"),
+            _path("event", edge_id="edge-event-top", score=2.0),
+        ],
+        entities=[_entity("event", node_id="node-event", score=3.0)],
+    )
+    reflexive = _result(
+        "reflexive",
+        paths=[_path("reflexive", edge_id="edge-reflexive", score=1.0)],
+        entities=[_entity("reflexive", node_id="node-reflexive", score=1.0)],
+    )
+
+    merged = merge_propagation_results(
+        [fundamental, event, reflexive],
+        result_limit=4,
+    )
+
+    assert [path["edge_id"] for path in merged.activated_paths] == [
+        "edge-event-top",
+        "edge-event",
+        "edge-fund",
+        "edge-reflexive",
+    ]
+    assert merged.channel_breakdown["merged"]["path_count"] == 4
+    assert merged.channel_breakdown["merged"]["total_path_score"] == pytest.approx(5.0)
+    assert merged.channel_breakdown["merged"]["result_limit"] == 4
+
+
+def test_merge_propagation_results_aggregates_entities_by_canonical_id() -> None:
+    fundamental = _result(
+        "fundamental",
+        paths=[
+            _path(
+                "fundamental",
+                edge_id="edge-fund",
+                score=0.4,
+                target_node_id="node-a",
+                target_entity_id="entity-shared",
+            )
+        ],
+        entities=[
+            _entity(
+                "fundamental",
+                node_id="node-a",
+                canonical_entity_id="entity-shared",
+                labels=["Supplier"],
+                score=0.4,
+                path_count=1,
+            )
+        ],
+    )
+    event = _result(
+        "event",
+        paths=[
+            _path(
+                "event",
+                edge_id="edge-event-1",
+                score=0.2,
+                target_node_id="node-b",
+                target_entity_id="entity-shared",
+            ),
+            _path(
+                "event",
+                edge_id="edge-event-2",
+                score=0.6,
+                target_node_id="node-b",
+                target_entity_id="entity-shared",
+            ),
+        ],
+        entities=[
+            _entity(
+                "event",
+                node_id="node-b",
+                canonical_entity_id="entity-shared",
+                labels=["Issuer"],
+                score=0.8,
+                path_count=2,
+            )
+        ],
+    )
+
+    merged = merge_propagation_results([fundamental, event])
+
+    assert len(merged.impacted_entities) == 1
+    entity = merged.impacted_entities[0]
+    assert entity["canonical_entity_id"] == "entity-shared"
+    assert entity["node_id"] == "node-a"
+    assert entity["labels"] == ["Issuer", "Supplier"]
+    assert entity["score"] == pytest.approx(1.2)
+    assert entity["channel_scores"] == {"event": 0.8, "fundamental": 0.4}
+    assert entity["channels"] == ["event", "fundamental"]
+    assert entity["path_count"] == 3
+    assert merged.channel_breakdown["fundamental"]["path_count"] == 1
+    assert merged.channel_breakdown["event"]["path_count"] == 2
+
+
+def test_merge_propagation_results_aggregates_entities_by_node_id_without_canonical_id() -> None:
+    fundamental = _result(
+        "fundamental",
+        entities=[
+            _entity(
+                "fundamental",
+                node_id="node-shared",
+                canonical_entity_id=None,
+                score=0.5,
+            )
+        ],
+    )
+    reflexive = _result(
+        "reflexive",
+        entities=[
+            _entity(
+                "reflexive",
+                node_id="node-shared",
+                canonical_entity_id=None,
+                score=0.25,
+            )
+        ],
+    )
+
+    merged = merge_propagation_results([fundamental, reflexive])
+
+    assert len(merged.impacted_entities) == 1
+    assert merged.impacted_entities[0]["canonical_entity_id"] is None
+    assert merged.impacted_entities[0]["node_id"] == "node-shared"
+    assert merged.impacted_entities[0]["score"] == pytest.approx(0.75)
+    assert merged.impacted_entities[0]["channel_scores"] == {
+        "fundamental": 0.5,
+        "reflexive": 0.25,
+    }
+
+
+def test_run_full_propagation_uses_distinct_projection_names_per_channel(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[str, str | None, int, int]] = []
+
+    monkeypatch.setattr(
+        propagation_pipeline,
+        "run_fundamental_propagation",
+        _runner("fundamental", calls),
+    )
+    monkeypatch.setattr(
+        propagation_pipeline,
+        "run_event_propagation",
+        _runner("event", calls),
+    )
+    monkeypatch.setattr(
+        propagation_pipeline,
+        "run_reflexive_propagation",
+        _runner("reflexive", calls),
+    )
+
+    result = run_full_propagation(
+        _context(enabled_channels=["fundamental", "event", "reflexive"]),
+        object(),  # type: ignore[arg-type]
+        status_manager=_status_manager(),
+        graph_name="unit-projection",
+        max_iterations=7,
+        result_limit=10,
+    )
+
+    assert calls == [
+        ("fundamental", "unit-projection-fundamental", 7, 10),
+        ("event", "unit-projection-event", 7, 10),
+        ("reflexive", "unit-projection-reflexive", 7, 10),
+    ]
+    assert result.channel_breakdown["merged"]["enabled_channels"] == [
+        "event",
+        "fundamental",
+        "reflexive",
+    ]
+
+
+def test_run_full_propagation_reuses_projection_name_for_single_channel(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[str, str | None, int, int]] = []
+    monkeypatch.setattr(
+        propagation_pipeline,
+        "run_event_propagation",
+        _runner("event", calls),
+    )
+
+    run_full_propagation(
+        _context(enabled_channels=["event"]),
+        object(),  # type: ignore[arg-type]
+        status_manager=_status_manager(),
+        graph_name="unit-projection",
+    )
+
+    assert calls == [("event", "unit-projection", 20, 100)]
+
+
+def _runner(channel: str, calls: list[tuple[str, str | None, int, int]]):
+    def run_channel(
+        context: PropagationContext,
+        client: Any,
+        *,
+        status_manager: GraphStatusManager,
+        graph_name: str | None = None,
+        max_iterations: int = 20,
+        result_limit: int = 100,
+    ) -> PropagationResult:
+        calls.append((channel, graph_name, max_iterations, result_limit))
+        return _result(channel, graph_generation_id=context.graph_generation_id)
+
+    return run_channel
+
+
+def _result(
+    channel: str,
+    *,
+    cycle_id: str = "cycle-1",
+    graph_generation_id: int = 1,
+    paths: list[dict[str, Any]] | None = None,
+    entities: list[dict[str, Any]] | None = None,
+) -> PropagationResult:
+    activated_paths = paths or [_path(channel, edge_id=f"edge-{channel}", score=1.0)]
+    impacted_entities = entities or [_entity(channel, node_id=f"node-{channel}", score=1.0)]
+    return PropagationResult(
+        cycle_id=cycle_id,
+        graph_generation_id=graph_generation_id,
+        activated_paths=activated_paths,
+        impacted_entities=impacted_entities,
+        channel_breakdown={
+            channel: {
+                "path_count": len(activated_paths),
+                "impacted_entity_count": len(impacted_entities),
+                "total_path_score": sum(float(path["score"]) for path in activated_paths),
+            },
+        },
+    )
+
+
+def _path(
+    channel: str,
+    *,
+    edge_id: str,
+    score: float,
+    source_node_id: str = "node-source",
+    relationship_type: str = "SUPPLY_CHAIN",
+    target_node_id: str = "node-target",
+    target_entity_id: str | None = "entity-target",
+) -> dict[str, Any]:
+    return {
+        "channel": channel,
+        "source_node_id": source_node_id,
+        "source_entity_id": "entity-source",
+        "source_labels": ["Entity"],
+        "target_node_id": target_node_id,
+        "target_entity_id": target_entity_id,
+        "target_labels": ["Entity"],
+        "edge_id": edge_id,
+        "relationship_type": relationship_type,
+        "score": score,
+        "explanation": {
+            "relation_weight": score,
+            "evidence_confidence": 1.0,
+            "channel_multiplier": 1.0,
+            "regime_multiplier": 1.0,
+            "recency_decay": 1.0,
+            "score": score,
+        },
+    }
+
+
+def _entity(
+    channel: str,
+    *,
+    node_id: str,
+    score: float,
+    canonical_entity_id: str | None = "entity-target",
+    labels: list[str] | None = None,
+    path_count: int = 1,
+) -> dict[str, Any]:
+    return {
+        "channel": channel,
+        "node_id": node_id,
+        "canonical_entity_id": canonical_entity_id,
+        "labels": ["Entity"] if labels is None else labels,
+        "score": score,
+        "path_count": path_count,
+    }
+
+
+def _context(*, enabled_channels: list[str]) -> PropagationContext:
+    return PropagationContext(
+        cycle_id="cycle-1",
+        world_state_ref="world-state-1",
+        graph_generation_id=1,
+        enabled_channels=enabled_channels,  # type: ignore[arg-type]
+        channel_multipliers={channel: 1.0 for channel in enabled_channels},
+        regime_multipliers={channel: 1.0 for channel in enabled_channels},
+        decay_policy={},
+        regime_context={},
+    )
+
+
+def _status_manager() -> GraphStatusManager:
+    return GraphStatusManager(
+        InMemoryStatusStore(
+            Neo4jGraphStatus(
+                graph_status="ready",
+                graph_generation_id=1,
+                node_count=0,
+                edge_count=0,
+                key_label_counts={},
+                checksum="abc123",
+                last_verified_at=NOW,
+                last_reload_at=None,
+            ),
+        ),
+    )

--- a/tests/unit/test_snapshots.py
+++ b/tests/unit/test_snapshots.py
@@ -283,6 +283,28 @@ def test_compute_graph_snapshots_requires_status_source_without_side_effects() -
     client.execute_write.assert_not_called()
 
 
+def test_compute_graph_snapshots_rejects_graph_status_without_status_manager() -> None:
+    client = MagicMock()
+    reader = StaticRegimeReader()
+    writer = RecordingSnapshotWriter()
+
+    with pytest.raises(TypeError, match="status_manager"):
+        compute_graph_snapshots(
+            "cycle-1",
+            "world-state-1",
+            client=client,
+            graph_generation_id=1,
+            regime_reader=reader,
+            snapshot_writer=writer,
+            graph_status=_ready_status(),
+        )
+
+    assert reader.calls == []
+    assert writer.calls == []
+    client.execute_read.assert_not_called()
+    client.execute_write.assert_not_called()
+
+
 def test_compute_graph_snapshots_rejects_non_ready_status_without_side_effects() -> None:
     client = MagicMock()
     reader = StaticRegimeReader()
@@ -385,7 +407,14 @@ def test_compute_graph_snapshots_uses_status_manager_and_derives_generation(
     assert graph_snapshot.key_label_counts == {"Entity": 2}
     assert graph_snapshot.checksum == "abc123"
     assert impact_snapshot.regime_context_ref == "world-state-1"
-    assert events == ["context:7", "propagation:7", "metrics", "metrics", "write"]
+    assert events == [
+        "metrics",
+        "context:7",
+        "propagation:7",
+        "metrics",
+        "metrics",
+        "write",
+    ]
     assert writer.calls == [(graph_snapshot, impact_snapshot)]
 
 
@@ -393,15 +422,15 @@ def test_compute_graph_snapshots_uses_status_manager_and_derives_generation(
     ("field_name", "graph_generation_id", "status_updates", "expected_events"),
     [
         ("graph_generation_id", 2, {}, []),
-        ("node_count", 1, {"node_count": 999}, ["propagation", "metrics"]),
-        ("edge_count", 1, {"edge_count": 999}, ["propagation", "metrics"]),
+        ("node_count", 1, {"node_count": 999}, ["metrics"]),
+        ("edge_count", 1, {"edge_count": 999}, ["metrics"]),
         (
             "key_label_counts",
             1,
             {"key_label_counts": {"Entity": 999}},
-            ["propagation", "metrics"],
+            ["metrics"],
         ),
-        ("checksum", 1, {"checksum": "stale"}, ["propagation", "metrics"]),
+        ("checksum", 1, {"checksum": "stale"}, ["metrics"]),
     ],
 )
 def test_compute_graph_snapshots_rejects_status_disagreements_before_write(
@@ -437,10 +466,7 @@ def test_compute_graph_snapshots_rejects_status_disagreements_before_write(
         )
 
     assert events == expected_events
-    if field_name == "graph_generation_id":
-        assert reader.calls == []
-    else:
-        assert reader.calls == ["world-state-1"]
+    assert reader.calls == []
     assert writer.calls == []
 
 
@@ -484,7 +510,15 @@ def test_compute_graph_snapshots_writes_once_after_both_snapshots(
     assert graph_snapshot.node_count == 2
     assert graph_snapshot.edge_count == 1
     assert graph_snapshot.checksum == "abc123"
-    assert events == ["context", "propagation", "metrics", "impact", "metrics", "write"]
+    assert events == [
+        "metrics",
+        "context",
+        "propagation",
+        "metrics",
+        "impact",
+        "metrics",
+        "write",
+    ]
     assert writer.calls == [(graph_snapshot, impact_snapshot)]
 
 
@@ -559,7 +593,7 @@ def test_compute_graph_snapshots_rechecks_status_before_write(
         )
 
     assert status_store.calls == 3
-    assert events == ["context", "propagation", "metrics", "impact"]
+    assert events == ["metrics", "context", "propagation", "metrics", "impact"]
     assert writer.calls == []
 
 
@@ -573,6 +607,7 @@ def test_compute_graph_snapshots_rechecks_live_metrics_before_write(
         monkeypatch,
         events,
         metrics_sequence=[
+            (2, 1, {"Entity": 2}, "abc123"),
             (2, 1, {"Entity": 2}, "abc123"),
             (3, 1, {"Entity": 3}, "changed"),
         ],
@@ -605,7 +640,7 @@ def test_compute_graph_snapshots_rechecks_live_metrics_before_write(
             status_manager=status_manager,
         )
 
-    assert events == ["context", "propagation", "metrics", "impact", "metrics"]
+    assert events == ["metrics", "context", "propagation", "metrics", "impact", "metrics"]
     assert writer.calls == []
 
 

--- a/tests/unit/test_snapshots.py
+++ b/tests/unit/test_snapshots.py
@@ -231,7 +231,35 @@ def test_build_graph_impact_snapshot_preserves_propagation_payload() -> None:
     assert impact_snapshot.regime_context_ref == "world-state-1"
     assert impact_snapshot.activated_paths == propagation_result.activated_paths
     assert impact_snapshot.impacted_entities == propagation_result.impacted_entities
-    assert impact_snapshot.channel_breakdown == propagation_result.channel_breakdown
+    assert impact_snapshot.channel_breakdown == {
+        "fundamental": {"path_count": 1},
+        "event": {},
+        "reflexive": {},
+        "merged": {},
+    }
+
+
+def test_build_graph_impact_snapshot_id_tracks_full_propagation_payload() -> None:
+    baseline = build_graph_impact_snapshot(
+        "cycle-1",
+        "world-state-1",
+        _propagation_result(),
+    )
+    repeated = build_graph_impact_snapshot(
+        "cycle-1",
+        "world-state-1",
+        _propagation_result(),
+    )
+    changed_breakdown = _propagation_result()
+    changed_breakdown.channel_breakdown["event"] = {"path_count": 1}
+    changed = build_graph_impact_snapshot(
+        "cycle-1",
+        "world-state-1",
+        changed_breakdown,
+    )
+
+    assert repeated.impact_snapshot_id == baseline.impact_snapshot_id
+    assert changed.impact_snapshot_id != baseline.impact_snapshot_id
 
 
 def test_compute_graph_snapshots_requires_status_source_without_side_effects() -> None:
@@ -327,6 +355,7 @@ def test_compute_graph_snapshots_uses_status_manager_and_derives_generation(
         **kwargs: Any,
     ) -> PropagationContext:
         events.append(f"context:{graph_generation_id}")
+        assert kwargs["enabled_channels"] == ["fundamental", "event", "reflexive"]
         return _context(graph_generation_id=graph_generation_id)
 
     def run_propagation(
@@ -338,7 +367,7 @@ def test_compute_graph_snapshots_uses_status_manager_and_derives_generation(
         return _propagation_result(graph_generation_id=context.graph_generation_id)
 
     monkeypatch.setattr(snapshot_generator, "build_propagation_context", build_context)
-    monkeypatch.setattr(snapshot_generator, "run_fundamental_propagation", run_propagation)
+    monkeypatch.setattr(snapshot_generator, "run_full_propagation", run_propagation)
 
     graph_snapshot, impact_snapshot = compute_graph_snapshots(
         "cycle-1",
@@ -349,14 +378,14 @@ def test_compute_graph_snapshots_uses_status_manager_and_derives_generation(
         status_manager=status_manager,
     )
 
-    assert status_store.calls == 2
+    assert status_store.calls == 3
     assert graph_snapshot.graph_generation_id == 7
     assert graph_snapshot.node_count == 2
     assert graph_snapshot.edge_count == 1
     assert graph_snapshot.key_label_counts == {"Entity": 2}
     assert graph_snapshot.checksum == "abc123"
     assert impact_snapshot.regime_context_ref == "world-state-1"
-    assert events == ["metrics", "context:7", "propagation:7", "metrics", "write"]
+    assert events == ["context:7", "propagation:7", "metrics", "metrics", "write"]
     assert writer.calls == [(graph_snapshot, impact_snapshot)]
 
 
@@ -364,13 +393,18 @@ def test_compute_graph_snapshots_uses_status_manager_and_derives_generation(
     ("field_name", "graph_generation_id", "status_updates", "expected_events"),
     [
         ("graph_generation_id", 2, {}, []),
-        ("node_count", 1, {"node_count": 999}, ["metrics"]),
-        ("edge_count", 1, {"edge_count": 999}, ["metrics"]),
-        ("key_label_counts", 1, {"key_label_counts": {"Entity": 999}}, ["metrics"]),
-        ("checksum", 1, {"checksum": "stale"}, ["metrics"]),
+        ("node_count", 1, {"node_count": 999}, ["propagation", "metrics"]),
+        ("edge_count", 1, {"edge_count": 999}, ["propagation", "metrics"]),
+        (
+            "key_label_counts",
+            1,
+            {"key_label_counts": {"Entity": 999}},
+            ["propagation", "metrics"],
+        ),
+        ("checksum", 1, {"checksum": "stale"}, ["propagation", "metrics"]),
     ],
 )
-def test_compute_graph_snapshots_rejects_status_disagreements_before_propagation(
+def test_compute_graph_snapshots_rejects_status_disagreements_before_write(
     monkeypatch: pytest.MonkeyPatch,
     field_name: str,
     graph_generation_id: int,
@@ -389,7 +423,7 @@ def test_compute_graph_snapshots_rejects_status_disagreements_before_propagation
         events.append("propagation")
         return _propagation_result()
 
-    monkeypatch.setattr(snapshot_generator, "run_fundamental_propagation", run_propagation)
+    monkeypatch.setattr(snapshot_generator, "run_full_propagation", run_propagation)
 
     with pytest.raises(ValueError, match=field_name):
         compute_graph_snapshots(
@@ -403,7 +437,10 @@ def test_compute_graph_snapshots_rejects_status_disagreements_before_propagation
         )
 
     assert events == expected_events
-    assert reader.calls == []
+    if field_name == "graph_generation_id":
+        assert reader.calls == []
+    else:
+        assert reader.calls == ["world-state-1"]
     assert writer.calls == []
 
 
@@ -421,7 +458,7 @@ def test_compute_graph_snapshots_writes_once_after_both_snapshots(
     )
     monkeypatch.setattr(
         snapshot_generator,
-        "run_fundamental_propagation",
+        "run_full_propagation",
         lambda *args, **kwargs: events.append("propagation") or _propagation_result(),
     )
     monkeypatch.setattr(
@@ -447,8 +484,41 @@ def test_compute_graph_snapshots_writes_once_after_both_snapshots(
     assert graph_snapshot.node_count == 2
     assert graph_snapshot.edge_count == 1
     assert graph_snapshot.checksum == "abc123"
-    assert events == ["metrics", "context", "propagation", "impact", "metrics", "write"]
+    assert events == ["context", "propagation", "metrics", "impact", "metrics", "write"]
     assert writer.calls == [(graph_snapshot, impact_snapshot)]
+
+
+def test_compute_graph_snapshots_accepts_single_channel_regression_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    requested_channels: list[str] = []
+
+    _patch_metrics(monkeypatch)
+
+    def build_context(*args: Any, **kwargs: Any) -> PropagationContext:
+        requested_channels.extend(kwargs["enabled_channels"])
+        return _context()
+
+    monkeypatch.setattr(snapshot_generator, "build_propagation_context", build_context)
+    monkeypatch.setattr(
+        snapshot_generator,
+        "run_full_propagation",
+        lambda *args, **kwargs: _propagation_result(),
+    )
+    status_manager, _ = _status_manager(_ready_status())
+
+    compute_graph_snapshots(
+        "cycle-1",
+        "world-state-1",
+        client=MagicMock(),
+        graph_generation_id=1,
+        regime_reader=StaticRegimeReader(),
+        snapshot_writer=RecordingSnapshotWriter(),
+        status_manager=status_manager,
+        enabled_channels=["fundamental"],
+    )
+
+    assert requested_channels == ["fundamental"]
 
 
 def test_compute_graph_snapshots_rechecks_status_before_write(
@@ -457,7 +527,7 @@ def test_compute_graph_snapshots_rechecks_status_before_write(
     events: list[str] = []
     ready_status = _ready_status()
     rebuilding_status = _ready_status(graph_status="rebuilding")
-    status_manager, status_store = _status_manager([ready_status, rebuilding_status])
+    status_manager, status_store = _status_manager([ready_status, ready_status, rebuilding_status])
     writer = RecordingSnapshotWriter(events)
 
     _patch_metrics(monkeypatch, events)
@@ -468,7 +538,7 @@ def test_compute_graph_snapshots_rechecks_status_before_write(
     )
     monkeypatch.setattr(
         snapshot_generator,
-        "run_fundamental_propagation",
+        "run_full_propagation",
         lambda *args, **kwargs: events.append("propagation") or _propagation_result(),
     )
     monkeypatch.setattr(
@@ -488,8 +558,8 @@ def test_compute_graph_snapshots_rechecks_status_before_write(
             status_manager=status_manager,
         )
 
-    assert status_store.calls == 2
-    assert events == ["metrics", "context", "propagation", "impact"]
+    assert status_store.calls == 3
+    assert events == ["context", "propagation", "metrics", "impact"]
     assert writer.calls == []
 
 
@@ -514,7 +584,7 @@ def test_compute_graph_snapshots_rechecks_live_metrics_before_write(
     )
     monkeypatch.setattr(
         snapshot_generator,
-        "run_fundamental_propagation",
+        "run_full_propagation",
         lambda *args, **kwargs: events.append("propagation") or _propagation_result(),
     )
     monkeypatch.setattr(
@@ -535,7 +605,7 @@ def test_compute_graph_snapshots_rechecks_live_metrics_before_write(
             status_manager=status_manager,
         )
 
-    assert events == ["metrics", "context", "propagation", "impact", "metrics"]
+    assert events == ["context", "propagation", "metrics", "impact", "metrics"]
     assert writer.calls == []
 
 
@@ -552,7 +622,7 @@ def test_compute_graph_snapshots_does_not_write_if_snapshot_build_fails(
     )
     monkeypatch.setattr(
         snapshot_generator,
-        "run_fundamental_propagation",
+        "run_full_propagation",
         lambda *args, **kwargs: _propagation_result(),
     )
 
@@ -591,7 +661,7 @@ def test_compute_graph_snapshots_surfaces_writer_errors(
     )
     monkeypatch.setattr(
         snapshot_generator,
-        "run_fundamental_propagation",
+        "run_full_propagation",
         lambda *args, **kwargs: _propagation_result(),
     )
     monkeypatch.setattr(


### PR DESCRIPTION
Closes #9

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `benchmarks/artifacts/lite_target_100k_800k.json`, `benchmarks/generate_synthetic.py`, `benchmarks/run_benchmark.py`, `cross-cutting`, `graph_engine/__pycache__/__init__.cpython-314.pyc`, `graph_engine/live_metrics.py`, `graph_engine/propagation/context.py`, `graph_engine/propagation/event.py`, `graph_engine/reload/service.py`, `graph_engine/sync/live_graph.py`


---
### 1. 背景与目标
项目文档 §11.3 和 §11.4 要求三通道传播结果合并后生成正式 `GraphImpactSnapshot`，且 `channel_breakdown` 必须可解释、可审计。当前 `graph_engine/snapshots/generator.py::compute_graph_snapshots()` 只调用 `run_fundamental_propagation()`，`build_graph_impact_snapshot()` 虽然会原样保存 `PropagationResult.channel_breakdown`，但没有跨通道 merge 逻辑。#8 交付 event/reflexive runner 后，本 issue 负责把三通道 pipeline 接入 snapshot 生成闭环，并保持 snapshot writer 的原子写入顺序。

### 2. 所属模块
**主要写入路径：**
- `graph_engine/propagation/merge.py`（新增三通道融合逻辑）
- `graph_engine/propagation/pipeline.py`（新增 full propagation orchestration，如实现者选择将 orchestration 放在 `merge.py`，需保持 public API 等价）
- `graph_engine/propagation/__init__.py`（导出 merge / full propagation entry points）
- `graph_engine/snapshots/generator.py`（把 `compute_graph_snapshots()` 从单通道切到 full propagation）
- `graph_engine/snapshots/__init__.py`（如新增 public helper，补充 export）
- `tests/unit/test_propagation_merge.py`（新增 merge 单测）
- `tests/unit/test_snapshots.py`（更新 snapshot orchestration 单测）
- `tests/integration/test_full_propagation.py`（新增三通道端到端集成测试）

**相邻只读 / 集成路径：**
- `graph_engine/models.py`（读取 `PropagationContext`、`PropagationResult`、`GraphImpactSnapshot`）
- `graph_engine/propagation/fundamental.py`（调用 `run_fundamental_propagation()`）
- `graph_engine/propagation/event.py`（调用 #8 的 `run_event_propagation()`）
- `graph_engine/propagation/reflexive.py`（调用 #8 的 `run_reflexive_propagation()`）
- `graph_engine/propagation/context.py`（调用 #8 扩展后的 `build_propagation_context()`）
- `graph_engine/status/` 与 `graph_engine/live_metrics.py`（消费 milestone-2/P0 后的 read-gate 和严格 metrics 边界，不在本 issue 重写）

### 3. 实现范围
- 新增 `graph_engine/propagation/merge.py::merge_propagation_results(results: Sequence[PropagationResult], *, result_limit: int = 100) -> PropagationResult`；函数必须拒绝空 results、不同 `cycle_id`、不同 `graph_generation_id` 和缺失 `channel` 的 path/entity payload。
- Merge activated paths：把三通道 `activated_paths` 合并为一个列表，按 `score DESC, channel ASC, source_node_id ASC, relationship_type ASC, target_node_id ASC, edge_id ASC` 稳定排序，