### PR TITLE
feat(#34): [follow-up from PR #31] StatusStore TOCTOU at persistence boundary

### DIFF
--- a/graph_engine/__init__.py
+++ b/graph_engine/__init__.py
@@ -38,7 +38,6 @@ from graph_engine.status import (
     StatusStore,
     check_live_graph_consistency,
     hold_ready_read,
-    require_ready_read,
     require_ready_status,
 )
 
@@ -78,7 +77,6 @@ __all__ = [
     "load_config_from_env",
     "query_subgraph",
     "rebuild_gds_projection",
-    "require_ready_read",
     "require_ready_status",
     "simulate_readonly_impact",
 ]

--- a/graph_engine/__init__.py
+++ b/graph_engine/__init__.py
@@ -37,6 +37,7 @@ from graph_engine.status import (
     PostgresStatusStore,
     StatusStore,
     check_live_graph_consistency,
+    hold_ready_read,
     require_ready_read,
     require_ready_status,
 )
@@ -73,6 +74,7 @@ __all__ = [
     "cold_reload",
     "get_constraint_statements",
     "get_index_statements",
+    "hold_ready_read",
     "load_config_from_env",
     "query_subgraph",
     "rebuild_gds_projection",

--- a/graph_engine/propagation/event.py
+++ b/graph_engine/propagation/event.py
@@ -15,7 +15,7 @@ from graph_engine.propagation._gds import (
 )
 from graph_engine.propagation.scoring import build_score_explanation
 from graph_engine.schema.definitions import RelationshipType
-from graph_engine.status import GraphStatusManager, require_ready_read
+from graph_engine.status import GraphStatusManager, hold_ready_read
 
 EVENT_RELATIONSHIP_TYPES = (RelationshipType.EVENT_IMPACT.value,)
 _EVENT_CHANNEL = "event"
@@ -39,31 +39,31 @@ def run_event_propagation(
     if result_limit < 1:
         raise ValueError("result_limit must be greater than zero")
 
-    ready_status = require_ready_read(status_manager, "event propagation")
-    if ready_status.graph_generation_id != context.graph_generation_id:
-        raise ValueError(
-            "PropagationContext graph_generation_id disagrees with Neo4jGraphStatus: "
-            f"context={context.graph_generation_id}, "
-            f"status={ready_status.graph_generation_id}",
-        )
+    with hold_ready_read(status_manager, "event propagation") as ready_status:
+        if ready_status.graph_generation_id != context.graph_generation_id:
+            raise ValueError(
+                "PropagationContext graph_generation_id disagrees with Neo4jGraphStatus: "
+                f"context={context.graph_generation_id}, "
+                f"status={ready_status.graph_generation_id}",
+            )
 
-    projection_name = graph_name or _default_projection_name(context)
-    drop_projection_if_exists(client, projection_name)
-    try:
-        _create_projection(client, projection_name)
-        pagerank_entities = _stream_pagerank(
-            client,
-            projection_name,
-            max_iterations=max_iterations,
-            result_limit=result_limit,
-        )
-        activated_paths = _read_activated_paths(
-            context,
-            client,
-            result_limit=result_limit,
-        )
-    finally:
+        projection_name = graph_name or _default_projection_name(context)
         drop_projection_if_exists(client, projection_name)
+        try:
+            _create_projection(client, projection_name)
+            pagerank_entities = _stream_pagerank(
+                client,
+                projection_name,
+                max_iterations=max_iterations,
+                result_limit=result_limit,
+            )
+            activated_paths = _read_activated_paths(
+                context,
+                client,
+                result_limit=result_limit,
+            )
+        finally:
+            drop_projection_if_exists(client, projection_name)
 
     impacted_entities = _impacted_entities_from_paths(
         activated_paths,

--- a/graph_engine/propagation/fundamental.py
+++ b/graph_engine/propagation/fundamental.py
@@ -15,7 +15,7 @@ from graph_engine.propagation._gds import (
 )
 from graph_engine.propagation.scoring import build_score_explanation
 from graph_engine.schema.definitions import RelationshipType
-from graph_engine.status import GraphStatusManager, require_ready_read
+from graph_engine.status import GraphStatusManager, hold_ready_read
 
 FUNDAMENTAL_RELATIONSHIP_TYPES = (
     RelationshipType.SUPPLY_CHAIN.value,
@@ -44,31 +44,31 @@ def run_fundamental_propagation(
     if result_limit < 1:
         raise ValueError("result_limit must be greater than zero")
 
-    ready_status = require_ready_read(status_manager, "fundamental propagation")
-    if ready_status.graph_generation_id != context.graph_generation_id:
-        raise ValueError(
-            "PropagationContext graph_generation_id disagrees with Neo4jGraphStatus: "
-            f"context={context.graph_generation_id}, "
-            f"status={ready_status.graph_generation_id}",
-        )
+    with hold_ready_read(status_manager, "fundamental propagation") as ready_status:
+        if ready_status.graph_generation_id != context.graph_generation_id:
+            raise ValueError(
+                "PropagationContext graph_generation_id disagrees with Neo4jGraphStatus: "
+                f"context={context.graph_generation_id}, "
+                f"status={ready_status.graph_generation_id}",
+            )
 
-    projection_name = graph_name or _default_projection_name(context)
-    drop_projection_if_exists(client, projection_name)
-    try:
-        _create_projection(client, projection_name)
-        pagerank_entities = _stream_pagerank(
-            client,
-            projection_name,
-            max_iterations=max_iterations,
-            result_limit=result_limit,
-        )
-        activated_paths = _read_activated_paths(
-            context,
-            client,
-            result_limit=result_limit,
-        )
-    finally:
+        projection_name = graph_name or _default_projection_name(context)
         drop_projection_if_exists(client, projection_name)
+        try:
+            _create_projection(client, projection_name)
+            pagerank_entities = _stream_pagerank(
+                client,
+                projection_name,
+                max_iterations=max_iterations,
+                result_limit=result_limit,
+            )
+            activated_paths = _read_activated_paths(
+                context,
+                client,
+                result_limit=result_limit,
+            )
+        finally:
+            drop_projection_if_exists(client, projection_name)
 
     # Keep PageRank as the GDS topology pass, but rank persisted impacts by the
     # documented five-factor path scores so the snapshot outputs stay coherent.

--- a/graph_engine/propagation/reflexive.py
+++ b/graph_engine/propagation/reflexive.py
@@ -14,7 +14,7 @@ from graph_engine.propagation._gds import (
     execute_gds_write,
 )
 from graph_engine.propagation.scoring import build_score_explanation
-from graph_engine.status import GraphStatusManager, require_ready_read
+from graph_engine.status import GraphStatusManager, hold_ready_read
 
 _REFLEXIVE_CHANNEL = "reflexive"
 _REFLEXIVE_PATH_SELECTOR = (
@@ -41,35 +41,35 @@ def run_reflexive_propagation(
     if result_limit < 1:
         raise ValueError("result_limit must be greater than zero")
 
-    ready_status = require_ready_read(status_manager, "reflexive propagation")
-    if ready_status.graph_generation_id != context.graph_generation_id:
-        raise ValueError(
-            "PropagationContext graph_generation_id disagrees with Neo4jGraphStatus: "
-            f"context={context.graph_generation_id}, "
-            f"status={ready_status.graph_generation_id}",
-        )
+    with hold_ready_read(status_manager, "reflexive propagation") as ready_status:
+        if ready_status.graph_generation_id != context.graph_generation_id:
+            raise ValueError(
+                "PropagationContext graph_generation_id disagrees with Neo4jGraphStatus: "
+                f"context={context.graph_generation_id}, "
+                f"status={ready_status.graph_generation_id}",
+            )
 
-    projection_name = graph_name or _default_projection_name(context)
-    drop_projection_if_exists(client, projection_name)
-    try:
-        relationship_count = _create_projection(client, projection_name)
-        if relationship_count == 0:
-            pagerank_entities: list[dict[str, Any]] = []
-            activated_paths: list[dict[str, Any]] = []
-        else:
-            pagerank_entities = _stream_pagerank(
-                client,
-                projection_name,
-                max_iterations=max_iterations,
-                result_limit=result_limit,
-            )
-            activated_paths = _read_activated_paths(
-                context,
-                client,
-                result_limit=result_limit,
-            )
-    finally:
+        projection_name = graph_name or _default_projection_name(context)
         drop_projection_if_exists(client, projection_name)
+        try:
+            relationship_count = _create_projection(client, projection_name)
+            if relationship_count == 0:
+                pagerank_entities: list[dict[str, Any]] = []
+                activated_paths: list[dict[str, Any]] = []
+            else:
+                pagerank_entities = _stream_pagerank(
+                    client,
+                    projection_name,
+                    max_iterations=max_iterations,
+                    result_limit=result_limit,
+                )
+                activated_paths = _read_activated_paths(
+                    context,
+                    client,
+                    result_limit=result_limit,
+                )
+        finally:
+            drop_projection_if_exists(client, projection_name)
 
     impacted_entities = _impacted_entities_from_paths(
         activated_paths,

--- a/graph_engine/query/__init__.py
+++ b/graph_engine/query/__init__.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from graph_engine.client import Neo4jClient
 from graph_engine.models import ReadonlySimulationRequest
-from graph_engine.status import GraphStatusManager, require_ready_read
+from graph_engine.status import GraphStatusManager, hold_ready_read
 
 MAX_QUERY_DEPTH = 10
 
@@ -20,8 +20,8 @@ def query_subgraph(
 ) -> dict[str, Any]:
     """Return a bounded live subgraph after verifying the graph is ready."""
 
-    require_ready_read(status_manager, "subgraph query")
-    return _query_subgraph_after_ready(seed_entities, depth, client=client)
+    with hold_ready_read(status_manager, "subgraph query"):
+        return _query_subgraph_after_ready(seed_entities, depth, client=client)
 
 
 def simulate_readonly_impact(
@@ -33,36 +33,36 @@ def simulate_readonly_impact(
 ) -> dict[str, Any]:
     """Run a read-only local impact simulation without modifying live graph state."""
 
-    ready_status = require_ready_read(status_manager, "readonly impact simulation")
-    if ready_status.graph_generation_id != context.graph_generation_id:
-        raise ValueError(
-            "ReadonlySimulationRequest graph_generation_id disagrees with Neo4jGraphStatus: "
-            f"context={context.graph_generation_id}, "
-            f"status={ready_status.graph_generation_id}",
-        )
+    with hold_ready_read(status_manager, "readonly impact simulation") as ready_status:
+        if ready_status.graph_generation_id != context.graph_generation_id:
+            raise ValueError(
+                "ReadonlySimulationRequest graph_generation_id disagrees with Neo4jGraphStatus: "
+                f"context={context.graph_generation_id}, "
+                f"status={ready_status.graph_generation_id}",
+            )
 
-    subgraph = _query_subgraph_after_ready(seed_entities, context.depth, client=client)
-    impacted_entities = _impacted_entities_from_subgraph(
-        subgraph,
-        set(seed_entities),
-        result_limit=context.result_limit,
-    )
-    return {
-        "cycle_id": context.cycle_id,
-        "world_state_ref": context.world_state_ref,
-        "graph_generation_id": ready_status.graph_generation_id,
-        "seed_entities": list(seed_entities),
-        "subgraph": subgraph,
-        "impacted_entities": impacted_entities,
-        "activated_paths": list(subgraph["relationships"]),
-        "channel_breakdown": {
-            "readonly": {
-                "depth": subgraph["depth"],
-                "node_count": len(subgraph["nodes"]),
-                "edge_count": len(subgraph["relationships"]),
+        subgraph = _query_subgraph_after_ready(seed_entities, context.depth, client=client)
+        impacted_entities = _impacted_entities_from_subgraph(
+            subgraph,
+            set(seed_entities),
+            result_limit=context.result_limit,
+        )
+        return {
+            "cycle_id": context.cycle_id,
+            "world_state_ref": context.world_state_ref,
+            "graph_generation_id": ready_status.graph_generation_id,
+            "seed_entities": list(seed_entities),
+            "subgraph": subgraph,
+            "impacted_entities": impacted_entities,
+            "activated_paths": list(subgraph["relationships"]),
+            "channel_breakdown": {
+                "readonly": {
+                    "depth": subgraph["depth"],
+                    "node_count": len(subgraph["nodes"]),
+                    "edge_count": len(subgraph["relationships"]),
+                },
             },
-        },
-    }
+        }
 
 
 def _query_subgraph_after_ready(

--- a/graph_engine/snapshots/generator.py
+++ b/graph_engine/snapshots/generator.py
@@ -21,7 +21,7 @@ from graph_engine.models import (
 from graph_engine.propagation.context import RegimeContextReader, build_propagation_context
 from graph_engine.propagation.pipeline import run_full_propagation
 from graph_engine.snapshots.writer import SnapshotWriter
-from graph_engine.status import GraphStatusManager, require_ready_read, require_ready_status
+from graph_engine.status import GraphStatusManager, hold_ready_read, require_ready_status
 
 _DEFAULT_SNAPSHOT_CHANNELS: tuple[PropagationChannel, ...] = (
     "fundamental",
@@ -39,17 +39,17 @@ def build_graph_snapshot(
 ) -> GraphSnapshot:
     """Read live graph metrics and return a deterministic structural snapshot."""
 
-    ready_status = require_ready_read(status_manager, "graph snapshot generation")
-    _validate_generation_input(graph_generation_id, ready_status)
-    node_count, edge_count, key_label_counts, checksum = _read_graph_metrics(client)
-    return _graph_snapshot_from_metrics(
-        cycle_id,
-        graph_generation_id,
-        node_count=node_count,
-        edge_count=edge_count,
-        key_label_counts=key_label_counts,
-        checksum=checksum,
-    )
+    with hold_ready_read(status_manager, "graph snapshot generation") as ready_status:
+        _validate_generation_input(graph_generation_id, ready_status)
+        node_count, edge_count, key_label_counts, checksum = _read_graph_metrics(client)
+        return _graph_snapshot_from_metrics(
+            cycle_id,
+            graph_generation_id,
+            node_count=node_count,
+            edge_count=edge_count,
+            key_label_counts=key_label_counts,
+            checksum=checksum,
+        )
 
 
 def build_graph_impact_snapshot(
@@ -96,57 +96,56 @@ def compute_graph_snapshots(
 ) -> tuple[GraphSnapshot, GraphImpactSnapshot]:
     """Run full propagation and write graph plus impact snapshots."""
 
-    ready_status = _resolve_ready_status(
-        status_manager=status_manager,
-        graph_status=graph_status,
-        operation="snapshot generation",
-    )
-    _validate_generation_input(graph_generation_id, ready_status)
-    _validate_pre_propagation_status_and_metrics(ready_status, client)
-    requested_channels = list(
-        _DEFAULT_SNAPSHOT_CHANNELS if enabled_channels is None else enabled_channels
-    )
-    context = build_propagation_context(
-        cycle_id,
-        world_state_ref,
-        ready_status.graph_generation_id,
-        regime_reader=regime_reader,
-        graph_status=ready_status,
-        enabled_channels=requested_channels,
-    )
-    propagation_result = run_full_propagation(
-        context,
-        client,
-        status_manager=status_manager,
-        graph_name=graph_name,
-        max_iterations=max_iterations,
-        result_limit=result_limit,
-    )
-    graph_snapshot = build_graph_snapshot(
-        cycle_id,
-        ready_status.graph_generation_id,
-        client,
-        status_manager=status_manager,
-    )
-    _validate_status_metrics(
-        ready_status,
-        node_count=graph_snapshot.node_count,
-        edge_count=graph_snapshot.edge_count,
-        key_label_counts=graph_snapshot.key_label_counts,
-        checksum=graph_snapshot.checksum,
-    )
-    impact_snapshot = build_graph_impact_snapshot(
-        cycle_id,
-        world_state_ref,
-        propagation_result,
-    )
-    _validate_publication_status_and_metrics(
-        ready_status,
-        status_manager,
-        client,
-    )
-    snapshot_writer.write_snapshots(graph_snapshot, impact_snapshot)
-    return graph_snapshot, impact_snapshot
+    with hold_ready_read(status_manager, "snapshot generation") as ready_status:
+        if graph_status is not None:
+            require_ready_status(graph_status)
+            _validate_status_matches_ready_status(ready_status, graph_status)
+        _validate_generation_input(graph_generation_id, ready_status)
+        _validate_pre_propagation_status_and_metrics(ready_status, client)
+        requested_channels = list(
+            _DEFAULT_SNAPSHOT_CHANNELS if enabled_channels is None else enabled_channels
+        )
+        context = build_propagation_context(
+            cycle_id,
+            world_state_ref,
+            ready_status.graph_generation_id,
+            regime_reader=regime_reader,
+            graph_status=ready_status,
+            enabled_channels=requested_channels,
+        )
+        propagation_result = run_full_propagation(
+            context,
+            client,
+            status_manager=status_manager,
+            graph_name=graph_name,
+            max_iterations=max_iterations,
+            result_limit=result_limit,
+        )
+        graph_snapshot = build_graph_snapshot(
+            cycle_id,
+            ready_status.graph_generation_id,
+            client,
+            status_manager=status_manager,
+        )
+        _validate_status_metrics(
+            ready_status,
+            node_count=graph_snapshot.node_count,
+            edge_count=graph_snapshot.edge_count,
+            key_label_counts=graph_snapshot.key_label_counts,
+            checksum=graph_snapshot.checksum,
+        )
+        impact_snapshot = build_graph_impact_snapshot(
+            cycle_id,
+            world_state_ref,
+            propagation_result,
+        )
+        _validate_publication_status_and_metrics(
+            ready_status,
+            status_manager,
+            client,
+        )
+        snapshot_writer.write_snapshots(graph_snapshot, impact_snapshot)
+        return graph_snapshot, impact_snapshot
 
 
 def _validate_generation_input(
@@ -173,21 +172,6 @@ def _complete_channel_breakdown(channel_breakdown: dict[str, Any]) -> dict[str, 
             completed[key] = value
     completed["merged"] = channel_breakdown.get("merged", {})
     return completed
-
-
-def _resolve_ready_status(
-    *,
-    status_manager: GraphStatusManager | None,
-    graph_status: Neo4jGraphStatus | None,
-    operation: str,
-) -> Neo4jGraphStatus:
-    if status_manager is None:
-        raise TypeError(f"{operation} requires status_manager")
-    ready_status = require_ready_read(status_manager, operation)
-    if graph_status is not None:
-        require_ready_status(graph_status)
-        _validate_status_matches_ready_status(ready_status, graph_status)
-    return ready_status
 
 
 def _validate_pre_propagation_status_and_metrics(
@@ -243,7 +227,7 @@ def _validate_publication_status_and_metrics(
     client: Neo4jClient,
 ) -> None:
     try:
-        current_status = require_ready_read(status_manager, "snapshot publication")
+        current_status = require_ready_status(status_manager.get_status())
     except PermissionError as exc:
         raise RuntimeError("ready graph status changed before snapshot publication") from exc
     _validate_status_matches_ready_status(current_status, ready_status)

--- a/graph_engine/status/__init__.py
+++ b/graph_engine/status/__init__.py
@@ -7,7 +7,6 @@ from graph_engine.status.consistency import (
 from graph_engine.status.manager import (
     GraphStatusManager,
     hold_ready_read,
-    require_ready_read,
     require_ready_status,
 )
 from graph_engine.status.store import PostgreSQLStatusStore, PostgresStatusStore, StatusStore
@@ -20,6 +19,5 @@ __all__ = [
     "StatusStore",
     "check_live_graph_consistency",
     "hold_ready_read",
-    "require_ready_read",
     "require_ready_status",
 ]

--- a/graph_engine/status/__init__.py
+++ b/graph_engine/status/__init__.py
@@ -6,6 +6,7 @@ from graph_engine.status.consistency import (
 )
 from graph_engine.status.manager import (
     GraphStatusManager,
+    hold_ready_read,
     require_ready_read,
     require_ready_status,
 )
@@ -18,6 +19,7 @@ __all__ = [
     "PostgresStatusStore",
     "StatusStore",
     "check_live_graph_consistency",
+    "hold_ready_read",
     "require_ready_read",
     "require_ready_status",
 ]

--- a/graph_engine/status/consistency.py
+++ b/graph_engine/status/consistency.py
@@ -8,7 +8,7 @@ from typing import Protocol
 from graph_engine.client import Neo4jClient
 from graph_engine.live_metrics import read_live_graph_metrics
 from graph_engine.models import GraphSnapshot, Neo4jGraphStatus
-from graph_engine.status.manager import GraphStatusManager
+from graph_engine.status.manager import GraphStatusManager, hold_ready_read
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -30,8 +30,33 @@ def check_live_graph_consistency(
 ) -> bool:
     """Return whether live Neo4j metrics match the canonical graph snapshot."""
 
-    status = _resolve_status(status_manager, require_ready=require_ready)
+    if require_ready:
+        if status_manager is None:
+            raise ValueError("status_manager is required when require_ready=True")
+        with hold_ready_read(status_manager, "live graph consistency") as status:
+            return _check_live_graph_consistency_after_status(
+                snapshot_ref,
+                client=client,
+                snapshot_reader=snapshot_reader,
+                status=status,
+            )
 
+    current_status = _resolve_status(status_manager)
+    return _check_live_graph_consistency_after_status(
+        snapshot_ref,
+        client=client,
+        snapshot_reader=snapshot_reader,
+        status=current_status,
+    )
+
+
+def _check_live_graph_consistency_after_status(
+    snapshot_ref: str,
+    *,
+    client: Neo4jClient,
+    snapshot_reader: CanonicalSnapshotReader,
+    status: Neo4jGraphStatus | None,
+) -> bool:
     try:
         snapshot = snapshot_reader.read_graph_snapshot(snapshot_ref)
     except Exception:
@@ -87,14 +112,7 @@ def check_live_graph_consistency(
 
 def _resolve_status(
     status_manager: GraphStatusManager | None,
-    *,
-    require_ready: bool,
 ) -> Neo4jGraphStatus | None:
-    if require_ready:
-        if status_manager is None:
-            raise ValueError("status_manager is required when require_ready=True")
-        return status_manager.require_ready()
-
     if status_manager is None:
         return None
     try:

--- a/graph_engine/status/manager.py
+++ b/graph_engine/status/manager.py
@@ -261,18 +261,6 @@ class GraphStatusManager:
             )
 
 
-def require_ready_read(
-    status_manager: GraphStatusManager | None,
-    operation: str,
-) -> Neo4jGraphStatus:
-    """Return the ready status required before a public Neo4j read operation."""
-
-    if status_manager is None:
-        raise ValueError(f"{operation} requires status_manager")
-    with status_manager.ready_read() as ready_status:
-        return ready_status
-
-
 @contextmanager
 def hold_ready_read(
     status_manager: GraphStatusManager | None,

--- a/graph_engine/status/manager.py
+++ b/graph_engine/status/manager.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
 from datetime import datetime, timezone
 
 from graph_engine.models import GraphSnapshot, Neo4jGraphStatus
@@ -48,6 +49,13 @@ class GraphStatusManager:
         """Return the current ready status or block non-ready graph reads."""
 
         return require_ready_status(self.get_status())
+
+    @contextmanager
+    def ready_read(self) -> Iterator[Neo4jGraphStatus]:
+        """Hold the shared ready-read lock while live graph reads execute."""
+
+        with self.store.ready_read_lock():
+            yield self.require_ready()
 
     def mark_rebuilding(self) -> Neo4jGraphStatus:
         """Move an empty, ready, or failed status into rebuilding."""
@@ -261,7 +269,21 @@ def require_ready_read(
 
     if status_manager is None:
         raise ValueError(f"{operation} requires status_manager")
-    return status_manager.require_ready()
+    with status_manager.ready_read() as ready_status:
+        return ready_status
+
+
+@contextmanager
+def hold_ready_read(
+    status_manager: GraphStatusManager | None,
+    operation: str,
+) -> Iterator[Neo4jGraphStatus]:
+    """Hold the ready-read lock required during a public Neo4j read operation."""
+
+    if status_manager is None:
+        raise ValueError(f"{operation} requires status_manager")
+    with status_manager.ready_read() as ready_status:
+        yield ready_status
 
 
 def _utc_now() -> datetime:

--- a/graph_engine/status/store.py
+++ b/graph_engine/status/store.py
@@ -45,11 +45,12 @@ class PostgreSQLStatusStore:
     PostgreSQL ``READ COMMITTED`` isolation or stronger: compare-and-set writes
     are a single ``UPDATE ... WHERE`` statement, so PostgreSQL locks the row and
     rechecks the expected fields after any competing transaction commits.  Ready
-    reads hold a shared advisory lock, and status writes take the matching
-    exclusive advisory lock so distinct store instances backed by the same row
-    share the same read/write barrier.  Empty store bootstrap uses the singleton
-    primary key with ``ON CONFLICT DO NOTHING`` so only one process can create
-    the first status row.
+    reads hold a shared advisory lock on a dedicated connection for the duration
+    of the read body, and status writes take the matching exclusive advisory lock
+    so distinct store instances backed by the same row share the same read/write
+    barrier.  Empty store bootstrap uses the singleton primary key with
+    ``ON CONFLICT DO NOTHING`` so only one process can create the first status
+    row.
     """
 
     def __init__(
@@ -79,7 +80,6 @@ class PostgreSQLStatusStore:
         self._connection_factory = connection_factory
         self._table_name = _quote_qualified_identifier(table_name)
         self._status_key = status_key
-        self._advisory_lock_key = _advisory_lock_key(table_name, status_key)
         self._auto_bootstrap = auto_bootstrap
         self._bootstrapped = False
         self._bootstrap_lock = Lock()
@@ -184,11 +184,13 @@ WHERE status_key = %s
         self._ensure_bootstrap()
         connection = self._connection_factory()
         locked = False
+        lock_key: int | None = None
         try:
             with connection.cursor() as cursor:
+                lock_key = self._resolve_advisory_lock_key(cursor)
                 cursor.execute(
                     "SELECT pg_advisory_lock_shared(%s)",
-                    (self._advisory_lock_key,),
+                    (lock_key,),
                 )
                 locked = True
             connection.commit()
@@ -198,11 +200,12 @@ WHERE status_key = %s
             raise
         finally:
             if locked:
+                assert lock_key is not None
                 try:
                     with connection.cursor() as cursor:
                         cursor.execute(
                             "SELECT pg_advisory_unlock_shared(%s)",
-                            (self._advisory_lock_key,),
+                            (lock_key,),
                         )
                     connection.commit()
                 except Exception:
@@ -324,10 +327,18 @@ RETURNING status_key
                 return cursor.fetchone() is not None
 
     def _acquire_exclusive_status_lock(self, cursor: Any) -> None:
+        lock_key = self._resolve_advisory_lock_key(cursor)
         cursor.execute(
             "SELECT pg_advisory_xact_lock(%s)",
-            (self._advisory_lock_key,),
+            (lock_key,),
         )
+
+    def _resolve_advisory_lock_key(self, cursor: Any) -> int:
+        cursor.execute("SELECT %s::regclass::oid", (self._table_name,))
+        row = cursor.fetchone()
+        if row is None:
+            raise RuntimeError("PostgreSQL did not return a status table OID")
+        return _advisory_lock_key(int(row[0]), self._status_key)
 
     def _ensure_bootstrap(self) -> None:
         if self._auto_bootstrap and not self._bootstrapped:
@@ -421,8 +432,8 @@ def _quote_identifier(identifier: str) -> str:
     return f'"{identifier}"'
 
 
-def _advisory_lock_key(table_name: str, status_key: str) -> int:
-    lock_name = f"{table_name}\0{status_key}".encode()
+def _advisory_lock_key(relation_oid: int, status_key: str) -> int:
+    lock_name = f"{relation_oid}\0{status_key}".encode()
     digest = hashlib.blake2b(
         lock_name,
         digest_size=8,

--- a/graph_engine/status/store.py
+++ b/graph_engine/status/store.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
-import json
+import hashlib
 import importlib
+import json
 import os
 import re
 from collections.abc import Callable, Iterator, Mapping
-from contextlib import contextmanager
+from contextlib import AbstractContextManager, contextmanager
 from threading import Lock
 from typing import Any, Protocol
 
@@ -18,6 +19,9 @@ _GRAPH_STATUS_CHECK_CONSTRAINT = "neo4j_graph_status_graph_status_check"
 
 class StatusStore(Protocol):
     """Persistence boundary for the singleton Neo4j graph status row."""
+
+    def ready_read_lock(self) -> AbstractContextManager[None]:
+        """Hold a shared persistence lock for a ready live-graph read."""
 
     def read_current_status(self) -> Neo4jGraphStatus | None:
         """Return the current status row, or None before bootstrap."""
@@ -40,9 +44,12 @@ class PostgreSQLStatusStore:
     The store keeps one row in ``neo4j_graph_status`` by default.  It expects
     PostgreSQL ``READ COMMITTED`` isolation or stronger: compare-and-set writes
     are a single ``UPDATE ... WHERE`` statement, so PostgreSQL locks the row and
-    rechecks the expected fields after any competing transaction commits.  Empty
-    store bootstrap uses the singleton primary key with ``ON CONFLICT DO
-    NOTHING`` so only one process can create the first status row.
+    rechecks the expected fields after any competing transaction commits.  Ready
+    reads hold a shared advisory lock, and status writes take the matching
+    exclusive advisory lock so distinct store instances backed by the same row
+    share the same read/write barrier.  Empty store bootstrap uses the singleton
+    primary key with ``ON CONFLICT DO NOTHING`` so only one process can create
+    the first status row.
     """
 
     def __init__(
@@ -72,6 +79,7 @@ class PostgreSQLStatusStore:
         self._connection_factory = connection_factory
         self._table_name = _quote_qualified_identifier(table_name)
         self._status_key = status_key
+        self._advisory_lock_key = _advisory_lock_key(table_name, status_key)
         self._auto_bootstrap = auto_bootstrap
         self._bootstrapped = False
         self._bootstrap_lock = Lock()
@@ -169,6 +177,42 @@ WHERE status_key = %s
             return None
         return _status_from_row(row)
 
+    @contextmanager
+    def ready_read_lock(self) -> Iterator[None]:
+        """Hold a shared PostgreSQL advisory lock for a live-graph read."""
+
+        self._ensure_bootstrap()
+        connection = self._connection_factory()
+        locked = False
+        try:
+            with connection.cursor() as cursor:
+                cursor.execute(
+                    "SELECT pg_advisory_lock_shared(%s)",
+                    (self._advisory_lock_key,),
+                )
+                locked = True
+            connection.commit()
+            yield
+        except Exception:
+            connection.rollback()
+            raise
+        finally:
+            if locked:
+                try:
+                    with connection.cursor() as cursor:
+                        cursor.execute(
+                            "SELECT pg_advisory_unlock_shared(%s)",
+                            (self._advisory_lock_key,),
+                        )
+                    connection.commit()
+                except Exception:
+                    connection.rollback()
+                    raise
+                finally:
+                    connection.close()
+            else:
+                connection.close()
+
     def write_current_status(self, status: Neo4jGraphStatus) -> None:
         """Persist the current status row without comparing the previous value."""
 
@@ -176,6 +220,7 @@ WHERE status_key = %s
         values = _status_write_values(status)
         with self._transaction() as connection:
             with connection.cursor() as cursor:
+                self._acquire_exclusive_status_lock(cursor)
                 cursor.execute(
                     f"""
 INSERT INTO {self._table_name} (
@@ -222,6 +267,7 @@ ON CONFLICT (status_key) DO UPDATE SET
         expected_values = _status_write_values(expected_status)
         with self._transaction() as connection:
             with connection.cursor() as cursor:
+                self._acquire_exclusive_status_lock(cursor)
                 cursor.execute(
                     f"""
 UPDATE {self._table_name}
@@ -254,6 +300,7 @@ RETURNING status_key
     def _insert_if_missing(self, next_values: tuple[Any, ...]) -> bool:
         with self._transaction() as connection:
             with connection.cursor() as cursor:
+                self._acquire_exclusive_status_lock(cursor)
                 cursor.execute(
                     f"""
 INSERT INTO {self._table_name} (
@@ -275,6 +322,12 @@ RETURNING status_key
                     (self._status_key, *next_values),
                 )
                 return cursor.fetchone() is not None
+
+    def _acquire_exclusive_status_lock(self, cursor: Any) -> None:
+        cursor.execute(
+            "SELECT pg_advisory_xact_lock(%s)",
+            (self._advisory_lock_key,),
+        )
 
     def _ensure_bootstrap(self) -> None:
         if self._auto_bootstrap and not self._bootstrapped:
@@ -366,6 +419,16 @@ def _quote_identifier(identifier: str) -> str:
     if _IDENTIFIER_RE.fullmatch(identifier) is None:
         raise ValueError(f"invalid PostgreSQL identifier: {identifier!r}")
     return f'"{identifier}"'
+
+
+def _advisory_lock_key(table_name: str, status_key: str) -> int:
+    lock_name = f"{table_name}\0{status_key}".encode()
+    digest = hashlib.blake2b(
+        lock_name,
+        digest_size=8,
+        person=b"ge-status",
+    ).digest()
+    return int.from_bytes(digest, byteorder="big", signed=True)
 
 
 def _status_write_values(status: Neo4jGraphStatus) -> tuple[Any, ...]:

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -2,14 +2,33 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator
+from contextlib import contextmanager
+from threading import Condition
+
 from graph_engine.models import Neo4jGraphStatus
+
+
+class InMemoryStatusState:
+    """Shared in-memory status row used by distinct StatusStore fakes."""
+
+    def __init__(self, status: Neo4jGraphStatus | None = None) -> None:
+        self.status = status
+        self.condition = Condition()
+        self.ready_readers = 0
+        self.writer_active = False
 
 
 class InMemoryStatusStore:
     """In-memory StatusStore fake with write and CAS observability."""
 
-    def __init__(self, status: Neo4jGraphStatus | None = None) -> None:
-        self.status = status
+    def __init__(
+        self,
+        status: Neo4jGraphStatus | None = None,
+        *,
+        state: InMemoryStatusState | None = None,
+    ) -> None:
+        self._state = state or InMemoryStatusState(status)
         self.writes: list[Neo4jGraphStatus] = []
         self.compare_calls: list[tuple[Neo4jGraphStatus | None, Neo4jGraphStatus]] = []
 
@@ -21,12 +40,35 @@ class InMemoryStatusStore:
     def graph_status(self, status: Neo4jGraphStatus | None) -> None:
         self.status = status
 
+    @property
+    def status(self) -> Neo4jGraphStatus | None:
+        return self._state.status
+
+    @status.setter
+    def status(self, status: Neo4jGraphStatus | None) -> None:
+        self._state.status = status
+
+    @contextmanager
+    def ready_read_lock(self) -> Iterator[None]:
+        with self._state.condition:
+            while self._state.writer_active:
+                self._state.condition.wait()
+            self._state.ready_readers += 1
+        try:
+            yield
+        finally:
+            with self._state.condition:
+                self._state.ready_readers -= 1
+                if self._state.ready_readers == 0:
+                    self._state.condition.notify_all()
+
     def read_current_status(self) -> Neo4jGraphStatus | None:
         return self.status
 
     def write_current_status(self, status: Neo4jGraphStatus) -> None:
-        self.status = status
-        self.writes.append(status)
+        with self._write_lock():
+            self.status = status
+            self.writes.append(status)
 
     def compare_and_write_current_status(
         self,
@@ -36,7 +78,22 @@ class InMemoryStatusStore:
     ) -> bool:
         if isinstance(self.compare_calls, list):
             self.compare_calls.append((expected_status, next_status))
-        if self.status != expected_status:
-            return False
-        self.write_current_status(next_status)
-        return True
+        with self._write_lock():
+            if self.status != expected_status:
+                return False
+            self.status = next_status
+            self.writes.append(next_status)
+            return True
+
+    @contextmanager
+    def _write_lock(self) -> Iterator[None]:
+        with self._state.condition:
+            while self._state.writer_active or self._state.ready_readers > 0:
+                self._state.condition.wait()
+            self._state.writer_active = True
+        try:
+            yield
+        finally:
+            with self._state.condition:
+                self._state.writer_active = False
+                self._state.condition.notify_all()

--- a/tests/integration/test_postgresql_status_store.py
+++ b/tests/integration/test_postgresql_status_store.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timezone
-from threading import Barrier
+from threading import Barrier, Event
 from typing import Any
 from uuid import uuid4
 
@@ -94,6 +94,63 @@ def test_postgresql_status_store_rejects_competing_reload_and_sync_transitions()
             and final_status.writer_lock_token is not None
         )
     finally:
+        _drop_table(database_url, table_name)
+
+
+def test_postgresql_ready_read_lock_blocks_competing_store_writer() -> None:
+    pytest.importorskip("psycopg")
+
+    database_url = _database_url()
+    table_name = _table_name()
+    store = PostgreSQLStatusStore(database_url, table_name=table_name)
+    store.write_current_status(_status())
+
+    reader_entered = Event()
+    release_reader = Event()
+    writer_started = Event()
+
+    class ObservedWriterStore(PostgreSQLStatusStore):
+        def compare_and_write_current_status(
+            self,
+            *,
+            expected_status: Neo4jGraphStatus | None,
+            next_status: Neo4jGraphStatus,
+        ) -> bool:
+            writer_started.set()
+            return super().compare_and_write_current_status(
+                expected_status=expected_status,
+                next_status=next_status,
+            )
+
+    def hold_reader() -> Neo4jGraphStatus:
+        reader_store = PostgreSQLStatusStore(database_url, table_name=table_name)
+        with GraphStatusManager(reader_store, clock=lambda: NOW).ready_read() as status:
+            reader_entered.set()
+            release_reader.wait(timeout=10)
+            return status
+
+    def begin_sync() -> tuple[Neo4jGraphStatus, Neo4jGraphStatus]:
+        writer_store = ObservedWriterStore(database_url, table_name=table_name)
+        return GraphStatusManager(writer_store, clock=lambda: NOW).begin_sync()
+
+    try:
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            reader_future = executor.submit(hold_reader)
+            assert reader_entered.wait(timeout=10)
+
+            writer_future = executor.submit(begin_sync)
+            assert writer_started.wait(timeout=10)
+            assert not writer_future.done()
+
+            release_reader.set()
+            ready_status, locked_status = writer_future.result(timeout=20)
+            assert reader_future.result(timeout=20) == _status()
+
+        assert ready_status == _status()
+        assert locked_status.graph_status == "ready"
+        assert locked_status.writer_lock_token is not None
+    finally:
+        release_reader.set()
         _drop_table(database_url, table_name)
 
 

--- a/tests/integration/test_postgresql_status_store.py
+++ b/tests/integration/test_postgresql_status_store.py
@@ -154,6 +154,64 @@ def test_postgresql_ready_read_lock_blocks_competing_store_writer() -> None:
         _drop_table(database_url, table_name)
 
 
+def test_postgresql_ready_read_lock_uses_resolved_relation_for_schema_qualified_store() -> None:
+    pytest.importorskip("psycopg")
+
+    database_url = _database_url()
+    table_name = _table_name()
+    qualified_table_name = f"public.{table_name}"
+    store = PostgreSQLStatusStore(database_url, table_name=qualified_table_name)
+    store.write_current_status(_status())
+
+    reader_entered = Event()
+    release_reader = Event()
+    writer_started = Event()
+
+    class ObservedWriterStore(PostgreSQLStatusStore):
+        def compare_and_write_current_status(
+            self,
+            *,
+            expected_status: Neo4jGraphStatus | None,
+            next_status: Neo4jGraphStatus,
+        ) -> bool:
+            writer_started.set()
+            return super().compare_and_write_current_status(
+                expected_status=expected_status,
+                next_status=next_status,
+            )
+
+    def hold_reader() -> Neo4jGraphStatus:
+        reader_store = PostgreSQLStatusStore(database_url, table_name=table_name)
+        with GraphStatusManager(reader_store, clock=lambda: NOW).ready_read() as status:
+            reader_entered.set()
+            release_reader.wait(timeout=10)
+            return status
+
+    def begin_sync() -> tuple[Neo4jGraphStatus, Neo4jGraphStatus]:
+        writer_store = ObservedWriterStore(database_url, table_name=qualified_table_name)
+        return GraphStatusManager(writer_store, clock=lambda: NOW).begin_sync()
+
+    try:
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            reader_future = executor.submit(hold_reader)
+            assert reader_entered.wait(timeout=10)
+
+            writer_future = executor.submit(begin_sync)
+            assert writer_started.wait(timeout=10)
+            assert not writer_future.done()
+
+            release_reader.set()
+            ready_status, locked_status = writer_future.result(timeout=20)
+            assert reader_future.result(timeout=20) == _status()
+
+        assert ready_status == _status()
+        assert locked_status.graph_status == "ready"
+        assert locked_status.writer_lock_token is not None
+    finally:
+        release_reader.set()
+        _drop_public_table(database_url, table_name)
+
+
 def test_postgresql_status_store_bootstrap_migrates_legacy_syncing_status() -> None:
     psycopg = pytest.importorskip("psycopg")
 
@@ -237,6 +295,13 @@ def _drop_table(database_url: str, table_name: str) -> None:
     with psycopg.connect(database_url) as connection:
         with connection.cursor() as cursor:
             cursor.execute(f'DROP TABLE IF EXISTS "{table_name}"')
+
+
+def _drop_public_table(database_url: str, table_name: str) -> None:
+    psycopg = pytest.importorskip("psycopg")
+    with psycopg.connect(database_url) as connection:
+        with connection.cursor() as cursor:
+            cursor.execute(f'DROP TABLE IF EXISTS public."{table_name}"')
 
 
 def _create_legacy_syncing_status_row(

--- a/tests/unit/test_snapshots.py
+++ b/tests/unit/test_snapshots.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from contextlib import nullcontext
 from datetime import datetime, timezone
 from typing import Any, Literal
 from unittest.mock import MagicMock
@@ -109,6 +110,9 @@ class SequentialStatusStore:
         self.calls += 1
         index = min(self.calls - 1, len(self.graph_statuses) - 1)
         return self.graph_statuses[index]
+
+    def ready_read_lock(self) -> nullcontext[None]:
+        return nullcontext()
 
     def write_current_status(self, status: Neo4jGraphStatus) -> None:
         self.graph_statuses = [status]

--- a/tests/unit/test_status.py
+++ b/tests/unit/test_status.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import logging
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timezone
+from threading import Event
 from typing import Any, Literal
 from unittest.mock import MagicMock
 
@@ -14,7 +16,7 @@ from graph_engine.status import (
     require_ready_status,
 )
 from graph_engine.status.consistency import _read_live_graph_metrics
-from tests.fakes import InMemoryStatusStore
+from tests.fakes import InMemoryStatusState, InMemoryStatusStore
 
 NOW = datetime(2026, 4, 17, 1, 2, 3, tzinfo=timezone.utc)
 SNAPSHOT_CREATED_AT = datetime(2026, 4, 17, 1, 0, 0, tzinfo=timezone.utc)
@@ -390,6 +392,52 @@ def test_require_ready_rejects_non_ready_status(
         require_ready_status(status)
     with pytest.raises(PermissionError, match="ready"):
         GraphStatusManager(InMemoryStatusStore(status)).require_ready()
+
+
+def test_ready_read_lock_blocks_writes_across_distinct_store_instances() -> None:
+    shared_state = InMemoryStatusState(_status(graph_generation_id=8))
+    reader_store = InMemoryStatusStore(state=shared_state)
+    reader_entered = Event()
+    writer_started = Event()
+    release_reader = Event()
+
+    class ObservedWriterStore(InMemoryStatusStore):
+        def compare_and_write_current_status(
+            self,
+            *,
+            expected_status: Neo4jGraphStatus | None,
+            next_status: Neo4jGraphStatus,
+        ) -> bool:
+            writer_started.set()
+            return super().compare_and_write_current_status(
+                expected_status=expected_status,
+                next_status=next_status,
+            )
+
+    writer_store = ObservedWriterStore(state=shared_state)
+    reader_manager = GraphStatusManager(reader_store, clock=lambda: NOW)
+    writer_manager = GraphStatusManager(writer_store, clock=lambda: NOW)
+
+    def hold_reader() -> Neo4jGraphStatus:
+        with reader_manager.ready_read() as ready_status:
+            reader_entered.set()
+            release_reader.wait(timeout=5)
+            return ready_status
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        reader_future = executor.submit(hold_reader)
+        assert reader_entered.wait(timeout=5)
+        writer_future = executor.submit(writer_manager.begin_sync)
+        assert writer_started.wait(timeout=5)
+        assert not writer_future.done()
+
+        release_reader.set()
+        ready_status, locked_status = writer_future.result(timeout=5)
+        assert reader_future.result(timeout=5) == _status(graph_generation_id=8)
+
+    assert ready_status == _status(graph_generation_id=8)
+    assert locked_status.writer_lock_token == "incremental-sync"
+    assert reader_store.status == locked_status
 
 
 def test_mark_verified_updates_metrics_without_bumping_generation() -> None:

--- a/tests/unit/test_status.py
+++ b/tests/unit/test_status.py
@@ -9,10 +9,13 @@ from unittest.mock import MagicMock
 
 import pytest
 
+import graph_engine
+import graph_engine.status as status_module
 from graph_engine.models import GraphSnapshot, Neo4jGraphStatus
 from graph_engine.status import (
     GraphStatusManager,
     check_live_graph_consistency,
+    hold_ready_read,
     require_ready_status,
 )
 from graph_engine.status.consistency import _read_live_graph_metrics
@@ -438,6 +441,64 @@ def test_ready_read_lock_blocks_writes_across_distinct_store_instances() -> None
     assert ready_status == _status(graph_generation_id=8)
     assert locked_status.writer_lock_token == "incremental-sync"
     assert reader_store.status == locked_status
+
+
+def test_hold_ready_read_keeps_writer_blocked_until_live_read_body_exits() -> None:
+    shared_state = InMemoryStatusState(_status(graph_generation_id=8))
+    reader_store = InMemoryStatusStore(state=shared_state)
+    read_started = Event()
+    writer_started = Event()
+    release_read = Event()
+
+    class BlockingLiveGraphClient:
+        def execute_read(self) -> list[dict[str, bool]]:
+            read_started.set()
+            release_read.wait(timeout=5)
+            return [{"ok": True}]
+
+    class ObservedWriterStore(InMemoryStatusStore):
+        def compare_and_write_current_status(
+            self,
+            *,
+            expected_status: Neo4jGraphStatus | None,
+            next_status: Neo4jGraphStatus,
+        ) -> bool:
+            writer_started.set()
+            return super().compare_and_write_current_status(
+                expected_status=expected_status,
+                next_status=next_status,
+            )
+
+    writer_store = ObservedWriterStore(state=shared_state)
+    reader_manager = GraphStatusManager(reader_store, clock=lambda: NOW)
+    writer_manager = GraphStatusManager(writer_store, clock=lambda: NOW)
+    client = BlockingLiveGraphClient()
+
+    def read_live_graph() -> list[dict[str, bool]]:
+        with hold_ready_read(reader_manager, "unit-test live graph read"):
+            return client.execute_read()
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        reader_future = executor.submit(read_live_graph)
+        assert read_started.wait(timeout=5)
+        writer_future = executor.submit(writer_manager.begin_sync)
+        assert writer_started.wait(timeout=5)
+        assert not writer_future.done()
+
+        release_read.set()
+        assert reader_future.result(timeout=5) == [{"ok": True}]
+        ready_status, locked_status = writer_future.result(timeout=5)
+
+    assert ready_status == _status(graph_generation_id=8)
+    assert locked_status.writer_lock_token == "incremental-sync"
+    assert reader_store.status == locked_status
+
+
+def test_legacy_require_ready_read_is_not_publicly_exported() -> None:
+    assert "require_ready_read" not in status_module.__all__
+    assert not hasattr(status_module, "require_ready_read")
+    assert "require_ready_read" not in graph_engine.__all__
+    assert not hasattr(graph_engine, "require_ready_read")
 
 
 def test_mark_verified_updates_metrics_without_bumping_generation() -> None:


### PR DESCRIPTION
Closes #34

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `benchmarks/artifacts/lite_target_100k_800k.json`, `benchmarks/generate_synthetic.py`, `benchmarks/run_benchmark.py`, `cross-cutting`, `graph_engine/__pycache__/__init__.cpython-314.pyc`, `graph_engine/live_metrics.py`, `graph_engine/propagation/event.py`, `graph_engine/propagation/pipeline.py`, `graph_engine/reload/service.py`, `graph_engine/sync/live_graph.py`


---
Tracked from PR #31 codex re-review. Latent issue: `_ReadyReadBarrier` is keyed by Python object identity. Two distinct StatusStore instances backed by the same persistence row would receive independent barriers, preserving the original TOCTOU race at the persistence boundary.

Currently latent: no production StatusStore implementation exists; test doubles use one-store-per-manager wiring. Becomes exploitable once a real DB-backed store is introduced.

**Action**: Before shipping a production StatusStore, move the barrier into the shared persistence boundary (e.g., DB advisory lock, transactional status-lock protocol in StatusStore contract).

**Source**: codex re-review of PR #31 round 3, confidence 0.90, source graph_engine/status/manager.py:311.

This was downgraded from P0 to follow-up because reviewer itself stated 'P0 is architecturally valid but low immediacy — recommend addressing before any production StatusStore implementation lands.'