### PR TITLE
feat(#40): [milestone-3 review] P0: Reflexive-tagged edges can be counted in both fundamental and reflexive channels

### DIFF
--- a/graph_engine/propagation/channels.py
+++ b/graph_engine/propagation/channels.py
@@ -1,0 +1,41 @@
+"""Shared propagation channel classification helpers."""
+
+from __future__ import annotations
+
+from graph_engine.schema.definitions import RelationshipType
+
+DEFAULT_CHANNEL_BY_RELATIONSHIP_TYPE: dict[str, str] = {
+    RelationshipType.SUPPLY_CHAIN.value: "fundamental",
+    RelationshipType.OWNERSHIP.value: "fundamental",
+    RelationshipType.INDUSTRY_CHAIN.value: "fundamental",
+    RelationshipType.SECTOR_MEMBERSHIP.value: "fundamental",
+    RelationshipType.EVENT_IMPACT.value: "event",
+}
+
+
+def effective_channel_expression(relationship_variable: str = "relationship") -> str:
+    """Return the Cypher expression used to classify propagation relationships."""
+
+    return (
+        f"coalesce({relationship_variable}.propagation_channel, "
+        f"{relationship_variable}.channel, "
+        f"{relationship_variable}.impact_channel, "
+        f"{_default_channel_case_expression(relationship_variable)})"
+    )
+
+
+def effective_channel_selector(
+    channel: str,
+    relationship_variable: str = "relationship",
+) -> str:
+    """Return the Cypher predicate for one propagation channel."""
+
+    return f'{effective_channel_expression(relationship_variable)} = "{channel}"'
+
+
+def _default_channel_case_expression(relationship_variable: str) -> str:
+    case_parts = [
+        f'WHEN "{relationship_type}" THEN "{channel}"'
+        for relationship_type, channel in DEFAULT_CHANNEL_BY_RELATIONSHIP_TYPE.items()
+    ]
+    return f"CASE type({relationship_variable}) {' '.join(case_parts)} ELSE null END"

--- a/graph_engine/propagation/event.py
+++ b/graph_engine/propagation/event.py
@@ -13,12 +13,14 @@ from graph_engine.propagation._gds import (
     execute_gds_read,
     execute_gds_write,
 )
+from graph_engine.propagation.channels import effective_channel_selector
 from graph_engine.propagation.scoring import build_score_explanation
 from graph_engine.schema.definitions import RelationshipType
 from graph_engine.status import GraphStatusManager, hold_ready_read
 
 EVENT_RELATIONSHIP_TYPES = (RelationshipType.EVENT_IMPACT.value,)
 _EVENT_CHANNEL = "event"
+_EVENT_PATH_SELECTOR = effective_channel_selector(_EVENT_CHANNEL)
 
 
 def run_event_propagation(
@@ -50,18 +52,22 @@ def run_event_propagation(
         projection_name = graph_name or _default_projection_name(context)
         drop_projection_if_exists(client, projection_name)
         try:
-            _create_projection(client, projection_name)
-            pagerank_entities = _stream_pagerank(
-                client,
-                projection_name,
-                max_iterations=max_iterations,
-                result_limit=result_limit,
-            )
-            activated_paths = _read_activated_paths(
-                context,
-                client,
-                result_limit=result_limit,
-            )
+            relationship_count = _create_projection(client, projection_name)
+            if relationship_count == 0:
+                pagerank_entities: list[dict[str, Any]] = []
+                activated_paths: list[dict[str, Any]] = []
+            else:
+                pagerank_entities = _stream_pagerank(
+                    client,
+                    projection_name,
+                    max_iterations=max_iterations,
+                    result_limit=result_limit,
+                )
+                activated_paths = _read_activated_paths(
+                    context,
+                    client,
+                    result_limit=result_limit,
+                )
         finally:
             drop_projection_if_exists(client, projection_name)
 
@@ -73,6 +79,7 @@ def run_event_propagation(
     channel_breakdown: dict[str, Any] = {
         _EVENT_CHANNEL: {
             "relationship_types": list(EVENT_RELATIONSHIP_TYPES),
+            "path_selector": _EVENT_PATH_SELECTOR,
             "path_count": len(activated_paths),
             "impacted_entity_count": len(impacted_entities),
             "total_path_score": sum(float(path["score"]) for path in activated_paths),
@@ -95,32 +102,32 @@ def _default_projection_name(context: PropagationContext) -> str:
     return f"graph_engine_event_{cycle_component}_{uuid4().hex[:8]}"
 
 
-def _create_projection(client: Neo4jClient, graph_name: str) -> None:
-    relationship_projection = {
-        relationship_type: {
-            "type": relationship_type,
-            "orientation": "NATURAL",
-            "properties": {
-                "weight": {
-                    "property": "weight",
-                    "defaultValue": 1.0,
-                },
-            },
-        }
-        for relationship_type in EVENT_RELATIONSHIP_TYPES
-    }
-    execute_gds_write(
+def _create_projection(client: Neo4jClient, graph_name: str) -> int:
+    rows = execute_gds_write(
         client,
-        """
-CALL gds.graph.project($graph_name, "*", $relationship_projection)
-YIELD graphName, nodeCount, relationshipCount
-RETURN graphName, nodeCount, relationshipCount
+        f"""
+MATCH (source)-[relationship]->(target)
+WHERE {_EVENT_PATH_SELECTOR}
+WITH gds.graph.project(
+    $graph_name,
+    source,
+    target,
+    {{
+        relationshipType: type(relationship),
+        relationshipProperties: {{
+            weight: coalesce(relationship.weight, 1.0)
+        }}
+    }}
+) AS projection
+RETURN projection.graphName AS graphName,
+       projection.nodeCount AS nodeCount,
+       projection.relationshipCount AS relationshipCount
 """,
-        {
-            "graph_name": graph_name,
-            "relationship_projection": relationship_projection,
-        },
+        {"graph_name": graph_name},
     )
+    if not rows:
+        return 0
+    return int(rows[0].get("relationshipCount") or 0)
 
 
 def _stream_pagerank(
@@ -172,9 +179,9 @@ def _read_activated_paths(
     channel_multiplier = _context_multiplier(context.channel_multipliers)
     regime_multiplier = _context_multiplier(context.regime_multipliers)
     rows = client.execute_read(
-        """
+        f"""
 MATCH (source)-[relationship]->(target)
-WHERE type(relationship) IN $relationship_types
+WHERE {_EVENT_PATH_SELECTOR}
 WITH source,
      relationship,
      target,
@@ -212,7 +219,6 @@ ORDER BY path_score DESC,
 LIMIT $result_limit
 """,
         {
-            "relationship_types": list(EVENT_RELATIONSHIP_TYPES),
             "result_limit": result_limit,
             "channel_multiplier": channel_multiplier,
             "regime_multiplier": regime_multiplier,

--- a/graph_engine/propagation/fundamental.py
+++ b/graph_engine/propagation/fundamental.py
@@ -13,6 +13,7 @@ from graph_engine.propagation._gds import (
     execute_gds_read,
     execute_gds_write,
 )
+from graph_engine.propagation.channels import effective_channel_selector
 from graph_engine.propagation.scoring import build_score_explanation
 from graph_engine.schema.definitions import RelationshipType
 from graph_engine.status import GraphStatusManager, hold_ready_read
@@ -24,6 +25,7 @@ FUNDAMENTAL_RELATIONSHIP_TYPES = (
     RelationshipType.SECTOR_MEMBERSHIP.value,
 )
 _FUNDAMENTAL_CHANNEL = "fundamental"
+_FUNDAMENTAL_PATH_SELECTOR = effective_channel_selector(_FUNDAMENTAL_CHANNEL)
 
 
 def run_fundamental_propagation(
@@ -55,18 +57,22 @@ def run_fundamental_propagation(
         projection_name = graph_name or _default_projection_name(context)
         drop_projection_if_exists(client, projection_name)
         try:
-            _create_projection(client, projection_name)
-            pagerank_entities = _stream_pagerank(
-                client,
-                projection_name,
-                max_iterations=max_iterations,
-                result_limit=result_limit,
-            )
-            activated_paths = _read_activated_paths(
-                context,
-                client,
-                result_limit=result_limit,
-            )
+            relationship_count = _create_projection(client, projection_name)
+            if relationship_count == 0:
+                pagerank_entities: list[dict[str, Any]] = []
+                activated_paths: list[dict[str, Any]] = []
+            else:
+                pagerank_entities = _stream_pagerank(
+                    client,
+                    projection_name,
+                    max_iterations=max_iterations,
+                    result_limit=result_limit,
+                )
+                activated_paths = _read_activated_paths(
+                    context,
+                    client,
+                    result_limit=result_limit,
+                )
         finally:
             drop_projection_if_exists(client, projection_name)
 
@@ -81,6 +87,7 @@ def run_fundamental_propagation(
     channel_breakdown: dict[str, Any] = {
         _FUNDAMENTAL_CHANNEL: {
             "relationship_types": list(FUNDAMENTAL_RELATIONSHIP_TYPES),
+            "path_selector": _FUNDAMENTAL_PATH_SELECTOR,
             "path_count": len(activated_paths),
             "impacted_entity_count": len(impacted_entities),
             "total_path_score": sum(float(path["score"]) for path in activated_paths),
@@ -103,32 +110,32 @@ def _default_projection_name(context: PropagationContext) -> str:
     return f"graph_engine_fundamental_{cycle_component}_{uuid4().hex[:8]}"
 
 
-def _create_projection(client: Neo4jClient, graph_name: str) -> None:
-    relationship_projection = {
-        relationship_type: {
-            "type": relationship_type,
-            "orientation": "NATURAL",
-            "properties": {
-                "weight": {
-                    "property": "weight",
-                    "defaultValue": 1.0,
-                },
-            },
-        }
-        for relationship_type in FUNDAMENTAL_RELATIONSHIP_TYPES
-    }
-    execute_gds_write(
+def _create_projection(client: Neo4jClient, graph_name: str) -> int:
+    rows = execute_gds_write(
         client,
-        """
-CALL gds.graph.project($graph_name, "*", $relationship_projection)
-YIELD graphName, nodeCount, relationshipCount
-RETURN graphName, nodeCount, relationshipCount
+        f"""
+MATCH (source)-[relationship]->(target)
+WHERE {_FUNDAMENTAL_PATH_SELECTOR}
+WITH gds.graph.project(
+    $graph_name,
+    source,
+    target,
+    {{
+        relationshipType: type(relationship),
+        relationshipProperties: {{
+            weight: coalesce(relationship.weight, 1.0)
+        }}
+    }}
+) AS projection
+RETURN projection.graphName AS graphName,
+       projection.nodeCount AS nodeCount,
+       projection.relationshipCount AS relationshipCount
 """,
-        {
-            "graph_name": graph_name,
-            "relationship_projection": relationship_projection,
-        },
+        {"graph_name": graph_name},
     )
+    if not rows:
+        return 0
+    return int(rows[0].get("relationshipCount") or 0)
 
 
 def _stream_pagerank(
@@ -180,9 +187,9 @@ def _read_activated_paths(
     channel_multiplier = _context_multiplier(context.channel_multipliers)
     regime_multiplier = _context_multiplier(context.regime_multipliers)
     rows = client.execute_read(
-        """
+        f"""
 MATCH (source)-[relationship]->(target)
-WHERE type(relationship) IN $relationship_types
+WHERE {_FUNDAMENTAL_PATH_SELECTOR}
 WITH source,
      relationship,
      target,
@@ -220,7 +227,6 @@ ORDER BY path_score DESC,
 LIMIT $result_limit
 """,
         {
-            "relationship_types": list(FUNDAMENTAL_RELATIONSHIP_TYPES),
             "result_limit": result_limit,
             "channel_multiplier": channel_multiplier,
             "regime_multiplier": regime_multiplier,

--- a/graph_engine/propagation/reflexive.py
+++ b/graph_engine/propagation/reflexive.py
@@ -13,14 +13,12 @@ from graph_engine.propagation._gds import (
     execute_gds_read,
     execute_gds_write,
 )
+from graph_engine.propagation.channels import effective_channel_selector
 from graph_engine.propagation.scoring import build_score_explanation
 from graph_engine.status import GraphStatusManager, hold_ready_read
 
 _REFLEXIVE_CHANNEL = "reflexive"
-_REFLEXIVE_PATH_SELECTOR = (
-    'coalesce(relationship.propagation_channel, relationship.channel, '
-    'relationship.impact_channel) = "reflexive"'
-)
+_REFLEXIVE_PATH_SELECTOR = effective_channel_selector(_REFLEXIVE_CHANNEL)
 
 
 def run_reflexive_propagation(

--- a/tests/integration/test_full_propagation.py
+++ b/tests/integration/test_full_propagation.py
@@ -147,9 +147,20 @@ def test_compute_graph_snapshots_generates_three_channel_impact_snapshot() -> No
         (path["edge_id"], path["channel"])
         for path in impact_snapshot.activated_paths
     }
+    channels_by_edge_id: dict[str, set[str]] = {}
+    for path in impact_snapshot.activated_paths:
+        channels_by_edge_id.setdefault(str(path["edge_id"]), set()).add(str(path["channel"]))
+
     assert (supply_edge_id, "fundamental") in path_channels_by_edge
     assert (event_edge_id, "event") in path_channels_by_edge
     assert (reflexive_edge_id, "reflexive") in path_channels_by_edge
+    assert channels_by_edge_id[reflexive_edge_id] == {"reflexive"}
+    duplicated_edges = {
+        edge_id: channels
+        for edge_id, channels in channels_by_edge_id.items()
+        if len(channels) > 1
+    }
+    assert duplicated_edges == {}
     assert set(impact_snapshot.channel_breakdown) == {
         "fundamental",
         "event",

--- a/tests/unit/test_propagation.py
+++ b/tests/unit/test_propagation.py
@@ -74,56 +74,27 @@ class FakeGDSClient:
                 },
             ]
         if "MATCH (source)-[relationship]->(target)" in query:
-            if self.path_rows is not None:
-                rows = list(self.path_rows)
-                if "ORDER BY path_score DESC" in query:
-                    rows.sort(
-                        key=lambda row: (
-                            -_path_score(row, params),
-                            str(row["source_node_id"]),
-                            str(row["relationship_type"]),
-                            str(row["target_node_id"]),
-                            str(row["edge_id"]),
-                        ),
-                    )
-                else:
-                    rows.sort(
-                        key=lambda row: (
-                            str(row["source_node_id"]),
-                            str(row["relationship_type"]),
-                            str(row["target_node_id"]),
-                            str(row["edge_id"]),
-                        ),
-                    )
-                return rows[: int(params.get("result_limit", len(rows)))]
-            return [
-                {
-                    "source_node_id": "node-a",
-                    "source_entity_id": "entity-a",
-                    "source_labels": ["Entity"],
-                    "target_node_id": "node-b",
-                    "target_entity_id": "entity-b",
-                    "target_labels": ["Entity"],
-                    "edge_id": "edge-1",
-                    "relationship_type": "SUPPLY_CHAIN",
-                    "relation_weight": 0.5,
-                    "evidence_confidence": None,
-                    "recency_decay": None,
-                },
-                {
-                    "source_node_id": "node-b",
-                    "source_entity_id": "entity-b",
-                    "source_labels": ["Entity"],
-                    "target_node_id": "node-c",
-                    "target_entity_id": "entity-c",
-                    "target_labels": ["Entity"],
-                    "edge_id": "edge-2",
-                    "relationship_type": "OWNERSHIP",
-                    "relation_weight": 0.8,
-                    "evidence_confidence": 0.5,
-                    "recency_decay": 0.5,
-                },
-            ]
+            rows = self._fundamental_rows()
+            if "ORDER BY path_score DESC" in query:
+                rows.sort(
+                    key=lambda row: (
+                        -_path_score(row, params),
+                        str(row["source_node_id"]),
+                        str(row["relationship_type"]),
+                        str(row["target_node_id"]),
+                        str(row["edge_id"]),
+                    ),
+                )
+            else:
+                rows.sort(
+                    key=lambda row: (
+                        str(row["source_node_id"]),
+                        str(row["relationship_type"]),
+                        str(row["target_node_id"]),
+                        str(row["edge_id"]),
+                    ),
+                )
+            return rows[: int(params.get("result_limit", len(rows)))]
         return []
 
     def execute_write(
@@ -131,8 +102,21 @@ class FakeGDSClient:
         query: str,
         parameters: dict[str, Any] | None = None,
     ) -> list[dict[str, Any]]:
-        self.write_calls.append((query, parameters or {}))
+        params = parameters or {}
+        self.write_calls.append((query, params))
+        if "gds.graph.project" in query:
+            return [
+                {
+                    "graphName": params.get("graph_name"),
+                    "nodeCount": 2 if self._fundamental_rows() else 0,
+                    "relationshipCount": len(self._fundamental_rows()),
+                }
+            ]
         return []
+
+    def _fundamental_rows(self) -> list[dict[str, Any]]:
+        rows = self.path_rows if self.path_rows is not None else _default_path_rows()
+        return [row for row in rows if _effective_channel(row) == "fundamental"]
 
 
 def test_compute_path_score_uses_documented_multiplication() -> None:
@@ -279,11 +263,12 @@ def test_run_fundamental_propagation_uses_gds_projection_and_explains_paths() ->
     assert "gds.graph.drop" in write_queries[2]
     assert all(" SET " not in query and " DELETE " not in query for query in write_queries)
 
-    projection_params = client.write_calls[1][1]
+    projection_query, projection_params = client.write_calls[1]
     assert projection_params["graph_name"] == "unit-fundamental"
-    assert set(projection_params["relationship_projection"]) == set(
-        FUNDAMENTAL_RELATIONSHIP_TYPES
-    )
+    assert "MATCH (source)-[relationship]->(target)" in projection_query
+    assert "coalesce(relationship.propagation_channel" in projection_query
+    assert 'WHEN "OWNERSHIP" THEN "fundamental"' in projection_query
+    assert '= "fundamental"' in projection_query
 
     pagerank_call = next(
         (query, params)
@@ -313,6 +298,48 @@ def test_run_fundamental_propagation_uses_gds_projection_and_explains_paths() ->
         "score": 0.5,
     }
     assert result.channel_breakdown["fundamental"]["path_count"] == 2
+
+
+def test_run_fundamental_propagation_excludes_relationships_tagged_for_other_channels() -> None:
+    client = FakeGDSClient(
+        path_rows=[
+            _path_row(
+                edge_id="edge-fundamental",
+                relationship_type="SUPPLY_CHAIN",
+                target_node_id="node-fundamental",
+                target_entity_id="entity-fundamental",
+                relation_weight=1.0,
+            ),
+            _path_row(
+                edge_id="edge-reflexive-ownership",
+                relationship_type="OWNERSHIP",
+                target_node_id="node-reflexive",
+                target_entity_id="entity-reflexive",
+                relation_weight=100.0,
+                propagation_channel="reflexive",
+            ),
+        ],
+    )
+
+    result = run_fundamental_propagation(
+        _context(),
+        client,  # type: ignore[arg-type]
+        status_manager=_status_manager(),
+        graph_name="unit-fundamental",
+    )
+
+    assert [path["edge_id"] for path in result.activated_paths] == ["edge-fundamental"]
+    assert result.channel_breakdown["fundamental"]["path_count"] == 1
+    projection_query = next(
+        query for query, _ in client.write_calls if "gds.graph.project" in query
+    )
+    path_query = next(
+        query
+        for query, _ in client.read_calls
+        if "MATCH (source)-[relationship]->(target)" in query
+    )
+    assert 'relationship.impact_channel, CASE type(relationship)' in projection_query
+    assert 'relationship.impact_channel, CASE type(relationship)' in path_query
 
 
 def test_run_fundamental_propagation_blocks_non_ready_before_neo4j_reads() -> None:
@@ -556,6 +583,73 @@ def _status_manager(
                 writer_lock_token=writer_lock_token,
             ),
         ),
+    )
+
+
+def _path_row(
+    *,
+    edge_id: str,
+    relationship_type: str,
+    target_node_id: str,
+    target_entity_id: str,
+    relation_weight: float,
+    evidence_confidence: float | None = 1.0,
+    recency_decay: float | None = 1.0,
+    propagation_channel: str | None = None,
+    channel: str | None = None,
+    impact_channel: str | None = None,
+) -> dict[str, Any]:
+    return {
+        "source_node_id": "node-a",
+        "source_entity_id": "entity-a",
+        "source_labels": ["Entity"],
+        "target_node_id": target_node_id,
+        "target_entity_id": target_entity_id,
+        "target_labels": ["Entity"],
+        "edge_id": edge_id,
+        "relationship_type": relationship_type,
+        "relation_weight": relation_weight,
+        "evidence_confidence": evidence_confidence,
+        "recency_decay": recency_decay,
+        "propagation_channel": propagation_channel,
+        "channel": channel,
+        "impact_channel": impact_channel,
+    }
+
+
+def _default_path_rows() -> list[dict[str, Any]]:
+    return [
+        _path_row(
+            edge_id="edge-1",
+            relationship_type="SUPPLY_CHAIN",
+            target_node_id="node-b",
+            target_entity_id="entity-b",
+            relation_weight=0.5,
+            evidence_confidence=None,
+            recency_decay=None,
+        ),
+        _path_row(
+            edge_id="edge-2",
+            relationship_type="OWNERSHIP",
+            target_node_id="node-c",
+            target_entity_id="entity-c",
+            relation_weight=0.8,
+            evidence_confidence=0.5,
+            recency_decay=0.5,
+        ),
+    ]
+
+
+def _effective_channel(row: dict[str, Any]) -> str | None:
+    return (
+        row.get("propagation_channel")
+        or row.get("channel")
+        or row.get("impact_channel")
+        or (
+            "fundamental"
+            if row.get("relationship_type") in FUNDAMENTAL_RELATIONSHIP_TYPES
+            else None
+        )
     )
 
 

--- a/tests/unit/test_propagation_event.py
+++ b/tests/unit/test_propagation_event.py
@@ -63,7 +63,7 @@ class FakeEventGDSClient:
                 },
             ]
         if "MATCH (source)-[relationship]->(target)" in query:
-            rows = list(self.path_rows)
+            rows = self._event_rows()
             rows.sort(
                 key=lambda row: (
                     -_path_score(row, params),
@@ -81,8 +81,20 @@ class FakeEventGDSClient:
         query: str,
         parameters: dict[str, Any] | None = None,
     ) -> list[dict[str, Any]]:
-        self.write_calls.append((query, parameters or {}))
+        params = parameters or {}
+        self.write_calls.append((query, params))
+        if "gds.graph.project" in query:
+            return [
+                {
+                    "graphName": params.get("graph_name"),
+                    "nodeCount": 2 if self._event_rows() else 0,
+                    "relationshipCount": len(self._event_rows()),
+                }
+            ]
         return []
+
+    def _event_rows(self) -> list[dict[str, Any]]:
+        return [row for row in self.path_rows if _effective_channel(row) == "event"]
 
 
 def test_run_event_propagation_requires_event_channel_before_neo4j_reads() -> None:
@@ -179,9 +191,11 @@ def test_run_event_propagation_uses_projection_and_explains_paths() -> None:
     assert "gds.graph.drop" in write_queries[2]
     assert all(" SET " not in query and " DELETE " not in query for query in write_queries)
 
-    projection_params = client.write_calls[1][1]
+    projection_query, projection_params = client.write_calls[1]
     assert projection_params["graph_name"] == "unit-event"
-    assert set(projection_params["relationship_projection"]) == set(EVENT_RELATIONSHIP_TYPES)
+    assert "coalesce(relationship.propagation_channel" in projection_query
+    assert 'WHEN "EVENT_IMPACT" THEN "event"' in projection_query
+    assert '= "event"' in projection_query
 
     pagerank_call = next(
         (query, params)
@@ -197,7 +211,8 @@ def test_run_event_propagation_uses_projection_and_explains_paths() -> None:
         if "MATCH (source)-[relationship]->(target)" in query
     )
     assert "ORDER BY path_score DESC" in path_call[0]
-    assert path_call[1]["relationship_types"] == list(EVENT_RELATIONSHIP_TYPES)
+    assert "coalesce(relationship.propagation_channel" in path_call[0]
+    assert 'WHEN "EVENT_IMPACT" THEN "event"' in path_call[0]
 
     assert [path["edge_id"] for path in result.activated_paths] == ["edge-top", "edge-mid"]
     assert result.activated_paths[0]["channel"] == "event"
@@ -214,6 +229,15 @@ def test_run_event_propagation_uses_projection_and_explains_paths() -> None:
     assert result.impacted_entities[0]["path_count"] == 1
     assert result.channel_breakdown["event"] == {
         "relationship_types": list(EVENT_RELATIONSHIP_TYPES),
+        "path_selector": (
+            'coalesce(relationship.propagation_channel, relationship.channel, '
+            'relationship.impact_channel, CASE type(relationship) '
+            'WHEN "SUPPLY_CHAIN" THEN "fundamental" '
+            'WHEN "OWNERSHIP" THEN "fundamental" '
+            'WHEN "INDUSTRY_CHAIN" THEN "fundamental" '
+            'WHEN "SECTOR_MEMBERSHIP" THEN "fundamental" '
+            'WHEN "EVENT_IMPACT" THEN "event" ELSE null END) = "event"'
+        ),
         "path_count": 2,
         "impacted_entity_count": 2,
         "total_path_score": 2.5,
@@ -223,7 +247,20 @@ def test_run_event_propagation_uses_projection_and_explains_paths() -> None:
 
 
 def test_run_event_propagation_cleans_up_projection_on_exception() -> None:
-    client = FakeEventGDSClient(exists_results=[False, True], fail_on_pagerank=True)
+    client = FakeEventGDSClient(
+        exists_results=[False, True],
+        fail_on_pagerank=True,
+        path_rows=[
+            _path_row(
+                edge_id="edge-1",
+                target_node_id="node-b",
+                target_entity_id="entity-b",
+                relation_weight=1.0,
+                evidence_confidence=1.0,
+                recency_decay=1.0,
+            ),
+        ],
+    )
 
     with pytest.raises(RuntimeError, match="pagerank failed"):
         run_event_propagation(
@@ -294,6 +331,9 @@ def _path_row(
     relation_weight: float,
     evidence_confidence: float,
     recency_decay: float,
+    propagation_channel: str | None = None,
+    channel: str | None = None,
+    impact_channel: str | None = None,
 ) -> dict[str, Any]:
     return {
         "source_node_id": "node-a",
@@ -307,7 +347,19 @@ def _path_row(
         "relation_weight": relation_weight,
         "evidence_confidence": evidence_confidence,
         "recency_decay": recency_decay,
+        "propagation_channel": propagation_channel,
+        "channel": channel,
+        "impact_channel": impact_channel,
     }
+
+
+def _effective_channel(row: dict[str, Any]) -> str | None:
+    return (
+        row.get("propagation_channel")
+        or row.get("channel")
+        or row.get("impact_channel")
+        or ("event" if row.get("relationship_type") in EVENT_RELATIONSHIP_TYPES else None)
+    )
 
 
 def _path_score(row: dict[str, Any], params: dict[str, Any]) -> float:

--- a/tests/unit/test_propagation_merge.py
+++ b/tests/unit/test_propagation_merge.py
@@ -12,6 +12,110 @@ from graph_engine.status import GraphStatusManager
 from tests.fakes import InMemoryStatusStore
 
 NOW = datetime(2026, 4, 17, 1, 2, 3, tzinfo=timezone.utc)
+_DEFAULT_CHANNEL_BY_RELATIONSHIP_TYPE = {
+    "SUPPLY_CHAIN": "fundamental",
+    "OWNERSHIP": "fundamental",
+    "INDUSTRY_CHAIN": "fundamental",
+    "SECTOR_MEMBERSHIP": "fundamental",
+    "EVENT_IMPACT": "event",
+}
+
+
+class FakeFullPropagationGDSClient:
+    def __init__(self, rows: list[dict[str, Any]]) -> None:
+        self.rows = rows
+        self.read_calls: list[tuple[str, dict[str, Any]]] = []
+        self.write_calls: list[tuple[str, dict[str, Any]]] = []
+
+    def execute_read(
+        self,
+        query: str,
+        parameters: dict[str, Any] | None = None,
+    ) -> list[dict[str, Any]]:
+        params = parameters or {}
+        self.read_calls.append((query, params))
+        if "gds.graph.exists" in query:
+            return [{"exists": False}]
+        if "gds.pageRank.stream" in query:
+            channel = _channel_from_graph_name(str(params.get("graph_name") or ""))
+            return self._pagerank_rows(channel)
+        if "MATCH (source)-[relationship]->(target)" in query:
+            rows = self._matching_rows(query, params)
+            rows.sort(
+                key=lambda row: (
+                    -_path_score(row, params),
+                    str(row["source_node_id"]),
+                    str(row["relationship_type"]),
+                    str(row["target_node_id"]),
+                    str(row["edge_id"]),
+                ),
+            )
+            return rows[: int(params.get("result_limit", len(rows)))]
+        return []
+
+    def execute_write(
+        self,
+        query: str,
+        parameters: dict[str, Any] | None = None,
+    ) -> list[dict[str, Any]]:
+        params = parameters or {}
+        self.write_calls.append((query, params))
+        if "gds.graph.project" not in query:
+            return []
+
+        rows = self._matching_rows(query, params)
+        node_ids = {
+            str(row[node_key])
+            for row in rows
+            for node_key in ("source_node_id", "target_node_id")
+        }
+        return [
+            {
+                "graphName": params.get("graph_name"),
+                "nodeCount": len(node_ids),
+                "relationshipCount": len(rows),
+            }
+        ]
+
+    def _matching_rows(self, query: str, params: dict[str, Any]) -> list[dict[str, Any]]:
+        channel = _channel_from_query(query)
+        if channel is not None:
+            return [row for row in self.rows if _effective_channel(row) == channel]
+
+        relationship_types = params.get("relationship_types")
+        if relationship_types is not None:
+            return [
+                row
+                for row in self.rows
+                if row.get("relationship_type") in set(relationship_types)
+            ]
+
+        relationship_projection = params.get("relationship_projection")
+        if isinstance(relationship_projection, dict):
+            return [
+                row
+                for row in self.rows
+                if row.get("relationship_type") in set(relationship_projection)
+            ]
+
+        return list(self.rows)
+
+    def _pagerank_rows(self, channel: str | None) -> list[dict[str, Any]]:
+        rows = [
+            row
+            for row in self.rows
+            if channel is None or _effective_channel(row) == channel
+        ]
+        return [
+            {
+                "node_id": row["target_node_id"],
+                "canonical_entity_id": row["target_entity_id"],
+                "labels": row["target_labels"],
+                "stable_node_id": row["target_node_id"],
+                "score": row["relation_weight"],
+            }
+            for row in rows
+        ]
 
 
 def test_merge_propagation_results_rejects_empty_results() -> None:
@@ -243,6 +347,57 @@ def test_run_full_propagation_uses_distinct_projection_names_per_channel(
     ]
 
 
+def test_run_full_propagation_emits_reflexive_tagged_ownership_only_once() -> None:
+    client = FakeFullPropagationGDSClient(
+        [
+            _full_path_row(
+                edge_id="edge-fundamental",
+                relationship_type="SUPPLY_CHAIN",
+                target_node_id="node-fundamental",
+                target_entity_id="entity-fundamental",
+                relation_weight=1.0,
+            ),
+            _full_path_row(
+                edge_id="edge-event",
+                relationship_type="EVENT_IMPACT",
+                target_node_id="node-event",
+                target_entity_id="entity-event",
+                relation_weight=2.0,
+            ),
+            _full_path_row(
+                edge_id="edge-reflexive-ownership",
+                relationship_type="OWNERSHIP",
+                target_node_id="node-reflexive",
+                target_entity_id="entity-reflexive",
+                relation_weight=3.0,
+                propagation_channel="reflexive",
+            ),
+        ]
+    )
+
+    result = run_full_propagation(
+        _context(enabled_channels=["fundamental", "event", "reflexive"]),
+        client,  # type: ignore[arg-type]
+        status_manager=_status_manager(),
+        graph_name="unit-projection",
+        result_limit=20,
+    )
+
+    channels_by_edge_id: dict[str, set[str]] = {}
+    for path in result.activated_paths:
+        channels_by_edge_id.setdefault(str(path["edge_id"]), set()).add(str(path["channel"]))
+
+    assert channels_by_edge_id["edge-reflexive-ownership"] == {"reflexive"}
+    assert channels_by_edge_id["edge-fundamental"] == {"fundamental"}
+    assert channels_by_edge_id["edge-event"] == {"event"}
+    duplicated_edges = {
+        edge_id: channels
+        for edge_id, channels in channels_by_edge_id.items()
+        if len(channels) > 1
+    }
+    assert duplicated_edges == {}
+
+
 def test_run_full_propagation_reuses_projection_name_for_single_channel(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -269,6 +424,74 @@ def test_run_full_propagation_requires_status_manager() -> None:
             _context(enabled_channels=["fundamental"]),
             object(),  # type: ignore[arg-type]
         )
+
+
+def _full_path_row(
+    *,
+    edge_id: str,
+    relationship_type: str,
+    target_node_id: str,
+    target_entity_id: str,
+    relation_weight: float,
+    propagation_channel: str | None = None,
+    channel: str | None = None,
+    impact_channel: str | None = None,
+) -> dict[str, Any]:
+    return {
+        "source_node_id": "node-source",
+        "source_entity_id": "entity-source",
+        "source_labels": ["Entity"],
+        "target_node_id": target_node_id,
+        "target_entity_id": target_entity_id,
+        "target_labels": ["Entity"],
+        "edge_id": edge_id,
+        "relationship_type": relationship_type,
+        "relation_weight": relation_weight,
+        "evidence_confidence": 1.0,
+        "recency_decay": 1.0,
+        "propagation_channel": propagation_channel,
+        "channel": channel,
+        "impact_channel": impact_channel,
+    }
+
+
+def _effective_channel(row: dict[str, Any]) -> str | None:
+    return (
+        row.get("propagation_channel")
+        or row.get("channel")
+        or row.get("impact_channel")
+        or _DEFAULT_CHANNEL_BY_RELATIONSHIP_TYPE.get(str(row.get("relationship_type") or ""))
+    )
+
+
+def _channel_from_query(query: str) -> str | None:
+    for channel in ("fundamental", "event", "reflexive"):
+        if f') = "{channel}"' in query:
+            return channel
+    return None
+
+
+def _channel_from_graph_name(graph_name: str) -> str | None:
+    for channel in ("fundamental", "event", "reflexive"):
+        if graph_name.endswith(f"-{channel}"):
+            return channel
+    return None
+
+
+def _path_score(row: dict[str, Any], params: dict[str, Any]) -> float:
+    return (
+        _float_or_default(row.get("relation_weight"))
+        * _float_or_default(row.get("evidence_confidence"))
+        * float(params.get("channel_multiplier", 1.0))
+        * float(params.get("regime_multiplier", 1.0))
+        * _float_or_default(row.get("recency_decay"))
+    )
+
+
+def _float_or_default(value: Any, default: float = 1.0) -> float:
+    if value is None:
+        return default
+    return float(value)
 
 
 def _runner(channel: str, calls: list[tuple[str, str | None, int, int]]):

--- a/tests/unit/test_propagation_reflexive.py
+++ b/tests/unit/test_propagation_reflexive.py
@@ -90,9 +90,7 @@ class FakeReflexiveGDSClient:
         return [
             row
             for row in self.path_rows
-            if row.get("propagation_channel") == "reflexive"
-            or row.get("channel") == "reflexive"
-            or row.get("impact_channel") == "reflexive"
+            if _effective_channel(row) == "reflexive"
         ]
 
 
@@ -193,7 +191,8 @@ def test_run_reflexive_propagation_filters_tagged_paths_and_explains_scores() ->
     assert all(" SET " not in query and " DELETE " not in query for query in write_queries)
     assert client.write_calls[1][1]["graph_name"] == "unit-reflexive"
     assert "relationship.propagation_channel" in write_queries[1]
-    assert 'relationship.impact_channel) = "reflexive"' in write_queries[1]
+    assert 'relationship.impact_channel, CASE type(relationship)' in write_queries[1]
+    assert '= "reflexive"' in write_queries[1]
 
     path_query = next(
         query
@@ -201,7 +200,8 @@ def test_run_reflexive_propagation_filters_tagged_paths_and_explains_scores() ->
         if "MATCH (source)-[relationship]->(target)" in query
     )
     assert "coalesce(relationship.propagation_channel" in path_query
-    assert 'relationship.impact_channel) = "reflexive"' in path_query
+    assert 'relationship.impact_channel, CASE type(relationship)' in path_query
+    assert '= "reflexive"' in path_query
 
     pagerank_call = next(
         (query, params)
@@ -343,6 +343,10 @@ def _path_row(
         "channel": channel,
         "impact_channel": impact_channel,
     }
+
+
+def _effective_channel(row: dict[str, Any]) -> str | None:
+    return row.get("propagation_channel") or row.get("channel") or row.get("impact_channel")
 
 
 def _path_score(row: dict[str, Any], params: dict[str, Any]) -> float:


### PR DESCRIPTION
Closes #40

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `benchmarks/artifacts/lite_target_100k_800k.json`, `benchmarks/generate_synthetic.py`, `benchmarks/run_benchmark.py`, `cross-cutting`, `graph_engine/__pycache__/__init__.cpython-314.pyc`, `graph_engine/live_metrics.py`, `graph_engine/propagation/pipeline.py`, `graph_engine/reload/service.py`, `graph_engine/snapshots/generator.py`, `graph_engine/status/consistency.py`


---
## 背景与目标
Milestone review for milestone-3 发现阻塞性问题，必须在进入下一阶段前修复。

## 问题描述
The reflexive runner selects relationships by channel tag, but the fundamental runner still selects all FUNDAMENTAL_RELATIONSHIP_TYPES by relationship type only. Since OWNERSHIP is fundamental and the full-propagation integration fixture uses an OWNERSHIP edge with propagation_channel='reflexive', the same edge can appear once as fundamental and once as reflexive, inflating merged impacted entity scores and making channel_breakdown non-auditable. The integration test only asserts that the reflexive path exists; it does not assert that the edge is absent from the fundamental channel.

## 实现范围
- 修改文件: `graph_engine/propagation/fundamental.py`
- Define one shared channel-classification rule, for example coalesce(relationship.propagation_channel, relationship.channel, relationship.impact_channel, default_channel_by_relationship_type), and make every channel runner filter on that effective channel in both the GDS projection and activated-path query. Add a full-propagation test asserting that a reflexive-tagged OWNERSHIP edge appears only under reflexive and that no edge_id is emitted by multiple channels unless an explicit multi-channel contract is introduced.

## 验收标准
- [ ] 原始 P0 问题已修复
- [ ] 新增回归测试覆盖该场景
- [ ] 构建通过

## 验证命令
```bash
/Users/fanjie/Desktop/Cowork/project-ult/graph-engine/.venv/bin/python -m pytest
```
