### PR TITLE
feat(#11): 只读局部传播模拟与消费方接入样例

### DIFF
--- a/examples/consumer_main_core.py
+++ b/examples/consumer_main_core.py
@@ -1,0 +1,52 @@
+"""Example main-core style consumer for read-only graph impact simulation."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from graph_engine import (
+    GraphStatusManager,
+    Neo4jClient,
+    ReadonlySimulationRequest,
+    simulate_readonly_impact,
+)
+
+
+def run_main_core_interim_impact(
+    seed_entities: list[str],
+    *,
+    client: Neo4jClient,
+    status_manager: GraphStatusManager,
+    cycle_id: str,
+    world_state_ref: str,
+    graph_generation_id: int,
+) -> dict[str, Any]:
+    """Read interim impact without creating a formal graph impact snapshot."""
+
+    request = ReadonlySimulationRequest(
+        cycle_id=cycle_id,
+        world_state_ref=world_state_ref,
+        graph_generation_id=graph_generation_id,
+        depth=2,
+        enabled_channels=["fundamental", "event", "reflexive"],
+        channel_multipliers={
+            "fundamental": 1.0,
+            "event": 1.0,
+            "reflexive": 1.0,
+        },
+        regime_multipliers={
+            "fundamental": 1.0,
+            "event": 1.0,
+            "reflexive": 1.0,
+        },
+        decay_policy={"default": 1.0},
+        regime_context={"source": "main-core-readonly"},
+        result_limit=100,
+        max_iterations=20,
+    )
+    return simulate_readonly_impact(
+        seed_entities,
+        request,
+        client=client,
+        status_manager=status_manager,
+    )

--- a/examples/consumer_stream_layer.py
+++ b/examples/consumer_stream_layer.py
@@ -1,0 +1,44 @@
+"""Example stream-layer style consumer for interim graph impact simulation."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from graph_engine import (
+    GraphStatusManager,
+    Neo4jClient,
+    ReadonlySimulationRequest,
+    simulate_readonly_impact,
+)
+
+
+def handle_stream_event(
+    event: dict[str, Any],
+    *,
+    client: Neo4jClient,
+    status_manager: GraphStatusManager,
+) -> dict[str, Any]:
+    """Return an interim impact response for an event-driven seed."""
+
+    seed_entities = [str(seed) for seed in event.get("seed_entities", []) if seed]
+    request = ReadonlySimulationRequest(
+        cycle_id=str(event["cycle_id"]),
+        world_state_ref=str(event["world_state_ref"]),
+        graph_generation_id=int(event["graph_generation_id"]),
+        depth=int(event.get("depth", 2)),
+        enabled_channels=["event", "reflexive"],
+        channel_multipliers={"event": 1.0, "reflexive": 1.0},
+        regime_multipliers={"event": 1.0, "reflexive": 1.0},
+        decay_policy={"default": 1.0},
+        regime_context={"source": "stream-layer-readonly"},
+        result_limit=int(event.get("result_limit", 50)),
+        max_iterations=int(event.get("max_iterations", 10)),
+    )
+    result = simulate_readonly_impact(
+        seed_entities,
+        request,
+        client=client,
+        status_manager=status_manager,
+    )
+    print(result)
+    return result

--- a/graph_engine/models.py
+++ b/graph_engine/models.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from datetime import datetime
 from typing import Any, Literal, Self, get_args
 
@@ -167,7 +168,42 @@ class ReadonlySimulationRequest(BaseModel):
         ]
         if unknown_channels:
             raise ValueError(f"unknown propagation channels: {unknown_channels}")
+        invalid_channels = [
+            channel
+            for channel, multiplier in multipliers.items()
+            if not math.isfinite(float(multiplier)) or float(multiplier) < 0.0
+        ]
+        if invalid_channels:
+            raise ValueError(
+                "multipliers must be finite non-negative values for channels: "
+                f"{invalid_channels}",
+            )
         return multipliers
+
+    @model_validator(mode="after")
+    def _enabled_channels_require_multipliers(self) -> Self:
+        missing_channel_multipliers = [
+            channel
+            for channel in self.enabled_channels
+            if channel not in self.channel_multipliers
+        ]
+        if missing_channel_multipliers:
+            raise ValueError(
+                "channel_multipliers must include every enabled channel: "
+                f"{missing_channel_multipliers}",
+            )
+
+        missing_regime_multipliers = [
+            channel
+            for channel in self.enabled_channels
+            if channel not in self.regime_multipliers
+        ]
+        if missing_regime_multipliers:
+            raise ValueError(
+                "regime_multipliers must include every enabled channel: "
+                f"{missing_regime_multipliers}",
+            )
+        return self
 
 
 class GraphQueryResult(BaseModel):

--- a/graph_engine/models.py
+++ b/graph_engine/models.py
@@ -132,8 +132,42 @@ class ReadonlySimulationRequest(BaseModel):
     cycle_id: str = Field(min_length=1)
     world_state_ref: str = Field(min_length=1)
     graph_generation_id: int = Field(ge=0)
-    depth: int = Field(default=1, ge=0)
-    result_limit: int = Field(default=100, ge=1)
+    depth: int = Field(default=2, ge=0, le=6)
+    enabled_channels: list[PropagationChannel] = Field(min_length=1)
+    channel_multipliers: dict[str, float]
+    regime_multipliers: dict[str, float]
+    decay_policy: dict[str, Any]
+    regime_context: dict[str, Any]
+    result_limit: int = Field(default=100, ge=1, le=1000)
+    max_iterations: int = Field(default=20, ge=1)
+    projection_name: str | None = Field(default=None, min_length=1)
+
+    @field_validator("enabled_channels")
+    @classmethod
+    def _validate_enabled_channels(
+        cls,
+        enabled_channels: list[PropagationChannel],
+    ) -> list[PropagationChannel]:
+        if not enabled_channels:
+            raise ValueError("enabled_channels must not be empty")
+        unknown_channels = [
+            channel for channel in enabled_channels if channel not in _ALLOWED_PROPAGATION_CHANNELS
+        ]
+        if unknown_channels:
+            raise ValueError(f"unknown propagation channels: {unknown_channels}")
+        if len(set(enabled_channels)) != len(enabled_channels):
+            raise ValueError("enabled_channels must not contain duplicates")
+        return enabled_channels
+
+    @field_validator("channel_multipliers", "regime_multipliers")
+    @classmethod
+    def _validate_multiplier_keys(cls, multipliers: dict[str, float]) -> dict[str, float]:
+        unknown_channels = [
+            channel for channel in multipliers if channel not in _ALLOWED_PROPAGATION_CHANNELS
+        ]
+        if unknown_channels:
+            raise ValueError(f"unknown propagation channels: {unknown_channels}")
+        return multipliers
 
 
 class GraphQueryResult(BaseModel):

--- a/graph_engine/query/__init__.py
+++ b/graph_engine/query/__init__.py
@@ -4,8 +4,8 @@ from graph_engine.query.service import (
     MAX_QUERY_DEPTH,
     query_propagation_paths,
     query_subgraph,
-    simulate_readonly_impact,
 )
+from graph_engine.query.simulation import simulate_readonly_impact
 
 __all__ = [
     "MAX_QUERY_DEPTH",

--- a/graph_engine/query/service.py
+++ b/graph_engine/query/service.py
@@ -7,7 +7,7 @@ from collections.abc import Mapping
 from typing import Any, get_args
 
 from graph_engine.client import Neo4jClient
-from graph_engine.models import GraphQueryResult, PropagationChannel, ReadonlySimulationRequest
+from graph_engine.models import GraphQueryResult, PropagationChannel
 from graph_engine.propagation.channels import effective_channel_expression
 from graph_engine.status import GraphStatusManager
 
@@ -100,64 +100,6 @@ def query_propagation_paths(
     row = rows[0] if isinstance(rows, list) and rows else {}
     raw_paths = row.get("paths") if isinstance(row, dict) else None
     return _normalize_paths(raw_paths, channels=channel_filter, result_limit=validated_limit)
-
-
-def simulate_readonly_impact(
-    seed_entities: list[str],
-    context: ReadonlySimulationRequest,
-    *,
-    client: Neo4jClient,
-    status_manager: GraphStatusManager,
-) -> dict[str, Any]:
-    """Run the existing read-only local impact adapter without mutating Neo4j."""
-
-    seed_list = _validated_seed_entities(seed_entities)
-    validated_depth = _validated_depth(context.depth, max_depth=MAX_QUERY_DEPTH)
-    validated_limit = _validated_result_limit(context.result_limit)
-    if status_manager is None:
-        raise ValueError("simulate_readonly_impact requires status_manager")
-
-    with status_manager.ready_read() as ready_status:
-        if ready_status.graph_generation_id != context.graph_generation_id:
-            raise ValueError(
-                "ReadonlySimulationRequest graph_generation_id disagrees with Neo4jGraphStatus: "
-                f"context={context.graph_generation_id}, "
-                f"status={ready_status.graph_generation_id}",
-            )
-        nodes, edges = _read_subgraph(
-            seed_list,
-            validated_depth,
-            client=client,
-            result_limit=validated_limit,
-        )
-
-    subgraph = {
-        "seed_entities": seed_list,
-        "depth": validated_depth,
-        "nodes": nodes,
-        "relationships": edges,
-    }
-    impacted_entities = _impacted_entities_from_subgraph(
-        nodes,
-        set(seed_list),
-        result_limit=validated_limit,
-    )
-    return {
-        "cycle_id": context.cycle_id,
-        "world_state_ref": context.world_state_ref,
-        "graph_generation_id": context.graph_generation_id,
-        "seed_entities": seed_list,
-        "subgraph": subgraph,
-        "impacted_entities": impacted_entities,
-        "activated_paths": list(edges),
-        "channel_breakdown": {
-            "readonly": {
-                "depth": validated_depth,
-                "edge_count": len(edges),
-                "node_count": len(nodes),
-            },
-        },
-    }
 
 
 def _read_subgraph(
@@ -534,36 +476,6 @@ def _path_sort_key(path: Mapping[str, Any]) -> tuple[float, int, bool, str, str,
         _sort_text(path.get("relationship_type")),
         _sort_text(path.get("target_node_id")),
     )
-
-
-def _impacted_entities_from_subgraph(
-    nodes: list[dict[str, Any]],
-    seed_entities: set[str],
-    *,
-    result_limit: int,
-) -> list[dict[str, Any]]:
-    impacted_entities: list[dict[str, Any]] = []
-    for node in nodes:
-        node_id = node.get("node_id")
-        canonical_entity_id = node.get("canonical_entity_id")
-        is_seed = node_id in seed_entities or canonical_entity_id in seed_entities
-        impacted_entities.append(
-            {
-                "canonical_entity_id": canonical_entity_id,
-                "is_seed": is_seed,
-                "labels": _sorted_text_list(node.get("labels", [])),
-                "node_id": node_id,
-                "score": 1.0 if is_seed else 0.0,
-            }
-        )
-    impacted_entities.sort(
-        key=lambda entity: (
-            not bool(entity["is_seed"]),
-            _sort_text(entity.get("node_id")),
-            _sort_text(entity.get("canonical_entity_id")),
-        ),
-    )
-    return impacted_entities[:result_limit]
 
 
 def _sorted_text_list(value: Any) -> list[str]:

--- a/graph_engine/query/simulation.py
+++ b/graph_engine/query/simulation.py
@@ -1,0 +1,528 @@
+"""Read-only local impact simulation over bounded GDS projections."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager
+from typing import Any, Protocol, cast
+from uuid import uuid4
+
+from graph_engine.client import Neo4jClient
+from graph_engine.models import (
+    Neo4jGraphStatus,
+    PropagationChannel,
+    PropagationContext,
+    PropagationResult,
+    ReadonlySimulationRequest,
+)
+from graph_engine.propagation._gds import execute_gds_read, execute_gds_write
+from graph_engine.propagation.channels import (
+    DEFAULT_CHANNEL_BY_RELATIONSHIP_TYPE,
+    effective_channel_selector,
+)
+from graph_engine.propagation.pipeline import run_full_propagation
+from graph_engine.query.service import (
+    _read_subgraph,
+    _validated_depth,
+    _validated_result_limit,
+    _validated_seed_entities,
+)
+from graph_engine.status import GraphStatusManager, hold_ready_read
+
+MAX_SIMULATION_DEPTH = 6
+_SAFE_PROJECTION_PATTERN = re.compile(r"[^A-Za-z0-9_-]+")
+_PROJECTION_NAME_LIMIT = 120
+_DEFAULT_CHANNELS: tuple[PropagationChannel, ...] = (
+    "fundamental",
+    "event",
+    "reflexive",
+)
+
+
+class _SimulationClient(Protocol):
+    def execute_read(
+        self,
+        query: str,
+        parameters: dict[str, Any] | None = None,
+    ) -> list[dict[str, Any]]:
+        ...
+
+    def execute_write(
+        self,
+        query: str,
+        parameters: dict[str, Any] | None = None,
+    ) -> list[dict[str, Any]]:
+        ...
+
+
+def simulate_readonly_impact(
+    seed_entities: list[str],
+    context: ReadonlySimulationRequest,
+    *,
+    client: Neo4jClient,
+    status_manager: GraphStatusManager,
+) -> dict[str, Any]:
+    """Run a local interim propagation simulation without mutating the live graph."""
+
+    seed_list = _validated_seed_entities(seed_entities)
+    depth = _validated_depth(context.depth, max_depth=MAX_SIMULATION_DEPTH)
+    result_limit = _validated_result_limit(context.result_limit)
+    projection_name = _default_projection_name(context)
+
+    with hold_ready_read(status_manager, "readonly local impact simulation") as ready_status:
+        if ready_status.graph_generation_id != context.graph_generation_id:
+            raise ValueError(
+                "ReadonlySimulationRequest graph_generation_id disagrees with Neo4jGraphStatus: "
+                f"context={context.graph_generation_id}, "
+                f"status={ready_status.graph_generation_id}",
+            )
+
+        nodes, edges = _read_subgraph(
+            seed_list,
+            depth,
+            client=client,
+            result_limit=result_limit,
+        )
+        subgraph = _subgraph_payload(seed_list, depth, nodes, edges)
+
+        if not nodes or not edges:
+            propagation_result = _empty_propagation_result(
+                context,
+                reason="empty_subgraph" if not nodes else "empty_relationship_set",
+            )
+        else:
+            projection_client = _ReadonlyProjectionClient(
+                client,
+                node_ids=_node_ids(nodes),
+                edges=edges,
+            )
+            propagation_result = _run_scoped_propagation(
+                context,
+                projection_name=projection_name,
+                client=projection_client,
+                ready_status=ready_status,
+            )
+
+    if propagation_result.graph_generation_id != context.graph_generation_id:
+        raise ValueError(
+            "PropagationResult graph_generation_id disagrees with ReadonlySimulationRequest: "
+            f"result={propagation_result.graph_generation_id}, "
+            f"context={context.graph_generation_id}",
+        )
+
+    return {
+        "status": "ready",
+        "interim": True,
+        "cycle_id": context.cycle_id,
+        "world_state_ref": context.world_state_ref,
+        "graph_generation_id": context.graph_generation_id,
+        "seed_entities": seed_list,
+        "depth": depth,
+        "subgraph": subgraph,
+        "activated_paths": propagation_result.activated_paths,
+        "impacted_entities": propagation_result.impacted_entities,
+        "channel_breakdown": propagation_result.channel_breakdown,
+        "projection_name": projection_name,
+    }
+
+
+def _run_scoped_propagation(
+    request: ReadonlySimulationRequest,
+    *,
+    projection_name: str,
+    client: _SimulationClient,
+    ready_status: Neo4jGraphStatus,
+) -> PropagationResult:
+    projection_names = _projection_names(projection_name, request.enabled_channels)
+    try:
+        _drop_projections(client, projection_names, suppress_missing_gds=False)
+        return run_full_propagation(
+            _simulation_context(request),
+            cast(Neo4jClient, client),
+            status_manager=cast(GraphStatusManager, _HeldReadyStatusManager(ready_status)),
+            graph_name=projection_name,
+            max_iterations=request.max_iterations,
+            result_limit=request.result_limit,
+        )
+    finally:
+        _drop_projections(client, projection_names, suppress_missing_gds=True)
+
+
+def _default_projection_name(context: ReadonlySimulationRequest) -> str:
+    if context.projection_name is not None:
+        return _safe_projection_name(context.projection_name)
+
+    cycle_component = _safe_projection_component(context.cycle_id)
+    return _safe_projection_name(
+        f"graph_engine_readonly_sim_{cycle_component}_{uuid4().hex[:8]}",
+    )
+
+
+def _drop_projection_if_exists(client: _SimulationClient, graph_name: str) -> None:
+    rows = execute_gds_read(
+        cast(Neo4jClient, client),
+        "CALL gds.graph.exists($graph_name) YIELD exists RETURN exists",
+        {"graph_name": graph_name},
+    )
+    if rows and rows[0].get("exists") is True:
+        execute_gds_write(
+            cast(Neo4jClient, client),
+            "CALL gds.graph.drop($graph_name) YIELD graphName RETURN graphName",
+            {"graph_name": graph_name},
+        )
+
+
+def _create_readonly_projection(
+    client: _SimulationClient,
+    graph_name: str,
+    node_ids: list[str],
+    edge_ids: list[str],
+) -> int:
+    if not node_ids or not edge_ids:
+        return 0
+
+    rows = execute_gds_write(
+        cast(Neo4jClient, client),
+        """
+MATCH (source)-[relationship]->(target)
+WHERE source.node_id IN $node_ids
+  AND target.node_id IN $node_ids
+  AND relationship.edge_id IN $edge_ids
+WITH gds.graph.project(
+    $graph_name,
+    source,
+    target,
+    {
+        relationshipType: type(relationship),
+        relationshipProperties: {
+            weight: coalesce(relationship.weight, 1.0)
+        }
+    }
+) AS projection
+RETURN projection.graphName AS graphName,
+       projection.nodeCount AS nodeCount,
+       projection.relationshipCount AS relationshipCount
+""",
+        {
+            "edge_ids": edge_ids,
+            "graph_name": graph_name,
+            "node_ids": node_ids,
+        },
+    )
+    if not rows:
+        return 0
+    return int(rows[0].get("relationshipCount") or 0)
+
+
+def _simulation_context(request: ReadonlySimulationRequest) -> PropagationContext:
+    return PropagationContext(
+        cycle_id=request.cycle_id,
+        world_state_ref=request.world_state_ref,
+        graph_generation_id=request.graph_generation_id,
+        enabled_channels=list(request.enabled_channels),
+        channel_multipliers=dict(request.channel_multipliers),
+        regime_multipliers=dict(request.regime_multipliers),
+        decay_policy=dict(request.decay_policy),
+        regime_context=dict(request.regime_context),
+    )
+
+
+class _HeldReadyStatusManager:
+    def __init__(self, ready_status: Neo4jGraphStatus) -> None:
+        self._ready_status = ready_status
+
+    @contextmanager
+    def ready_read(self) -> Iterator[Neo4jGraphStatus]:
+        yield self._ready_status
+
+
+class _ReadonlyProjectionClient:
+    def __init__(
+        self,
+        client: Neo4jClient,
+        *,
+        node_ids: list[str],
+        edges: list[dict[str, Any]],
+    ) -> None:
+        self._client = client
+        self._node_ids = node_ids
+        self._edge_ids_by_channel = _edge_ids_by_channel(edges)
+
+    def execute_read(
+        self,
+        query: str,
+        parameters: dict[str, Any] | None = None,
+    ) -> list[dict[str, Any]]:
+        params = parameters or {}
+        if _is_activated_path_read(query):
+            channel = _channel_from_query(query, params)
+            if channel is not None:
+                return _read_scoped_activated_path_rows(
+                    self._client,
+                    channel=channel,
+                    node_ids=self._node_ids,
+                    edge_ids=self._edge_ids_by_channel.get(channel, []),
+                    parameters=params,
+                )
+        return self._client.execute_read(query, parameters)
+
+    def execute_write(
+        self,
+        query: str,
+        parameters: dict[str, Any] | None = None,
+    ) -> list[dict[str, Any]]:
+        params = parameters or {}
+        if "gds.graph.project" in query:
+            graph_name = _graph_name_from_parameters(params)
+            channel = _channel_from_query(query, params)
+            edge_ids = (
+                self._edge_ids_by_channel.get(channel, [])
+                if channel is not None
+                else _all_edge_ids(self._edge_ids_by_channel)
+            )
+            relationship_count = _create_readonly_projection(
+                self._client,
+                graph_name,
+                self._node_ids,
+                edge_ids,
+            )
+            return [
+                {
+                    "graphName": graph_name,
+                    "nodeCount": len(self._node_ids),
+                    "relationshipCount": relationship_count,
+                }
+            ]
+        if "gds.graph.drop" in query:
+            return self._client.execute_write(query, parameters)
+        raise PermissionError("readonly simulation only permits GDS projection writes")
+
+
+def _read_scoped_activated_path_rows(
+    client: Neo4jClient,
+    *,
+    channel: str,
+    node_ids: list[str],
+    edge_ids: list[str],
+    parameters: dict[str, Any],
+) -> list[dict[str, Any]]:
+    if not node_ids or not edge_ids:
+        return []
+
+    rows = client.execute_read(
+        f"""
+MATCH (source)-[relationship]->(target)
+WHERE source.node_id IN $node_ids
+  AND target.node_id IN $node_ids
+  AND relationship.edge_id IN $edge_ids
+  AND {effective_channel_selector(channel)}
+WITH source,
+     relationship,
+     target,
+     coalesce(relationship.weight, 1.0) AS relation_weight,
+     coalesce(relationship.evidence_confidence, 1.0) AS evidence_confidence,
+     coalesce(relationship.recency_decay, 1.0) AS recency_decay
+WITH source,
+     relationship,
+     target,
+     relation_weight,
+     evidence_confidence,
+     recency_decay,
+     relation_weight
+         * evidence_confidence
+         * $channel_multiplier
+         * $regime_multiplier
+         * recency_decay AS path_score
+RETURN source.node_id AS source_node_id,
+       source.canonical_entity_id AS source_entity_id,
+       labels(source) AS source_labels,
+       target.node_id AS target_node_id,
+       target.canonical_entity_id AS target_entity_id,
+       labels(target) AS target_labels,
+       relationship.edge_id AS edge_id,
+       type(relationship) AS relationship_type,
+       relation_weight,
+       evidence_confidence,
+       recency_decay,
+       path_score
+ORDER BY path_score DESC,
+         source_node_id ASC,
+         relationship_type ASC,
+         target_node_id ASC,
+         edge_id ASC
+LIMIT $result_limit
+""",
+        {
+            "channel_multiplier": float(parameters.get("channel_multiplier", 1.0)),
+            "edge_ids": edge_ids,
+            "node_ids": node_ids,
+            "regime_multiplier": float(parameters.get("regime_multiplier", 1.0)),
+            "result_limit": int(parameters.get("result_limit", 100)),
+        },
+    )
+    return rows
+
+
+def _drop_projections(
+    client: _SimulationClient,
+    projection_names: list[str],
+    *,
+    suppress_missing_gds: bool,
+) -> None:
+    for projection_name in projection_names:
+        try:
+            _drop_projection_if_exists(client, projection_name)
+        except RuntimeError as exc:
+            if suppress_missing_gds and str(exc) == "GDS plugin not available":
+                continue
+            raise
+
+
+def _projection_names(base_name: str, enabled_channels: list[PropagationChannel]) -> list[str]:
+    names = [base_name]
+    if len(enabled_channels) > 1:
+        names.extend(f"{base_name}-{channel}" for channel in enabled_channels)
+    return list(dict.fromkeys(names))
+
+
+def _safe_projection_name(value: str) -> str:
+    normalized = _SAFE_PROJECTION_PATTERN.sub("_", value).strip("_-")
+    if not normalized:
+        raise ValueError("projection_name must contain a safe graph name component")
+    return normalized[:_PROJECTION_NAME_LIMIT]
+
+
+def _safe_projection_component(value: str) -> str:
+    return (_SAFE_PROJECTION_PATTERN.sub("_", value).strip("_-") or "cycle")[:48]
+
+
+def _subgraph_payload(
+    seed_entities: list[str],
+    depth: int,
+    nodes: list[dict[str, Any]],
+    edges: list[dict[str, Any]],
+) -> dict[str, Any]:
+    return {
+        "seed_entities": seed_entities,
+        "depth": depth,
+        "nodes": nodes,
+        "relationships": edges,
+    }
+
+
+def _empty_propagation_result(
+    request: ReadonlySimulationRequest,
+    *,
+    reason: str,
+) -> PropagationResult:
+    channel_breakdown: dict[str, Any] = {
+        channel: {
+            "status": "skipped",
+            "reason": reason,
+            "path_count": 0,
+            "impacted_entity_count": 0,
+            "total_path_score": 0.0,
+        }
+        for channel in request.enabled_channels
+    }
+    channel_breakdown["merged"] = {
+        "enabled_channels": sorted(request.enabled_channels),
+        "path_count": 0,
+        "impacted_entity_count": 0,
+        "total_path_score": 0.0,
+        "result_limit": request.result_limit,
+    }
+    return PropagationResult(
+        cycle_id=request.cycle_id,
+        graph_generation_id=request.graph_generation_id,
+        activated_paths=[],
+        impacted_entities=[],
+        channel_breakdown=channel_breakdown,
+    )
+
+
+def _node_ids(nodes: list[dict[str, Any]]) -> list[str]:
+    return _unique_text_values(node.get("node_id") for node in nodes)
+
+
+def _edge_ids_by_channel(edges: list[dict[str, Any]]) -> dict[str, list[str]]:
+    edge_ids_by_channel: dict[str, list[str]] = {channel: [] for channel in _DEFAULT_CHANNELS}
+    for edge in edges:
+        channel = _edge_channel(edge)
+        edge_id = edge.get("edge_id")
+        if channel is None or edge_id is None:
+            continue
+        edge_ids_by_channel.setdefault(channel, []).append(str(edge_id))
+    return {
+        channel: _unique_text_values(edge_ids)
+        for channel, edge_ids in edge_ids_by_channel.items()
+    }
+
+
+def _edge_channel(edge: Mapping[str, Any]) -> str | None:
+    properties = edge.get("properties")
+    property_map = properties if isinstance(properties, Mapping) else {}
+    explicit_channel = (
+        property_map.get("propagation_channel")
+        or property_map.get("channel")
+        or property_map.get("impact_channel")
+    )
+    if explicit_channel is not None:
+        return str(explicit_channel)
+
+    relationship_type = edge.get("relationship_type")
+    if relationship_type is None:
+        return None
+    return DEFAULT_CHANNEL_BY_RELATIONSHIP_TYPE.get(str(relationship_type))
+
+
+def _unique_text_values(values: Iterator[Any] | list[Any]) -> list[str]:
+    seen: set[str] = set()
+    unique_values: list[str] = []
+    for value in values:
+        if value is None:
+            continue
+        text = str(value)
+        if not text or text in seen:
+            continue
+        seen.add(text)
+        unique_values.append(text)
+    return unique_values
+
+
+def _all_edge_ids(edge_ids_by_channel: Mapping[str, list[str]]) -> list[str]:
+    return _unique_text_values(
+        edge_id for edge_ids in edge_ids_by_channel.values() for edge_id in edge_ids
+    )
+
+
+def _is_activated_path_read(query: str) -> bool:
+    return (
+        "MATCH (source)-[relationship]->(target)" in query
+        and "path_score" in query
+        and "gds.graph.project" not in query
+    )
+
+
+def _channel_from_query(
+    query: str,
+    parameters: Mapping[str, Any],
+) -> PropagationChannel | None:
+    for channel in _DEFAULT_CHANNELS:
+        if f'= "{channel}"' in query:
+            return channel
+
+    graph_name = parameters.get("graph_name")
+    if isinstance(graph_name, str):
+        for channel in _DEFAULT_CHANNELS:
+            if graph_name.endswith(f"-{channel}"):
+                return channel
+    return None
+
+
+def _graph_name_from_parameters(parameters: Mapping[str, Any]) -> str:
+    graph_name = parameters.get("graph_name")
+    if not isinstance(graph_name, str) or not graph_name:
+        raise ValueError("GDS projection calls require graph_name")
+    return graph_name

--- a/graph_engine/query/simulation.py
+++ b/graph_engine/query/simulation.py
@@ -96,6 +96,10 @@ def simulate_readonly_impact(
                 client,
                 node_ids=_node_ids(nodes),
                 edges=edges,
+                projection_names=_projection_names(
+                    projection_name,
+                    context.enabled_channels,
+                ),
             )
             propagation_result = _run_scoped_propagation(
                 context,
@@ -131,12 +135,12 @@ def _run_scoped_propagation(
     request: ReadonlySimulationRequest,
     *,
     projection_name: str,
-    client: _SimulationClient,
+    client: "_ReadonlyProjectionClient",
     ready_status: Neo4jGraphStatus,
 ) -> PropagationResult:
     projection_names = _projection_names(projection_name, request.enabled_channels)
+    _assert_projection_names_available(client, projection_names)
     try:
-        _drop_projections(client, projection_names, suppress_missing_gds=False)
         return run_full_propagation(
             _simulation_context(request),
             cast(Neo4jClient, client),
@@ -146,17 +150,15 @@ def _run_scoped_propagation(
             result_limit=request.result_limit,
         )
     finally:
-        _drop_projections(client, projection_names, suppress_missing_gds=True)
+        _drop_projections(client, client.created_projection_names, suppress_missing_gds=True)
 
 
 def _default_projection_name(context: ReadonlySimulationRequest) -> str:
     if context.projection_name is not None:
-        return _safe_projection_name(context.projection_name)
+        return _unique_projection_name(context.projection_name)
 
     cycle_component = _safe_projection_component(context.cycle_id)
-    return _safe_projection_name(
-        f"graph_engine_readonly_sim_{cycle_component}_{uuid4().hex[:8]}",
-    )
+    return _unique_projection_name(f"graph_engine_readonly_sim_{cycle_component}")
 
 
 def _drop_projection_if_exists(client: _SimulationClient, graph_name: str) -> None:
@@ -244,10 +246,17 @@ class _ReadonlyProjectionClient:
         *,
         node_ids: list[str],
         edges: list[dict[str, Any]],
+        projection_names: list[str],
     ) -> None:
         self._client = client
         self._node_ids = node_ids
         self._edge_ids_by_channel = _edge_ids_by_channel(edges)
+        self._owned_projection_names = set(projection_names)
+        self._created_projection_names: set[str] = set()
+
+    @property
+    def created_projection_names(self) -> list[str]:
+        return sorted(self._created_projection_names)
 
     def execute_read(
         self,
@@ -255,16 +264,22 @@ class _ReadonlyProjectionClient:
         parameters: dict[str, Any] | None = None,
     ) -> list[dict[str, Any]]:
         params = parameters or {}
+        if _is_gds_graph_exists(query):
+            graph_name = _graph_name_from_parameters(params)
+            return self._read_owned_projection_exists(graph_name)
         if _is_activated_path_read(query):
             channel = _channel_from_query(query, params)
-            if channel is not None:
-                return _read_scoped_activated_path_rows(
-                    self._client,
-                    channel=channel,
-                    node_ids=self._node_ids,
-                    edge_ids=self._edge_ids_by_channel.get(channel, []),
-                    parameters=params,
+            if channel is None:
+                raise PermissionError(
+                    "readonly simulation activated-path reads require a resolvable channel",
                 )
+            return _read_scoped_activated_path_rows(
+                self._client,
+                channel=channel,
+                node_ids=self._node_ids,
+                edge_ids=self._edge_ids_by_channel.get(channel, []),
+                parameters=params,
+            )
         return self._client.execute_read(query, parameters)
 
     def execute_write(
@@ -275,6 +290,8 @@ class _ReadonlyProjectionClient:
         params = parameters or {}
         if "gds.graph.project" in query:
             graph_name = _graph_name_from_parameters(params)
+            self._require_owned_projection(graph_name)
+            self._ensure_projection_available(graph_name)
             channel = _channel_from_query(query, params)
             edge_ids = (
                 self._edge_ids_by_channel.get(channel, [])
@@ -287,6 +304,8 @@ class _ReadonlyProjectionClient:
                 self._node_ids,
                 edge_ids,
             )
+            if relationship_count > 0:
+                self._created_projection_names.add(graph_name)
             return [
                 {
                     "graphName": graph_name,
@@ -295,8 +314,38 @@ class _ReadonlyProjectionClient:
                 }
             ]
         if "gds.graph.drop" in query:
-            return self._client.execute_write(query, parameters)
+            graph_name = _graph_name_from_parameters(params)
+            self._require_owned_projection(graph_name)
+            if graph_name not in self._created_projection_names:
+                raise PermissionError(
+                    "readonly simulation cannot drop a projection it did not create",
+                )
+            rows = self._client.execute_write(query, parameters)
+            self._created_projection_names.discard(graph_name)
+            return rows
         raise PermissionError("readonly simulation only permits GDS projection writes")
+
+    def _read_owned_projection_exists(self, graph_name: str) -> list[dict[str, Any]]:
+        self._require_owned_projection(graph_name)
+        rows = execute_gds_read(
+            self._client,
+            "CALL gds.graph.exists($graph_name) YIELD exists RETURN exists",
+            {"graph_name": graph_name},
+        )
+        if rows and rows[0].get("exists") is True and graph_name not in self._created_projection_names:
+            raise ValueError(f"GDS projection name already exists: {graph_name}")
+        return rows
+
+    def _ensure_projection_available(self, graph_name: str) -> None:
+        rows = self._read_owned_projection_exists(graph_name)
+        if rows and rows[0].get("exists") is True:
+            raise ValueError(f"GDS projection name already exists: {graph_name}")
+
+    def _require_owned_projection(self, graph_name: str) -> None:
+        if graph_name not in self._owned_projection_names:
+            raise PermissionError(
+                "readonly simulation can only manage projections owned by this invocation",
+            )
 
 
 def _read_scoped_activated_path_rows(
@@ -379,11 +428,35 @@ def _drop_projections(
             raise
 
 
+def _assert_projection_names_available(
+    client: _SimulationClient,
+    projection_names: list[str],
+) -> None:
+    for projection_name in projection_names:
+        rows = execute_gds_read(
+            cast(Neo4jClient, client),
+            "CALL gds.graph.exists($graph_name) YIELD exists RETURN exists",
+            {"graph_name": projection_name},
+        )
+        if rows and rows[0].get("exists") is True:
+            raise ValueError(f"GDS projection name already exists: {projection_name}")
+
+
 def _projection_names(base_name: str, enabled_channels: list[PropagationChannel]) -> list[str]:
-    names = [base_name]
-    if len(enabled_channels) > 1:
-        names.extend(f"{base_name}-{channel}" for channel in enabled_channels)
+    if len(enabled_channels) == 1:
+        names = [base_name]
+    else:
+        names = [f"{base_name}-{channel}" for channel in enabled_channels]
     return list(dict.fromkeys(names))
+
+
+def _unique_projection_name(value: str) -> str:
+    owner_token = uuid4().hex[:12]
+    max_prefix_length = _PROJECTION_NAME_LIMIT - len(owner_token) - 1
+    prefix = _safe_projection_name(value)[:max_prefix_length].strip("_-")
+    if not prefix:
+        prefix = "graph_engine_readonly_sim"
+    return f"{prefix}_{owner_token}"
 
 
 def _safe_projection_name(value: str) -> str:
@@ -418,11 +491,14 @@ def _empty_propagation_result(
 ) -> PropagationResult:
     channel_breakdown: dict[str, Any] = {
         channel: {
-            "status": "skipped",
+            "status": "empty",
             "reason": reason,
+            "path_selector": effective_channel_selector(channel),
             "path_count": 0,
             "impacted_entity_count": 0,
             "total_path_score": 0.0,
+            "channel_multiplier": float(request.channel_multipliers[channel]),
+            "regime_multiplier": float(request.regime_multipliers[channel]),
         }
         for channel in request.enabled_channels
     }
@@ -495,6 +571,10 @@ def _all_edge_ids(edge_ids_by_channel: Mapping[str, list[str]]) -> list[str]:
     return _unique_text_values(
         edge_id for edge_ids in edge_ids_by_channel.values() for edge_id in edge_ids
     )
+
+
+def _is_gds_graph_exists(query: str) -> bool:
+    return "gds.graph.exists" in query
 
 
 def _is_activated_path_read(query: str) -> bool:

--- a/tests/integration/test_simulation.py
+++ b/tests/integration/test_simulation.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+from uuid import uuid4
+
+import pytest
+
+from graph_engine.client import Neo4jClient
+from graph_engine.config import load_config_from_env
+from graph_engine.live_metrics import read_live_graph_metrics
+from graph_engine.models import Neo4jGraphStatus, ReadonlySimulationRequest
+from graph_engine.query import simulate_readonly_impact
+from graph_engine.schema.manager import SchemaManager
+from graph_engine.status import GraphStatusManager
+from tests.fakes import InMemoryStatusStore
+
+pytestmark = pytest.mark.skipif(
+    os.getenv("NEO4J_PASSWORD") is None,
+    reason="NEO4J_PASSWORD is not set; Neo4j simulation integration tests require a database.",
+)
+
+NOW = datetime(2026, 4, 17, 1, 2, 3, tzinfo=timezone.utc)
+
+
+def test_readonly_simulation_runs_on_seed_subgraph_without_live_graph_mutation() -> None:
+    pytest.importorskip("neo4j")
+    prefix = f"sim-{uuid4().hex}"
+    node_ids = [
+        f"{prefix}-source",
+        f"{prefix}-fundamental",
+        f"{prefix}-event",
+        f"{prefix}-reflexive",
+        f"{prefix}-outside-a",
+        f"{prefix}-outside-b",
+    ]
+
+    with Neo4jClient(load_config_from_env()) as client:
+        if not client.verify_connectivity():
+            pytest.skip("Neo4j is not reachable with the configured environment.")
+
+        manager = SchemaManager(client)
+        manager.apply_schema()
+        assert manager.verify_schema() is True
+
+        try:
+            _create_simulation_graph(client, prefix)
+            before = read_live_graph_metrics(client)
+            status_manager = GraphStatusManager(
+                InMemoryStatusStore(_ready_status(before, graph_generation_id=41)),
+            )
+            try:
+                result = simulate_readonly_impact(
+                    [f"{prefix}-entity-source"],
+                    _request(prefix, graph_generation_id=41),
+                    client=client,
+                    status_manager=status_manager,
+                )
+            except RuntimeError as exc:
+                if str(exc) == "GDS plugin not available":
+                    pytest.skip("GDS plugin is not available in the configured Neo4j instance.")
+                raise
+            after = read_live_graph_metrics(client)
+        finally:
+            client.execute_write(
+                "MATCH (node) WHERE node.node_id IN $node_ids DETACH DELETE node",
+                {"node_ids": node_ids},
+            )
+
+    assert after == before
+    assert result["status"] == "ready"
+    assert result["interim"] is True
+    assert result["graph_generation_id"] == 41
+    assert "impact_snapshot_id" not in result
+    assert "snapshot_id" not in result
+    edge_channels = {(path["edge_id"], path["channel"]) for path in result["activated_paths"]}
+    assert (f"{prefix}-supply-edge", "fundamental") in edge_channels
+    assert (f"{prefix}-event-edge", "event") in edge_channels
+    assert (f"{prefix}-reflexive-edge", "reflexive") in edge_channels
+    assert f"{prefix}-outside-edge" not in {path["edge_id"] for path in result["activated_paths"]}
+    assert result["channel_breakdown"]["merged"]["enabled_channels"] == [
+        "event",
+        "fundamental",
+        "reflexive",
+    ]
+
+
+def _create_simulation_graph(client: Neo4jClient, prefix: str) -> None:
+    client.execute_write(
+        """
+CREATE (source:Entity {
+    node_id: $source_node_id,
+    canonical_entity_id: $source_entity_id,
+    label: "Entity",
+    properties_json: $source_properties_json
+})
+CREATE (fundamental:Entity {
+    node_id: $fundamental_node_id,
+    canonical_entity_id: $fundamental_entity_id,
+    label: "Entity",
+    properties_json: $fundamental_properties_json
+})
+CREATE (event:Entity {
+    node_id: $event_node_id,
+    canonical_entity_id: $event_entity_id,
+    label: "Entity",
+    properties_json: $event_properties_json
+})
+CREATE (reflexive:Entity {
+    node_id: $reflexive_node_id,
+    canonical_entity_id: $reflexive_entity_id,
+    label: "Entity",
+    properties_json: $reflexive_properties_json
+})
+CREATE (outside_a:Entity {
+    node_id: $outside_a_node_id,
+    canonical_entity_id: $outside_a_entity_id,
+    label: "Entity",
+    properties_json: $outside_a_properties_json
+})
+CREATE (outside_b:Entity {
+    node_id: $outside_b_node_id,
+    canonical_entity_id: $outside_b_entity_id,
+    label: "Entity",
+    properties_json: $outside_b_properties_json
+})
+CREATE (source)-[:SUPPLY_CHAIN {
+    edge_id: $supply_edge_id,
+    relationship_type: "SUPPLY_CHAIN",
+    weight: 2.0
+}]->(fundamental)
+CREATE (source)-[:EVENT_IMPACT {
+    edge_id: $event_edge_id,
+    relationship_type: "EVENT_IMPACT",
+    propagation_channel: "event",
+    weight: 3.0
+}]->(event)
+CREATE (source)-[:OWNERSHIP {
+    edge_id: $reflexive_edge_id,
+    relationship_type: "OWNERSHIP",
+    propagation_channel: "reflexive",
+    weight: 4.0
+}]->(reflexive)
+CREATE (outside_a)-[:SUPPLY_CHAIN {
+    edge_id: $outside_edge_id,
+    relationship_type: "SUPPLY_CHAIN",
+    weight: 99.0
+}]->(outside_b)
+""",
+        {
+            "event_edge_id": f"{prefix}-event-edge",
+            "event_entity_id": f"{prefix}-entity-event",
+            "event_node_id": f"{prefix}-event",
+            "event_properties_json": '{"name": "event"}',
+            "fundamental_entity_id": f"{prefix}-entity-fundamental",
+            "fundamental_node_id": f"{prefix}-fundamental",
+            "fundamental_properties_json": '{"name": "fundamental"}',
+            "outside_a_entity_id": f"{prefix}-entity-outside-a",
+            "outside_a_node_id": f"{prefix}-outside-a",
+            "outside_a_properties_json": '{"name": "outside-a"}',
+            "outside_b_entity_id": f"{prefix}-entity-outside-b",
+            "outside_b_node_id": f"{prefix}-outside-b",
+            "outside_b_properties_json": '{"name": "outside-b"}',
+            "outside_edge_id": f"{prefix}-outside-edge",
+            "reflexive_edge_id": f"{prefix}-reflexive-edge",
+            "reflexive_entity_id": f"{prefix}-entity-reflexive",
+            "reflexive_node_id": f"{prefix}-reflexive",
+            "reflexive_properties_json": '{"name": "reflexive"}',
+            "source_entity_id": f"{prefix}-entity-source",
+            "source_node_id": f"{prefix}-source",
+            "source_properties_json": '{"name": "source"}',
+            "supply_edge_id": f"{prefix}-supply-edge",
+        },
+    )
+
+
+def _request(prefix: str, *, graph_generation_id: int) -> ReadonlySimulationRequest:
+    return ReadonlySimulationRequest(
+        cycle_id=f"{prefix}-cycle",
+        world_state_ref=f"{prefix}-world-state",
+        graph_generation_id=graph_generation_id,
+        depth=1,
+        enabled_channels=["fundamental", "event", "reflexive"],
+        channel_multipliers={
+            "fundamental": 1.0,
+            "event": 1.0,
+            "reflexive": 1.0,
+        },
+        regime_multipliers={
+            "fundamental": 1.0,
+            "event": 1.0,
+            "reflexive": 1.0,
+        },
+        decay_policy={"default": 1.0},
+        regime_context={"source": "integration"},
+        result_limit=20,
+        max_iterations=5,
+        projection_name=f"{prefix}-projection",
+    )
+
+
+def _ready_status(
+    metrics: tuple[int, int, dict[str, int], str],
+    *,
+    graph_generation_id: int,
+) -> Neo4jGraphStatus:
+    node_count, edge_count, key_label_counts, checksum = metrics
+    return Neo4jGraphStatus(
+        graph_status="ready",
+        graph_generation_id=graph_generation_id,
+        node_count=node_count,
+        edge_count=edge_count,
+        key_label_counts=key_label_counts,
+        checksum=checksum,
+        last_verified_at=NOW,
+        last_reload_at=None,
+    )

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -18,6 +18,7 @@ from graph_engine.models import (
     PropagationContext,
     PropagationResult,
     PromotionPlan,
+    ReadonlySimulationRequest,
 )
 
 NOW = datetime(2026, 4, 17, 1, 2, 3, tzinfo=timezone.utc)
@@ -106,6 +107,31 @@ def _model_payloads() -> list[tuple[type[BaseModel], dict[str, Any]]]:
                 "activated_paths": [{"path": ["node-1", "node-2"]}],
                 "impacted_entities": [{"entity_id": "entity-2", "score": 0.5}],
                 "channel_breakdown": {"fundamental": {"score": 0.5}},
+            },
+        ),
+        (
+            ReadonlySimulationRequest,
+            {
+                "cycle_id": "cycle-1",
+                "world_state_ref": "world-state-1",
+                "graph_generation_id": 1,
+                "depth": 2,
+                "enabled_channels": ["fundamental", "event", "reflexive"],
+                "channel_multipliers": {
+                    "fundamental": 1.0,
+                    "event": 1.0,
+                    "reflexive": 1.0,
+                },
+                "regime_multipliers": {
+                    "fundamental": 1.0,
+                    "event": 1.0,
+                    "reflexive": 1.0,
+                },
+                "decay_policy": {"default": 1.0},
+                "regime_context": {"risk_regime": "baseline"},
+                "result_limit": 100,
+                "max_iterations": 20,
+                "projection_name": "graph_engine_readonly_sim_cycle_1",
             },
         ),
         (
@@ -302,6 +328,38 @@ def test_propagation_context_requires_fundamental_channel() -> None:
             decay_policy={},
             regime_context={},
         )
+
+
+@pytest.mark.parametrize(
+    ("payload_update", "match"),
+    [
+        ({"depth": 7}, "less than or equal"),
+        ({"result_limit": 0}, "greater than or equal"),
+        ({"result_limit": 1001}, "less than or equal"),
+        ({"max_iterations": 0}, "greater than or equal"),
+        ({"enabled_channels": ["fundamental", "fundamental"]}, "duplicates"),
+        ({"enabled_channels": []}, "too_short"),
+        ({"channel_multipliers": {"unknown": 1.0}}, "unknown"),
+    ],
+)
+def test_readonly_simulation_request_validates_runtime_bounds(
+    payload_update: dict[str, Any],
+    match: str,
+) -> None:
+    payload = {
+        "cycle_id": "cycle-1",
+        "world_state_ref": "world-state-1",
+        "graph_generation_id": 1,
+        "enabled_channels": ["fundamental"],
+        "channel_multipliers": {"fundamental": 1.0},
+        "regime_multipliers": {"fundamental": 1.0},
+        "decay_policy": {},
+        "regime_context": {},
+    }
+    payload.update(payload_update)
+
+    with pytest.raises(ValidationError, match=match):
+        ReadonlySimulationRequest(**payload)
 
 
 def test_models_forbid_unexpected_fields() -> None:

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -8,12 +8,11 @@ from typing import Any, Iterator, Literal
 import pytest
 from pydantic import ValidationError
 
-from graph_engine.models import GraphQueryResult, Neo4jGraphStatus, ReadonlySimulationRequest
+from graph_engine.models import GraphQueryResult, Neo4jGraphStatus
 from graph_engine.query import (
     MAX_QUERY_DEPTH,
     query_propagation_paths,
     query_subgraph,
-    simulate_readonly_impact,
 )
 from graph_engine.status import GraphStatusManager
 from tests.fakes import InMemoryStatusStore
@@ -352,36 +351,6 @@ def test_query_apis_do_not_call_execute_write() -> None:
         status_manager=_status_manager(),
     )
 
-    assert client.write_calls == []
-
-
-def test_simulate_readonly_impact_keeps_existing_readonly_adapter() -> None:
-    client = FakeQueryClient()
-
-    result = simulate_readonly_impact(
-        ["entity-a"],
-        ReadonlySimulationRequest(
-            cycle_id="cycle-1",
-            world_state_ref="world-state-1",
-            graph_generation_id=1,
-            depth=1,
-            result_limit=1,
-        ),
-        client=client,  # type: ignore[arg-type]
-        status_manager=_status_manager(),
-    )
-
-    assert result["graph_generation_id"] == 1
-    assert result["subgraph"]["depth"] == 1
-    assert result["impacted_entities"] == [
-        {
-            "canonical_entity_id": "entity-a",
-            "is_seed": True,
-            "labels": ["Entity"],
-            "node_id": "node-a",
-            "score": 1.0,
-        }
-    ]
     assert client.write_calls == []
 
 

--- a/tests/unit/test_simulation.py
+++ b/tests/unit/test_simulation.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Any, Iterator, Literal
 
 import pytest
+from pydantic import ValidationError
 
 import graph_engine.query.simulation as simulation_module
 from graph_engine.models import Neo4jGraphStatus, PropagationContext, PropagationResult
@@ -165,7 +166,7 @@ def test_simulate_readonly_impact_returns_interim_propagation_envelope() -> None
     assert result["graph_generation_id"] == 1
     assert result["seed_entities"] == ["entity-a"]
     assert result["depth"] == 2
-    assert result["projection_name"] == "unsafe_projection_DROP_GRAPH"
+    assert re.fullmatch(r"unsafe_projection_DROP_GRAPH_[0-9a-f]{12}", result["projection_name"])
     assert "snapshot_id" not in result
     assert "impact_snapshot_id" not in result
     assert [path["edge_id"] for path in result["activated_paths"]] == ["edge-fundamental"]
@@ -240,14 +241,15 @@ def test_ready_read_barrier_covers_subgraph_projection_and_propagation() -> None
 def test_projection_is_dropped_after_success() -> None:
     client = FakeSimulationClient()
 
-    simulate_readonly_impact(
+    result = simulate_readonly_impact(
         ["entity-a"],
         _request(projection_name="unit-projection"),
         client=client,  # type: ignore[arg-type]
         status_manager=_status_manager(),
     )
 
-    assert client.projections["unit-projection"] is False
+    assert re.fullmatch(r"unit-projection_[0-9a-f]{12}", result["projection_name"])
+    assert client.projections[result["projection_name"]] is False
     write_queries = [query for query, _ in client.write_calls]
     assert any("gds.graph.project" in query for query in write_queries)
     assert write_queries[-1].strip().startswith("CALL gds.graph.drop")
@@ -264,7 +266,58 @@ def test_projection_is_dropped_after_propagation_error() -> None:
             status_manager=_status_manager(),
         )
 
-    assert client.projections["unit-projection"] is False
+    dropped_projection_names = [
+        parameters["graph_name"]
+        for query, parameters in client.write_calls
+        if "gds.graph.drop" in query
+    ]
+    assert len(dropped_projection_names) == 1
+    assert re.fullmatch(r"unit-projection_[0-9a-f]{12}", dropped_projection_names[0])
+    assert client.projections[dropped_projection_names[0]] is False
+
+
+def test_caller_projection_name_is_prefix_and_does_not_drop_existing_exact_name() -> None:
+    client = FakeSimulationClient()
+    client.projections["unit-projection"] = True
+
+    result = simulate_readonly_impact(
+        ["entity-a"],
+        _request(projection_name="unit-projection"),
+        client=client,  # type: ignore[arg-type]
+        status_manager=_status_manager(),
+    )
+
+    assert result["projection_name"] != "unit-projection"
+    assert re.fullmatch(r"unit-projection_[0-9a-f]{12}", result["projection_name"])
+    assert client.projections["unit-projection"] is True
+    dropped_projection_names = [
+        parameters["graph_name"]
+        for query, parameters in client.write_calls
+        if "gds.graph.drop" in query
+    ]
+    assert "unit-projection" not in dropped_projection_names
+
+
+def test_projection_name_collision_rejects_without_dropping(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FixedUUID:
+        hex = "0123456789abcdef0123456789abcdef"
+
+    monkeypatch.setattr(simulation_module, "uuid4", lambda: FixedUUID())
+    client = FakeSimulationClient()
+    client.projections["unit-projection_0123456789ab"] = True
+
+    with pytest.raises(ValueError, match="already exists"):
+        simulate_readonly_impact(
+            ["entity-a"],
+            _request(projection_name="unit-projection"),
+            client=client,  # type: ignore[arg-type]
+            status_manager=_status_manager(),
+        )
+
+    assert client.projections["unit-projection_0123456789ab"] is True
+    assert not any("gds.graph.drop" in query for query, _ in client.write_calls)
 
 
 def test_gds_missing_errors_are_normalized() -> None:
@@ -299,7 +352,9 @@ def test_empty_subgraph_returns_empty_interim_without_running_propagation(
     assert result["interim"] is True
     assert result["activated_paths"] == []
     assert result["impacted_entities"] == []
+    assert result["channel_breakdown"]["fundamental"]["status"] == "empty"
     assert result["channel_breakdown"]["fundamental"]["reason"] == "empty_subgraph"
+    assert result["channel_breakdown"]["fundamental"]["path_count"] == 0
     assert client.write_calls == []
 
 
@@ -345,12 +400,53 @@ def test_run_full_propagation_receives_request_controls(
         status_manager=_status_manager(),
     )
 
-    assert calls[0]["graph_name"] == "unit-projection"
+    assert re.fullmatch(r"unit-projection_[0-9a-f]{12}", calls[0]["graph_name"])
     assert calls[0]["max_iterations"] == 3
     assert calls[0]["result_limit"] == 7
     assert calls[0]["context"].enabled_channels == ["fundamental"]
     assert result["activated_paths"] == [{"edge_id": "from-runner", "channel": "fundamental"}]
     assert result["impacted_entities"] == [{"node_id": "node-b", "channel": "fundamental"}]
+
+
+def test_activated_path_read_requires_resolvable_channel(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = FakeSimulationClient()
+
+    def run_full(
+        context: PropagationContext,
+        run_client: Any,
+        *,
+        status_manager: Any,
+        graph_name: str | None = None,
+        max_iterations: int = 20,
+        result_limit: int = 100,
+    ) -> PropagationResult:
+        run_client.execute_read(
+            """
+MATCH (source)-[relationship]->(target)
+WITH source, relationship, target, 1.0 AS path_score
+RETURN path_score
+""",
+            {"result_limit": result_limit},
+        )
+        return PropagationResult(
+            cycle_id=context.cycle_id,
+            graph_generation_id=context.graph_generation_id,
+            activated_paths=[],
+            impacted_entities=[],
+            channel_breakdown={"fundamental": {"path_count": 0}},
+        )
+
+    monkeypatch.setattr(simulation_module, "run_full_propagation", run_full)
+
+    with pytest.raises(PermissionError, match="resolvable channel"):
+        simulate_readonly_impact(
+            ["entity-a"],
+            _request(),
+            client=client,  # type: ignore[arg-type]
+            status_manager=_status_manager(),
+        )
 
 
 def test_simulation_module_has_no_snapshot_writer_runtime_dependency() -> None:
@@ -359,6 +455,37 @@ def test_simulation_module_has_no_snapshot_writer_runtime_dependency() -> None:
     assert "SnapshotWriter" not in source
     assert "snapshots.writer" not in source
     assert "write_snapshots" not in source
+
+
+@pytest.mark.parametrize(
+    ("request_update", "match"),
+    [
+        ({"channel_multipliers": {"fundamental": -1.0}}, "finite non-negative"),
+        ({"channel_multipliers": {"fundamental": float("nan")}}, "finite non-negative"),
+        ({"regime_multipliers": {"fundamental": float("inf")}}, "finite non-negative"),
+        ({"channel_multipliers": {}}, "must include every enabled channel"),
+        ({"regime_multipliers": {}}, "must include every enabled channel"),
+    ],
+)
+def test_readonly_request_rejects_invalid_runtime_multipliers(
+    request_update: dict[str, Any],
+    match: str,
+) -> None:
+    payload = {
+        "cycle_id": "cycle-1",
+        "world_state_ref": "world-state-1",
+        "graph_generation_id": 1,
+        "depth": 2,
+        "enabled_channels": ["fundamental"],
+        "channel_multipliers": {"fundamental": 1.0},
+        "regime_multipliers": {"fundamental": 1.0},
+        "decay_policy": {"default": 1.0},
+        "regime_context": {"risk_regime": "baseline"},
+    }
+    payload.update(request_update)
+
+    with pytest.raises(ValidationError, match=match):
+        ReadonlySimulationRequest(**payload)
 
 
 def test_readonly_projection_scopes_paths_to_seed_subgraph() -> None:

--- a/tests/unit/test_simulation.py
+++ b/tests/unit/test_simulation.py
@@ -1,0 +1,549 @@
+from __future__ import annotations
+
+import re
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterator, Literal
+
+import pytest
+
+import graph_engine.query.simulation as simulation_module
+from graph_engine.models import Neo4jGraphStatus, PropagationContext, PropagationResult
+from graph_engine.models import ReadonlySimulationRequest
+from graph_engine.query import simulate_readonly_impact
+from graph_engine.status import GraphStatusManager
+from tests.fakes import InMemoryStatusStore
+
+NOW = datetime(2026, 4, 17, 1, 2, 3, tzinfo=timezone.utc)
+_LIVE_MUTATION_PATTERN = re.compile(r"\b(MERGE|SET|CREATE|DELETE)\b", re.IGNORECASE)
+
+
+class FakeSimulationClient:
+    def __init__(
+        self,
+        *,
+        nodes: list[dict[str, Any]] | None = None,
+        edges: list[dict[str, Any]] | None = None,
+        live_edges: list[dict[str, Any]] | None = None,
+        missing_gds: bool = False,
+        raise_on_pagerank: bool = False,
+    ) -> None:
+        self.nodes = _nodes() if nodes is None else nodes
+        self.edges = _edges() if edges is None else edges
+        self.live_edges = list(self.edges if live_edges is None else live_edges)
+        self.missing_gds = missing_gds
+        self.raise_on_pagerank = raise_on_pagerank
+        self.projections: dict[str, bool] = {}
+        self.read_calls: list[tuple[str, dict[str, Any]]] = []
+        self.write_calls: list[tuple[str, dict[str, Any]]] = []
+
+    def execute_read(
+        self,
+        query: str,
+        parameters: dict[str, Any] | None = None,
+    ) -> list[dict[str, Any]]:
+        params = parameters or {}
+        self.read_calls.append((query, params))
+        assert _LIVE_MUTATION_PATTERN.search(query) is None
+        if self.missing_gds and "gds." in query:
+            raise RuntimeError("There is no procedure with name `gds.graph.exists` registered")
+        if "RETURN nodes, relationships" in query:
+            return [{"nodes": self.nodes, "relationships": self.edges}]
+        if "gds.graph.exists" in query:
+            return [{"exists": self.projections.get(str(params.get("graph_name")), False)}]
+        if "gds.pageRank.stream" in query:
+            if self.raise_on_pagerank:
+                raise RuntimeError("pagerank failed")
+            return self._pagerank_rows(str(params.get("graph_name") or ""))
+        if "MATCH (source)-[relationship]->(target)" in query and "path_score" in query:
+            return self._path_rows(query, params)
+        return []
+
+    def execute_write(
+        self,
+        query: str,
+        parameters: dict[str, Any] | None = None,
+    ) -> list[dict[str, Any]]:
+        params = parameters or {}
+        self.write_calls.append((query, params))
+        if self.missing_gds and "gds." in query:
+            raise RuntimeError("There is no procedure with name `gds.graph.project` registered")
+        allowed_gds_write = "gds.graph.project" in query or "gds.graph.drop" in query
+        assert allowed_gds_write
+        assert _LIVE_MUTATION_PATTERN.search(query) is None
+
+        graph_name = str(params.get("graph_name") or "")
+        if "gds.graph.project" in query:
+            relationship_count = len(params.get("edge_ids", []))
+            if relationship_count:
+                self.projections[graph_name] = True
+            return [
+                {
+                    "graphName": graph_name,
+                    "nodeCount": len(params.get("node_ids", [])),
+                    "relationshipCount": relationship_count,
+                }
+            ]
+        self.projections[graph_name] = False
+        return [{"graphName": graph_name}]
+
+    def _pagerank_rows(self, graph_name: str) -> list[dict[str, Any]]:
+        channel = _channel_from_graph_name(graph_name)
+        rows = [
+            edge
+            for edge in self.live_edges
+            if channel is None or _edge_channel(edge) == channel
+        ]
+        return [
+            {
+                "node_id": edge["target_node_id"],
+                "canonical_entity_id": f"{edge['target_node_id']}-entity",
+                "labels": ["Entity"],
+                "stable_node_id": edge["target_node_id"],
+                "score": edge.get("weight", 1.0),
+            }
+            for edge in rows
+        ]
+
+    def _path_rows(
+        self,
+        query: str,
+        params: dict[str, Any],
+    ) -> list[dict[str, Any]]:
+        edge_ids = set(params.get("edge_ids", []))
+        channel = _channel_from_query(query)
+        rows = [
+            edge
+            for edge in self.live_edges
+            if edge["edge_id"] in edge_ids and (channel is None or _edge_channel(edge) == channel)
+        ]
+        return [
+            {
+                "source_node_id": edge["source_node_id"],
+                "source_entity_id": f"{edge['source_node_id']}-entity",
+                "source_labels": ["Entity"],
+                "target_node_id": edge["target_node_id"],
+                "target_entity_id": f"{edge['target_node_id']}-entity",
+                "target_labels": ["Entity"],
+                "edge_id": edge["edge_id"],
+                "relationship_type": edge["relationship_type"],
+                "relation_weight": edge.get("weight", 1.0),
+                "evidence_confidence": 1.0,
+                "recency_decay": 1.0,
+            }
+            for edge in rows
+        ]
+
+
+class RecordingStatusManager:
+    def __init__(self, status: Neo4jGraphStatus, events: list[str]) -> None:
+        self.status = status
+        self.events = events
+
+    @contextmanager
+    def ready_read(self) -> Iterator[Neo4jGraphStatus]:
+        self.events.append("enter")
+        try:
+            yield self.status
+        finally:
+            self.events.append("exit")
+
+
+def test_simulate_readonly_impact_returns_interim_propagation_envelope() -> None:
+    client = FakeSimulationClient()
+
+    result = simulate_readonly_impact(
+        [" entity-a ", "entity-a"],
+        _request(projection_name="unsafe `projection`; DROP GRAPH"),
+        client=client,  # type: ignore[arg-type]
+        status_manager=_status_manager(),
+    )
+
+    assert result["status"] == "ready"
+    assert result["interim"] is True
+    assert result["graph_generation_id"] == 1
+    assert result["seed_entities"] == ["entity-a"]
+    assert result["depth"] == 2
+    assert result["projection_name"] == "unsafe_projection_DROP_GRAPH"
+    assert "snapshot_id" not in result
+    assert "impact_snapshot_id" not in result
+    assert [path["edge_id"] for path in result["activated_paths"]] == ["edge-fundamental"]
+    assert result["channel_breakdown"]["merged"]["enabled_channels"] == ["fundamental"]
+    assert result["subgraph"]["relationships"][0]["edge_id"] == "edge-fundamental"
+
+
+@pytest.mark.parametrize("graph_status", ["rebuilding", "failed"])
+def test_simulation_blocks_non_ready_before_neo4j_reads(
+    graph_status: Literal["rebuilding", "failed"],
+) -> None:
+    client = FakeSimulationClient()
+
+    with pytest.raises(PermissionError, match="ready"):
+        simulate_readonly_impact(
+            ["entity-a"],
+            _request(),
+            client=client,  # type: ignore[arg-type]
+            status_manager=_status_manager(graph_status=graph_status),
+        )
+
+    assert client.read_calls == []
+    assert client.write_calls == []
+
+
+def test_simulation_blocks_active_writer_lock_before_neo4j_reads() -> None:
+    client = FakeSimulationClient()
+
+    with pytest.raises(PermissionError, match="writer lock"):
+        simulate_readonly_impact(
+            ["entity-a"],
+            _request(),
+            client=client,  # type: ignore[arg-type]
+            status_manager=_status_manager(writer_lock_token="incremental-sync"),
+        )
+
+    assert client.read_calls == []
+    assert client.write_calls == []
+
+
+def test_simulation_rejects_generation_mismatch_before_neo4j_reads() -> None:
+    client = FakeSimulationClient()
+
+    with pytest.raises(ValueError, match="graph_generation_id"):
+        simulate_readonly_impact(
+            ["entity-a"],
+            _request(graph_generation_id=1),
+            client=client,  # type: ignore[arg-type]
+            status_manager=_status_manager(graph_generation_id=2),
+        )
+
+    assert client.read_calls == []
+    assert client.write_calls == []
+
+
+def test_ready_read_barrier_covers_subgraph_projection_and_propagation() -> None:
+    events: list[str] = []
+    client = FakeSimulationClient()
+
+    simulate_readonly_impact(
+        ["entity-a"],
+        _request(),
+        client=client,  # type: ignore[arg-type]
+        status_manager=RecordingStatusManager(_ready_status(), events),  # type: ignore[arg-type]
+    )
+
+    assert events == ["enter", "exit"]
+    assert client.read_calls
+    assert client.write_calls
+
+
+def test_projection_is_dropped_after_success() -> None:
+    client = FakeSimulationClient()
+
+    simulate_readonly_impact(
+        ["entity-a"],
+        _request(projection_name="unit-projection"),
+        client=client,  # type: ignore[arg-type]
+        status_manager=_status_manager(),
+    )
+
+    assert client.projections["unit-projection"] is False
+    write_queries = [query for query, _ in client.write_calls]
+    assert any("gds.graph.project" in query for query in write_queries)
+    assert write_queries[-1].strip().startswith("CALL gds.graph.drop")
+
+
+def test_projection_is_dropped_after_propagation_error() -> None:
+    client = FakeSimulationClient(raise_on_pagerank=True)
+
+    with pytest.raises(RuntimeError, match="pagerank failed"):
+        simulate_readonly_impact(
+            ["entity-a"],
+            _request(projection_name="unit-projection"),
+            client=client,  # type: ignore[arg-type]
+            status_manager=_status_manager(),
+        )
+
+    assert client.projections["unit-projection"] is False
+
+
+def test_gds_missing_errors_are_normalized() -> None:
+    client = FakeSimulationClient(missing_gds=True)
+
+    with pytest.raises(RuntimeError, match="GDS plugin not available"):
+        simulate_readonly_impact(
+            ["entity-a"],
+            _request(),
+            client=client,  # type: ignore[arg-type]
+            status_manager=_status_manager(),
+        )
+
+
+def test_empty_subgraph_returns_empty_interim_without_running_propagation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = FakeSimulationClient(nodes=[], edges=[])
+
+    def fail_run_full(*args: Any, **kwargs: Any) -> PropagationResult:
+        raise AssertionError("empty subgraphs must not run GDS propagation")
+
+    monkeypatch.setattr(simulation_module, "run_full_propagation", fail_run_full)
+
+    result = simulate_readonly_impact(
+        ["missing-entity"],
+        _request(),
+        client=client,  # type: ignore[arg-type]
+        status_manager=_status_manager(),
+    )
+
+    assert result["interim"] is True
+    assert result["activated_paths"] == []
+    assert result["impacted_entities"] == []
+    assert result["channel_breakdown"]["fundamental"]["reason"] == "empty_subgraph"
+    assert client.write_calls == []
+
+
+def test_run_full_propagation_receives_request_controls(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = FakeSimulationClient()
+    calls: list[dict[str, Any]] = []
+
+    def run_full(
+        context: PropagationContext,
+        run_client: Any,
+        *,
+        status_manager: Any,
+        graph_name: str | None = None,
+        max_iterations: int = 20,
+        result_limit: int = 100,
+    ) -> PropagationResult:
+        calls.append(
+            {
+                "context": context,
+                "graph_name": graph_name,
+                "max_iterations": max_iterations,
+                "result_limit": result_limit,
+                "run_client": run_client,
+                "status_manager": status_manager,
+            }
+        )
+        return PropagationResult(
+            cycle_id=context.cycle_id,
+            graph_generation_id=context.graph_generation_id,
+            activated_paths=[{"edge_id": "from-runner", "channel": "fundamental"}],
+            impacted_entities=[{"node_id": "node-b", "channel": "fundamental"}],
+            channel_breakdown={"fundamental": {"path_count": 1}},
+        )
+
+    monkeypatch.setattr(simulation_module, "run_full_propagation", run_full)
+
+    result = simulate_readonly_impact(
+        ["entity-a"],
+        _request(max_iterations=3, result_limit=7, projection_name="unit-projection"),
+        client=client,  # type: ignore[arg-type]
+        status_manager=_status_manager(),
+    )
+
+    assert calls[0]["graph_name"] == "unit-projection"
+    assert calls[0]["max_iterations"] == 3
+    assert calls[0]["result_limit"] == 7
+    assert calls[0]["context"].enabled_channels == ["fundamental"]
+    assert result["activated_paths"] == [{"edge_id": "from-runner", "channel": "fundamental"}]
+    assert result["impacted_entities"] == [{"node_id": "node-b", "channel": "fundamental"}]
+
+
+def test_simulation_module_has_no_snapshot_writer_runtime_dependency() -> None:
+    source = Path(simulation_module.__file__).read_text()
+
+    assert "SnapshotWriter" not in source
+    assert "snapshots.writer" not in source
+    assert "write_snapshots" not in source
+
+
+def test_readonly_projection_scopes_paths_to_seed_subgraph() -> None:
+    client = FakeSimulationClient(
+        live_edges=[
+            *_edges(),
+            {
+                "edge_id": "outside-edge",
+                "source_node_id": "outside-a",
+                "target_node_id": "outside-b",
+                "relationship_type": "SUPPLY_CHAIN",
+                "properties": {},
+                "weight": 10.0,
+            },
+        ]
+    )
+
+    result = simulate_readonly_impact(
+        ["entity-a"],
+        _request(),
+        client=client,  # type: ignore[arg-type]
+        status_manager=_status_manager(),
+    )
+
+    assert [path["edge_id"] for path in result["activated_paths"]] == ["edge-fundamental"]
+    project_parameters = [
+        parameters
+        for query, parameters in client.write_calls
+        if "gds.graph.project" in query
+    ]
+    assert project_parameters[0]["edge_ids"] == ["edge-fundamental"]
+
+
+def test_reflexive_tagged_ownership_is_not_counted_as_fundamental() -> None:
+    client = FakeSimulationClient()
+
+    result = simulate_readonly_impact(
+        ["entity-a"],
+        _request(enabled_channels=["fundamental", "reflexive"]),
+        client=client,  # type: ignore[arg-type]
+        status_manager=_status_manager(),
+    )
+
+    channels_by_edge_id: dict[str, set[str]] = {}
+    for path in result["activated_paths"]:
+        channels_by_edge_id.setdefault(str(path["edge_id"]), set()).add(str(path["channel"]))
+
+    assert channels_by_edge_id["edge-fundamental"] == {"fundamental"}
+    assert channels_by_edge_id["edge-reflexive"] == {"reflexive"}
+
+
+def test_examples_do_not_import_business_modules() -> None:
+    examples_dir = Path(__file__).resolve().parents[2] / "examples"
+    for filename in ("consumer_main_core.py", "consumer_stream_layer.py"):
+        path = examples_dir / filename
+        if not path.exists():
+            continue
+        source = path.read_text()
+        assert "import main_core" not in source
+        assert "import stream_layer" not in source
+
+
+def _nodes() -> list[dict[str, Any]]:
+    return [
+        {
+            "node_id": "node-a",
+            "canonical_entity_id": "entity-a",
+            "labels": ["Entity"],
+            "properties": {"name": "Alpha"},
+        },
+        {
+            "node_id": "node-b",
+            "canonical_entity_id": "entity-b",
+            "labels": ["Entity"],
+            "properties": {"name": "Beta"},
+        },
+        {
+            "node_id": "node-c",
+            "canonical_entity_id": "entity-c",
+            "labels": ["Entity"],
+            "properties": {"name": "Gamma"},
+        },
+    ]
+
+
+def _edges() -> list[dict[str, Any]]:
+    return [
+        {
+            "edge_id": "edge-fundamental",
+            "source_node_id": "node-a",
+            "target_node_id": "node-b",
+            "relationship_type": "SUPPLY_CHAIN",
+            "properties": {},
+            "weight": 2.0,
+        },
+        {
+            "edge_id": "edge-reflexive",
+            "source_node_id": "node-a",
+            "target_node_id": "node-c",
+            "relationship_type": "OWNERSHIP",
+            "properties": {"propagation_channel": "reflexive"},
+            "weight": 3.0,
+        },
+    ]
+
+
+def _request(
+    *,
+    graph_generation_id: int = 1,
+    enabled_channels: list[Literal["fundamental", "event", "reflexive"]] | None = None,
+    max_iterations: int = 20,
+    projection_name: str | None = None,
+    result_limit: int = 100,
+) -> ReadonlySimulationRequest:
+    channels = ["fundamental"] if enabled_channels is None else enabled_channels
+    return ReadonlySimulationRequest(
+        cycle_id="cycle-1",
+        world_state_ref="world-state-1",
+        graph_generation_id=graph_generation_id,
+        depth=2,
+        enabled_channels=channels,
+        channel_multipliers={channel: 1.0 for channel in channels},
+        regime_multipliers={channel: 1.0 for channel in channels},
+        decay_policy={"default": 1.0},
+        regime_context={"risk_regime": "baseline"},
+        max_iterations=max_iterations,
+        projection_name=projection_name,
+        result_limit=result_limit,
+    )
+
+
+def _status_manager(
+    *,
+    graph_status: Literal["ready", "rebuilding", "failed"] = "ready",
+    graph_generation_id: int = 1,
+    writer_lock_token: str | None = None,
+) -> GraphStatusManager:
+    return GraphStatusManager(
+        InMemoryStatusStore(
+            _ready_status(
+                graph_status=graph_status,
+                graph_generation_id=graph_generation_id,
+                writer_lock_token=writer_lock_token,
+            ),
+        ),
+    )
+
+
+def _ready_status(
+    *,
+    graph_status: Literal["ready", "rebuilding", "failed"] = "ready",
+    graph_generation_id: int = 1,
+    writer_lock_token: str | None = None,
+) -> Neo4jGraphStatus:
+    return Neo4jGraphStatus(
+        graph_status=graph_status,
+        graph_generation_id=graph_generation_id,
+        node_count=3,
+        edge_count=2,
+        key_label_counts={"Entity": 3},
+        checksum="abc123" if graph_status == "ready" else graph_status,
+        last_verified_at=NOW if graph_status == "ready" else None,
+        last_reload_at=None,
+        writer_lock_token=writer_lock_token,
+    )
+
+
+def _edge_channel(edge: dict[str, Any]) -> str:
+    properties = edge.get("properties", {})
+    if properties.get("propagation_channel") is not None:
+        return str(properties["propagation_channel"])
+    if edge["relationship_type"] == "EVENT_IMPACT":
+        return "event"
+    return "fundamental"
+
+
+def _channel_from_query(query: str) -> str | None:
+    for channel in ("fundamental", "event", "reflexive"):
+        if f'= "{channel}"' in query:
+            return channel
+    return None
+
+
+def _channel_from_graph_name(graph_name: str) -> str | None:
+    for channel in ("fundamental", "event", "reflexive"):
+        if graph_name.endswith(f"-{channel}"):
+            return channel
+    return None


### PR DESCRIPTION
Closes #11

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `benchmarks/artifacts/lite_target_100k_800k.json`, `benchmarks/generate_synthetic.py`, `benchmarks/run_benchmark.py`, `cross-cutting`, `graph_engine/__pycache__/__init__.cpython-314.pyc`, `graph_engine/live_metrics.py`, `graph_engine/propagation/pipeline.py`, `graph_engine/reload/service.py`, `graph_engine/snapshots/generator.py`, `graph_engine/status/consistency.py`


---
### 1. 背景与目标
项目文档 §11.6 / §16.1 要求 `simulate_readonly_impact(seed_entities, context)` 在只读命名投影上做局部传播模拟，返回 interim impact 结果，并严格禁止写 live graph 或正式 snapshot。当前代码已有 `PropagationContext`, `PropagationResult`, `GraphImpactSnapshot` 和 `run_fundamental_propagation()` 的 GDS projection 清理模式；#9 会把这一能力扩展为三通道 `run_full_propagation(...) -> PropagationResult` 并修复 channel attribution P0。#10 会先补齐只读子图查询，本 issue 在该基础上交付面向 `main-core` / `stream-layer` 的局部模拟入口和示例代码。

### 2. 所属模块
主要写入路径：
- `graph_engine/models.py`（新增 `ReadonlySimulationRequest`）
- `graph_engine/query/__init__.py`（导出 simulation API）
- `graph_engine/query/simulation.py`（新增只读局部模拟主入口）
- `examples/consumer_main_core.py`（新增只读消费样例）
- `examples/consumer_stream_layer.py`（新增事件驱动 interim 消费样例）
- `tests/unit/test_simulation.py`（新增单元测试）
- `tests/integration/test_simulation.py`（新增 Neo4j + GDS 集成测试，按现有 skip 模式）

相邻只读 / 集成路径：
- `graph_engine/query/service.py`（复用 #10 的子图读取与 normalization helper）
- `graph_engine/client.py`（复用 `Neo4jClient.execute_read()`；GDS projection lifecycle 仅允许 `gds.graph.project*` / `gds.graph.drop`）
- `graph_engine/status/`（调用 #6 ready-read barrier）
- `graph_engine/propagation/pipeline.py`（调用 #9 的 `run_full_propagation(context: PropagationContext, client: Neo4jClient, *, graph_name: str | None = None, max_iterations: int = 20, result_limit: int = 100) -> PropagationResult`）
- `graph_engine/propagation/context.py` 与 `graph_engine/models.py`（复用 `PropagationContext` / `PropagationResult` 结构）

### 3. 实现范围
- 在 `graph_engine/models.py` 新增 `ReadonlySimulationRequest(BaseModel)`，字段建议为：`cycle_id: str`, `world_state_ref: str`, `graph_generation_id: int`, `depth: int = Field(default=2, ge=0, le=6)`, `enabled_channels: list[Literal["fundamental", "event", "reflexive"]]`, `channel_multipliers: dict[str, float]`, `regime_multipliers: dict[str, float]`, `decay_policy: dict[str, Any]`, `regime_context: dict[str, Any]`, `result_limit: int = Field(default=100, ge=1, le=1000)`, `max_iterations: int = Field(default=20, ge=1)`, `projec