### PR TITLE
feat(#44): [milestone-4 review] P0: Unbounded path expansion before result limits

### DIFF
--- a/benchmarks/report.py
+++ b/benchmarks/report.py
@@ -62,7 +62,14 @@ def check_budgets(
 
 
 def _result_passes_budget(result: BenchmarkResult, budget: dict[str, float]) -> bool:
-    if result.operation in {"pagerank", "path_traversal", "propagation"}:
+    if result.operation in {
+        "pagerank",
+        "path_traversal",
+        "propagation",
+        "query_subgraph",
+        "query_propagation_paths",
+        "simulate_readonly_impact",
+    }:
         return result.passed and result.duration_seconds < budget["propagation"]
     if result.operation == "consistency_check":
         return result.passed and result.duration_seconds < budget["consistency_check"]
@@ -76,7 +83,14 @@ def _result_passes_budget(result: BenchmarkResult, budget: dict[str, float]) -> 
 
 
 def _budget_label(operation: str, budget: dict[str, float]) -> str:
-    if operation in {"pagerank", "path_traversal", "propagation"}:
+    if operation in {
+        "pagerank",
+        "path_traversal",
+        "propagation",
+        "query_subgraph",
+        "query_propagation_paths",
+        "simulate_readonly_impact",
+    }:
         return f"budget=propagation<{budget['propagation']:.1f}s"
     if operation == "consistency_check":
         return f"budget=consistency_check<{budget['consistency_check']:.1f}s"
@@ -86,4 +100,3 @@ def _budget_label(operation: str, budget: dict[str, float]) -> str:
             f"(hard<{budget['cold_reload_hard']:.1f}s)"
         )
     return "budget=n/a"
-

--- a/benchmarks/run_benchmark.py
+++ b/benchmarks/run_benchmark.py
@@ -5,10 +5,11 @@ from __future__ import annotations
 import argparse
 import json
 import time
+from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterator
 
 from benchmarks.generate_synthetic import (
     clear_graph,
@@ -18,8 +19,11 @@ from benchmarks.generate_synthetic import (
 )
 from graph_engine.client import Neo4jClient
 from graph_engine.config import load_config_from_env
+from graph_engine.models import Neo4jGraphStatus, ReadonlySimulationRequest
+from graph_engine.query import query_propagation_paths, query_subgraph, simulate_readonly_impact
 from graph_engine.schema.definitions import NodeLabel, RelationshipType
 from graph_engine.schema.manager import SchemaManager
+from graph_engine.status import GraphStatusManager
 
 _DEFAULT_GRAPH_NAME = "graph_engine_benchmark"
 _LITE_TARGET_NODE_COUNT = 100_000
@@ -312,6 +316,92 @@ def benchmark_path_traversal(
     )
 
 
+def benchmark_read_api_queries(
+    client: Neo4jClient,
+    seed_entity_id: str,
+    *,
+    graph_generation_id: int = 1,
+    depth: int = 4,
+    result_limit: int = 100,
+) -> list[BenchmarkResult]:
+    """Run the public bounded read APIs against one seed entity."""
+
+    if not seed_entity_id:
+        raise ValueError("seed_entity_id must be non-empty")
+    if depth <= 0:
+        raise ValueError("depth must be positive")
+    if result_limit <= 0:
+        raise ValueError("result_limit must be positive")
+
+    node_count, edge_count = _live_graph_counts(client)
+    status_manager = GraphStatusManager(
+        _StaticBenchmarkStatusStore(
+            Neo4jGraphStatus(
+                graph_status="ready",
+                graph_generation_id=graph_generation_id,
+                node_count=node_count,
+                edge_count=edge_count,
+                key_label_counts={},
+                checksum="benchmark",
+                last_verified_at=datetime.now(UTC),
+                last_reload_at=None,
+            ),
+        ),
+    )
+    simulation_request = ReadonlySimulationRequest(
+        cycle_id="benchmark",
+        world_state_ref="benchmark",
+        graph_generation_id=graph_generation_id,
+        depth=min(depth, 6),
+        enabled_channels=["fundamental", "event", "reflexive"],
+        channel_multipliers={"fundamental": 1.0, "event": 1.0, "reflexive": 1.0},
+        regime_multipliers={"fundamental": 1.0, "event": 1.0, "reflexive": 1.0},
+        decay_policy={"default": 1.0},
+        regime_context={"benchmark": True},
+        result_limit=result_limit,
+        max_iterations=20,
+        projection_name="graph_engine_benchmark_readonly_sim",
+    )
+
+    return [
+        _time_read_api_operation(
+            "query_subgraph",
+            node_count,
+            edge_count,
+            lambda: query_subgraph(
+                [seed_entity_id],
+                min(depth, 4),
+                client=client,
+                status_manager=status_manager,
+                result_limit=result_limit,
+            ),
+        ),
+        _time_read_api_operation(
+            "query_propagation_paths",
+            node_count,
+            edge_count,
+            lambda: query_propagation_paths(
+                [seed_entity_id],
+                min(depth, 4),
+                client=client,
+                status_manager=status_manager,
+                result_limit=result_limit,
+            ),
+        ),
+        _time_read_api_operation(
+            "simulate_readonly_impact",
+            node_count,
+            edge_count,
+            lambda: simulate_readonly_impact(
+                [seed_entity_id],
+                simulation_request,
+                client=client,
+                status_manager=status_manager,
+            ),
+        ),
+    ]
+
+
 def benchmark_cold_reload_simulation(
     client: Neo4jClient,
     nodes: list[dict[str, Any]],
@@ -391,6 +481,7 @@ def run_full_benchmark_suite(
         benchmark_gds_projection_create(client, _DEFAULT_GRAPH_NAME),
         benchmark_pagerank(client, _DEFAULT_GRAPH_NAME),
         benchmark_path_traversal(client, nodes[0]["node_id"]),
+        *benchmark_read_api_queries(client, nodes[0]["canonical_entity_id"]),
         benchmark_cold_reload_simulation(client, nodes, edges),
     ]
     return results
@@ -461,6 +552,51 @@ def _benchmark_command(args: argparse.Namespace) -> str:
     if args.record_report is not None:
         parts.append(f"--record-report {args.record_report}")
     return " ".join(parts)
+
+
+class _StaticBenchmarkStatusStore:
+    def __init__(self, status: Neo4jGraphStatus) -> None:
+        self.status = status
+
+    @contextmanager
+    def ready_read_lock(self) -> Iterator[None]:
+        yield
+
+    def read_current_status(self) -> Neo4jGraphStatus | None:
+        return self.status
+
+    def write_current_status(self, status: Neo4jGraphStatus) -> None:
+        self.status = status
+
+    def compare_and_write_current_status(
+        self,
+        *,
+        expected_status: Neo4jGraphStatus | None,
+        next_status: Neo4jGraphStatus,
+    ) -> bool:
+        if self.status != expected_status:
+            return False
+        self.status = next_status
+        return True
+
+
+def _time_read_api_operation(
+    operation: str,
+    node_count: int,
+    edge_count: int,
+    callback: Any,
+) -> BenchmarkResult:
+    start = time.perf_counter()
+    callback()
+    duration_seconds = time.perf_counter() - start
+    return BenchmarkResult(
+        operation=operation,
+        node_count=node_count,
+        edge_count=edge_count,
+        duration_seconds=duration_seconds,
+        memory_mb=None,
+        passed=duration_seconds < _default_budget("propagation"),
+    )
 
 
 def _benchmark_result_to_dict(result: BenchmarkResult) -> dict[str, Any]:

--- a/graph_engine/models.py
+++ b/graph_engine/models.py
@@ -215,6 +215,11 @@ class GraphQueryResult(BaseModel):
     subgraph_nodes: list[dict[str, Any]]
     subgraph_edges: list[dict[str, Any]]
     status: Literal["ready"]
+    seed_entities: list[str] = Field(default_factory=list)
+    depth: int = Field(default=0, ge=0)
+    result_limit: int = Field(default=0, ge=0)
+    truncated: bool = False
+    truncation: dict[str, Any] = Field(default_factory=dict)
 
 
 class GraphSnapshot(BaseModel):

--- a/graph_engine/query/service.py
+++ b/graph_engine/query/service.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import json
-from collections.abc import Mapping
+from collections.abc import Iterator, Mapping
+from dataclasses import dataclass
 from typing import Any, get_args
 
 from graph_engine.client import Neo4jClient
@@ -37,6 +38,33 @@ _EDGE_STRUCTURAL_PROPERTY_KEYS = frozenset(
 )
 
 
+@dataclass(frozen=True)
+class BoundedSubgraph:
+    nodes: list[dict[str, Any]]
+    relationships: list[dict[str, Any]]
+    truncation: dict[str, Any]
+
+    @property
+    def truncated(self) -> bool:
+        return bool(self.truncation.get("truncated"))
+
+    def __iter__(self) -> Iterator[list[dict[str, Any]]]:
+        yield self.nodes
+        yield self.relationships
+
+
+class BoundedPathList(list[dict[str, Any]]):
+    def __init__(
+        self,
+        paths: list[dict[str, Any]],
+        *,
+        truncation: dict[str, Any],
+    ) -> None:
+        super().__init__(paths)
+        self.truncation = truncation
+        self.truncated = bool(truncation.get("truncated"))
+
+
 def query_subgraph(
     seed_entities: list[str],
     depth: int,
@@ -55,7 +83,7 @@ def query_subgraph(
         raise ValueError("query_subgraph requires status_manager")
 
     with status_manager.ready_read() as graph_status:
-        nodes, edges = _read_subgraph(
+        subgraph = _read_subgraph(
             seed_list,
             validated_depth,
             client=client,
@@ -63,9 +91,14 @@ def query_subgraph(
         )
         return GraphQueryResult(
             graph_generation_id=graph_status.graph_generation_id,
-            subgraph_nodes=nodes,
-            subgraph_edges=edges,
+            subgraph_nodes=subgraph.nodes,
+            subgraph_edges=subgraph.relationships,
             status="ready",
+            seed_entities=seed_list,
+            depth=validated_depth,
+            result_limit=validated_limit,
+            truncated=subgraph.truncated,
+            truncation=subgraph.truncation,
         )
 
 
@@ -89,17 +122,13 @@ def query_propagation_paths(
         raise ValueError("query_propagation_paths requires status_manager")
 
     with status_manager.ready_read():
-        rows = client.execute_read(
-            _path_query(validated_depth),
-            {
-                "channels": channel_filter,
-                "result_limit": validated_limit,
-                "seed_entities": seed_list,
-            },
+        return _read_propagation_paths(
+            seed_list,
+            validated_depth,
+            client=client,
+            channels=channel_filter,
+            result_limit=validated_limit,
         )
-    row = rows[0] if isinstance(rows, list) and rows else {}
-    raw_paths = row.get("paths") if isinstance(row, dict) else None
-    return _normalize_paths(raw_paths, channels=channel_filter, result_limit=validated_limit)
 
 
 def _read_subgraph(
@@ -108,119 +137,511 @@ def _read_subgraph(
     *,
     client: Neo4jClient,
     result_limit: int,
-) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
-    rows = client.execute_read(
-        _subgraph_query(depth),
-        {
-            "result_limit": result_limit,
-            "seed_entities": seed_entities,
-        },
+) -> BoundedSubgraph:
+    seed_rows = _read_seed_rows(
+        client,
+        seed_entities=seed_entities,
+        result_limit=result_limit,
     )
-    row = rows[0] if isinstance(rows, list) and rows else {}
-    if not isinstance(row, dict):
-        row = {}
 
-    raw_nodes = row.get("nodes", row.get("subgraph_nodes"))
-    raw_edges = row.get("relationships", row.get("subgraph_edges", row.get("edges")))
-    return (
-        _normalize_nodes(raw_nodes, result_limit=result_limit),
-        _normalize_edges(raw_edges, result_limit=result_limit),
+    nodes_by_key: dict[str, dict[str, Any]] = {}
+    frontier_node_keys: list[str] = []
+    node_limit_reached = len(seed_rows) > result_limit
+    for row in seed_rows[:result_limit]:
+        node, node_key = _node_from_traversal_row(row)
+        if node_key is None or node_key in nodes_by_key:
+            continue
+        nodes_by_key[node_key] = node
+        frontier_node_keys.append(node_key)
+
+    relationships_by_key: dict[str, dict[str, Any]] = {}
+    visited_relationship_keys: set[str] = set()
+    frontier_limit_reached = False
+    relationship_limit_reached = False
+    truncated_depths: set[int] = set()
+    reached_depth = 0
+
+    for current_depth in range(1, depth + 1):
+        if not frontier_node_keys:
+            break
+        reached_depth = current_depth
+        rows = _read_frontier_rows(
+            client,
+            frontier_node_keys=frontier_node_keys,
+            visited_relationship_keys=visited_relationship_keys,
+            result_limit=result_limit,
+            include_channel=False,
+        )
+        if len(rows) > result_limit:
+            frontier_limit_reached = True
+            truncated_depths.add(current_depth)
+
+        previous_node_keys = set(nodes_by_key)
+        next_frontier_keys: list[str] = []
+        for row in rows[:result_limit]:
+            relationship, relationship_key = _relationship_from_traversal_row(row)
+            if relationship_key is None or relationship_key in visited_relationship_keys:
+                continue
+            visited_relationship_keys.add(relationship_key)
+
+            endpoint_nodes = _endpoint_nodes_from_traversal_row(row)
+            endpoints_available = True
+            for endpoint_key, endpoint_node in endpoint_nodes:
+                if endpoint_key is None or endpoint_key in nodes_by_key:
+                    continue
+                if len(nodes_by_key) >= result_limit:
+                    node_limit_reached = True
+                    truncated_depths.add(current_depth)
+                    endpoints_available = False
+                    break
+                nodes_by_key[endpoint_key] = endpoint_node
+
+            if not endpoints_available:
+                continue
+            if len(relationships_by_key) >= result_limit:
+                relationship_limit_reached = True
+                truncated_depths.add(current_depth)
+                break
+
+            relationships_by_key[relationship_key] = relationship
+            neighbor_key = _text_or_none(row.get("neighbor_key"))
+            if (
+                neighbor_key is not None
+                and neighbor_key not in previous_node_keys
+                and neighbor_key in nodes_by_key
+                and neighbor_key not in next_frontier_keys
+            ):
+                next_frontier_keys.append(neighbor_key)
+
+        frontier_node_keys = next_frontier_keys
+        if node_limit_reached or relationship_limit_reached:
+            break
+
+    nodes = _normalize_nodes(list(nodes_by_key.values()), result_limit=result_limit)
+    included_node_ids = {
+        node_id
+        for node in nodes
+        if (node_id := _text_or_none(node.get("node_id"))) is not None
+    }
+    relationships = _normalize_edges(
+        [
+            relationship
+            for relationship in relationships_by_key.values()
+            if _relationship_endpoints_included(relationship, included_node_ids)
+        ],
+        result_limit=result_limit,
     )
+    truncation = _truncation_metadata(
+        depth=depth,
+        reached_depth=reached_depth,
+        result_limit=result_limit,
+        node_count=len(nodes),
+        relationship_count=len(relationships),
+        path_count=None,
+        node_limit_reached=node_limit_reached,
+        relationship_limit_reached=relationship_limit_reached,
+        path_limit_reached=False,
+        frontier_limit_reached=frontier_limit_reached,
+        truncated_depths=truncated_depths,
+    )
+    return BoundedSubgraph(nodes, relationships, truncation)
 
 
 def _subgraph_query(depth: int) -> str:
-    return f"""
+    return _seed_nodes_query()
+
+
+def _seed_nodes_query() -> str:
+    return """
 MATCH (seed)
 WHERE seed.canonical_entity_id IN $seed_entities
    OR seed.node_id IN $seed_entities
-OPTIONAL MATCH path = (seed)-[*0..{depth}]-(reachable)
-WITH collect(path) AS paths
-CALL {{
-    WITH paths
-    UNWIND paths AS graph_path
-    WITH graph_path
-    WHERE graph_path IS NOT NULL
-    UNWIND nodes(graph_path) AS graph_node
-    WITH DISTINCT graph_node
-    ORDER BY coalesce(graph_node.node_id, ""),
-             coalesce(graph_node.canonical_entity_id, "")
-    LIMIT $result_limit
-    RETURN collect({{
-        node_id: graph_node.node_id,
-        canonical_entity_id: graph_node.canonical_entity_id,
-        labels: labels(graph_node),
-        properties: properties(graph_node)
-    }}) AS nodes
-}}
-CALL {{
-    WITH paths
-    UNWIND paths AS graph_path
-    WITH graph_path
-    WHERE graph_path IS NOT NULL
-    UNWIND relationships(graph_path) AS relationship
-    WITH DISTINCT relationship
-    ORDER BY coalesce(relationship.edge_id, ""),
-             coalesce(startNode(relationship).node_id, ""),
-             type(relationship),
-             coalesce(endNode(relationship).node_id, "")
-    LIMIT $result_limit
-    RETURN collect({{
-        edge_id: relationship.edge_id,
-        source_node_id: startNode(relationship).node_id,
-        target_node_id: endNode(relationship).node_id,
-        relationship_type: type(relationship),
-        properties: properties(relationship),
-        weight: coalesce(relationship.weight, 1.0)
-    }}) AS relationships
-}}
-RETURN nodes, relationships
+WITH DISTINCT seed,
+     coalesce(seed.node_id, elementId(seed)) AS node_key
+ORDER BY coalesce(seed.node_id, ""),
+         coalesce(seed.canonical_entity_id, ""),
+         node_key
+LIMIT $per_depth_limit
+RETURN node_key,
+       {
+           node_id: seed.node_id,
+           canonical_entity_id: seed.canonical_entity_id,
+           labels: labels(seed),
+           properties: properties(seed)
+       } AS node
 """
 
 
 def _path_query(depth: int) -> str:
     if depth == 0:
-        return """
-MATCH (seed)
-WHERE seed.canonical_entity_id IN $seed_entities
-   OR seed.node_id IN $seed_entities
-WITH count(seed) AS seed_count
-RETURN [] AS paths
+        return "RETURN [] AS paths"
+
+    return _frontier_expansion_query(include_channel=True)
+
+
+def _frontier_expansion_query(*, include_channel: bool) -> str:
+    channel_expression = effective_channel_expression("relationship")
+    channel_projection = f"{channel_expression} AS channel" if include_channel else "null AS channel"
+    return f"""
+MATCH (frontier)-[relationship]-(neighbor)
+WHERE coalesce(frontier.node_id, elementId(frontier)) IN $frontier_node_keys
+WITH DISTINCT relationship
+WITH relationship,
+     startNode(relationship) AS source,
+     endNode(relationship) AS target,
+     coalesce(relationship.edge_id, elementId(relationship)) AS relationship_key
+WITH relationship,
+     source,
+     target,
+     relationship_key,
+     coalesce(source.node_id, elementId(source)) AS source_key,
+     coalesce(target.node_id, elementId(target)) AS target_key
+WHERE NOT (relationship_key IN $visited_relationship_keys)
+WITH relationship,
+     source,
+     target,
+     relationship_key,
+     source_key,
+     target_key,
+     CASE
+         WHEN source_key IN $frontier_node_keys
+              AND NOT (target_key IN $frontier_node_keys) THEN target
+         WHEN target_key IN $frontier_node_keys
+              AND NOT (source_key IN $frontier_node_keys) THEN source
+         WHEN source_key IN $frontier_node_keys THEN target
+         ELSE source
+     END AS neighbor
+WITH relationship,
+     source,
+     target,
+     relationship_key,
+     source_key,
+     target_key,
+     neighbor,
+     coalesce(neighbor.node_id, elementId(neighbor)) AS neighbor_key,
+     {channel_projection}
+ORDER BY relationship_key,
+         source_key,
+         type(relationship),
+         target_key,
+         neighbor_key
+LIMIT $per_depth_limit
+RETURN relationship_key,
+       source_key,
+       target_key,
+       neighbor_key,
+       channel,
+       {{
+           node_id: source.node_id,
+           canonical_entity_id: source.canonical_entity_id,
+           labels: labels(source),
+           properties: properties(source)
+       }} AS source,
+       {{
+           node_id: target.node_id,
+           canonical_entity_id: target.canonical_entity_id,
+           labels: labels(target),
+           properties: properties(target)
+       }} AS target,
+       {{
+           node_id: neighbor.node_id,
+           canonical_entity_id: neighbor.canonical_entity_id,
+           labels: labels(neighbor),
+           properties: properties(neighbor)
+       }} AS neighbor,
+       {{
+           edge_id: relationship.edge_id,
+           source_node_id: source.node_id,
+           target_node_id: target.node_id,
+           relationship_type: type(relationship),
+           properties: properties(relationship),
+           weight: coalesce(relationship.weight, 1.0)
+       }} AS relationship
 """
 
-    channel_expression = effective_channel_expression("relationship")
-    return f"""
-MATCH (seed)
-WHERE seed.canonical_entity_id IN $seed_entities
-   OR seed.node_id IN $seed_entities
-MATCH path = (seed)-[*1..{depth}]-(reachable)
-UNWIND relationships(path) AS relationship
-WITH relationship,
-     {channel_expression} AS channel,
-     length(path) AS path_length
-WHERE channel IS NOT NULL
-  AND ($channels IS NULL OR channel IN $channels)
-WITH relationship,
-     channel,
-     min(path_length) AS path_length,
-     toFloat(coalesce(relationship.weight, 1.0)) AS score
-ORDER BY score DESC,
-         path_length ASC,
-         coalesce(relationship.edge_id, ""),
-         coalesce(startNode(relationship).node_id, ""),
-         type(relationship),
-         coalesce(endNode(relationship).node_id, "")
-LIMIT $result_limit
-RETURN collect({{
-    channel: channel,
-    edge_id: relationship.edge_id,
-    source_node_id: startNode(relationship).node_id,
-    target_node_id: endNode(relationship).node_id,
-    relationship_type: type(relationship),
-    score: score,
-    path_length: path_length,
-    properties: properties(relationship)
-}}) AS paths
-"""
+
+def _read_propagation_paths(
+    seed_entities: list[str],
+    depth: int,
+    *,
+    client: Neo4jClient,
+    channels: list[str] | None,
+    result_limit: int,
+) -> BoundedPathList:
+    if depth == 0:
+        return BoundedPathList(
+            [],
+            truncation=_truncation_metadata(
+                depth=depth,
+                reached_depth=0,
+                result_limit=result_limit,
+                node_count=0,
+                relationship_count=0,
+                path_count=0,
+                node_limit_reached=False,
+                relationship_limit_reached=False,
+                path_limit_reached=False,
+                frontier_limit_reached=False,
+                truncated_depths=set(),
+            ),
+        )
+
+    seed_rows = _read_seed_rows(
+        client,
+        seed_entities=seed_entities,
+        result_limit=result_limit,
+    )
+    nodes_by_key: dict[str, dict[str, Any]] = {}
+    frontier_node_keys: list[str] = []
+    node_limit_reached = len(seed_rows) > result_limit
+    for row in seed_rows[:result_limit]:
+        node, node_key = _node_from_traversal_row(row)
+        if node_key is None or node_key in nodes_by_key:
+            continue
+        nodes_by_key[node_key] = node
+        frontier_node_keys.append(node_key)
+
+    visited_relationship_keys: set[str] = set()
+    paths_by_key: dict[tuple[str, str, str, str, str], dict[str, Any]] = {}
+    channel_set = set(channels) if channels is not None else None
+    candidate_limit = result_limit * max(depth, 1)
+    frontier_limit_reached = False
+    relationship_limit_reached = False
+    path_limit_reached = False
+    truncated_depths: set[int] = set()
+    reached_depth = 0
+
+    for current_depth in range(1, depth + 1):
+        if not frontier_node_keys:
+            break
+        reached_depth = current_depth
+        rows = _read_frontier_rows(
+            client,
+            frontier_node_keys=frontier_node_keys,
+            visited_relationship_keys=visited_relationship_keys,
+            result_limit=result_limit,
+            include_channel=True,
+        )
+        if len(rows) > result_limit:
+            frontier_limit_reached = True
+            truncated_depths.add(current_depth)
+
+        previous_node_keys = set(nodes_by_key)
+        next_frontier_keys: list[str] = []
+        for row in rows[:result_limit]:
+            relationship, relationship_key = _relationship_from_traversal_row(row)
+            if relationship_key is None or relationship_key in visited_relationship_keys:
+                continue
+            visited_relationship_keys.add(relationship_key)
+
+            neighbor = row.get("neighbor")
+            neighbor_payload = _node_payload(neighbor) if isinstance(neighbor, Mapping) else {}
+            neighbor_key = _text_or_none(row.get("neighbor_key"))
+            if neighbor_key is not None and neighbor_key not in nodes_by_key:
+                if len(nodes_by_key) >= result_limit:
+                    node_limit_reached = True
+                    truncated_depths.add(current_depth)
+                else:
+                    nodes_by_key[neighbor_key] = neighbor_payload
+
+            if (
+                neighbor_key is not None
+                and neighbor_key not in previous_node_keys
+                and neighbor_key in nodes_by_key
+                and neighbor_key not in next_frontier_keys
+            ):
+                next_frontier_keys.append(neighbor_key)
+
+            channel = _text_or_none(row.get("channel"))
+            if channel is None or (channel_set is not None and channel not in channel_set):
+                continue
+            if len(paths_by_key) >= candidate_limit:
+                path_limit_reached = True
+                truncated_depths.add(current_depth)
+                continue
+
+            path = _path_payload(
+                {
+                    **relationship,
+                    "channel": channel,
+                    "path_length": current_depth,
+                    "score": relationship.get("weight"),
+                },
+            )
+            key = _path_identity(path)
+            paths_by_key.setdefault(key, path)
+
+        frontier_node_keys = next_frontier_keys
+        if node_limit_reached and not frontier_node_keys:
+            break
+        if relationship_limit_reached:
+            break
+
+    raw_paths = list(paths_by_key.values())
+    paths = _normalize_paths(raw_paths, channels=channels, result_limit=result_limit)
+    if len(raw_paths) > result_limit:
+        path_limit_reached = True
+    truncation = _truncation_metadata(
+        depth=depth,
+        reached_depth=reached_depth,
+        result_limit=result_limit,
+        node_count=len(nodes_by_key),
+        relationship_count=len(visited_relationship_keys),
+        path_count=len(paths),
+        node_limit_reached=node_limit_reached,
+        relationship_limit_reached=relationship_limit_reached,
+        path_limit_reached=path_limit_reached,
+        frontier_limit_reached=frontier_limit_reached,
+        truncated_depths=truncated_depths,
+    )
+    return BoundedPathList(paths, truncation=truncation)
+
+
+def _read_seed_rows(
+    client: Neo4jClient,
+    *,
+    seed_entities: list[str],
+    result_limit: int,
+) -> list[dict[str, Any]]:
+    return client.execute_read(
+        _seed_nodes_query(),
+        {
+            "per_depth_limit": _per_depth_limit(result_limit),
+            "seed_entities": seed_entities,
+        },
+    )
+
+
+def _read_frontier_rows(
+    client: Neo4jClient,
+    *,
+    frontier_node_keys: list[str],
+    visited_relationship_keys: set[str],
+    result_limit: int,
+    include_channel: bool,
+) -> list[dict[str, Any]]:
+    return client.execute_read(
+        _frontier_expansion_query(include_channel=include_channel),
+        {
+            "frontier_node_keys": frontier_node_keys,
+            "per_depth_limit": _per_depth_limit(result_limit),
+            "visited_relationship_keys": sorted(visited_relationship_keys),
+        },
+    )
+
+
+def _per_depth_limit(result_limit: int) -> int:
+    return result_limit + 1
+
+
+def _node_from_traversal_row(row: Mapping[str, Any]) -> tuple[dict[str, Any], str | None]:
+    raw_node = row.get("node")
+    if not isinstance(raw_node, Mapping):
+        raw_node = row
+    node = _node_payload(raw_node)
+    return node, _text_or_none(row.get("node_key")) or _node_key(node)
+
+
+def _relationship_from_traversal_row(
+    row: Mapping[str, Any],
+) -> tuple[dict[str, Any], str | None]:
+    raw_relationship = row.get("relationship")
+    if not isinstance(raw_relationship, Mapping):
+        raw_relationship = row
+    relationship = _edge_payload(raw_relationship)
+    return relationship, _text_or_none(row.get("relationship_key")) or _relationship_key(
+        relationship,
+    )
+
+
+def _endpoint_nodes_from_traversal_row(
+    row: Mapping[str, Any],
+) -> list[tuple[str | None, dict[str, Any]]]:
+    endpoints: list[tuple[str | None, dict[str, Any]]] = []
+    for key_name, node_name in (("source_key", "source"), ("target_key", "target")):
+        raw_node = row.get(node_name)
+        if not isinstance(raw_node, Mapping):
+            continue
+        node = _node_payload(raw_node)
+        endpoints.append((_text_or_none(row.get(key_name)) or _node_key(node), node))
+    return endpoints
+
+
+def _node_key(node: Mapping[str, Any]) -> str | None:
+    node_id = _text_or_none(node.get("node_id"))
+    if node_id:
+        return node_id
+    canonical_entity_id = _text_or_none(node.get("canonical_entity_id"))
+    if canonical_entity_id:
+        return canonical_entity_id
+    return None
+
+
+def _relationship_key(relationship: Mapping[str, Any]) -> str | None:
+    edge_id = _text_or_none(relationship.get("edge_id"))
+    if edge_id:
+        return edge_id
+    source_node_id = _text_or_none(relationship.get("source_node_id"))
+    relationship_type = _text_or_none(relationship.get("relationship_type"))
+    target_node_id = _text_or_none(relationship.get("target_node_id"))
+    if source_node_id is None or relationship_type is None or target_node_id is None:
+        return None
+    return "|".join((source_node_id, relationship_type, target_node_id))
+
+
+def _relationship_endpoints_included(
+    relationship: Mapping[str, Any],
+    included_node_ids: set[str],
+) -> bool:
+    source_node_id = _text_or_none(relationship.get("source_node_id"))
+    target_node_id = _text_or_none(relationship.get("target_node_id"))
+    if source_node_id is None or target_node_id is None:
+        return False
+    return source_node_id in included_node_ids and target_node_id in included_node_ids
+
+
+def _truncation_metadata(
+    *,
+    depth: int,
+    reached_depth: int,
+    result_limit: int,
+    node_count: int,
+    relationship_count: int,
+    path_count: int | None,
+    node_limit_reached: bool,
+    relationship_limit_reached: bool,
+    path_limit_reached: bool,
+    frontier_limit_reached: bool,
+    truncated_depths: set[int],
+) -> dict[str, Any]:
+    reasons: list[str] = []
+    if node_limit_reached:
+        reasons.append("node_limit_reached")
+    if relationship_limit_reached:
+        reasons.append("relationship_limit_reached")
+    if path_limit_reached:
+        reasons.append("path_limit_reached")
+    if frontier_limit_reached:
+        reasons.append("frontier_limit_reached")
+
+    metadata: dict[str, Any] = {
+        "truncated": bool(reasons),
+        "reasons": reasons,
+        "depth": depth,
+        "reached_depth": reached_depth,
+        "result_limit": result_limit,
+        "per_depth_limit": result_limit,
+        "node_count": node_count,
+        "relationship_count": relationship_count,
+        "node_limit_reached": node_limit_reached,
+        "relationship_limit_reached": relationship_limit_reached,
+        "path_limit_reached": path_limit_reached,
+        "frontier_limit_reached": frontier_limit_reached,
+        "truncated_depths": sorted(truncated_depths),
+    }
+    if path_count is not None:
+        metadata["path_count"] = path_count
+    return metadata
 
 
 def _node_payload(value: Mapping[str, Any]) -> dict[str, Any]:

--- a/graph_engine/query/simulation.py
+++ b/graph_engine/query/simulation.py
@@ -78,13 +78,21 @@ def simulate_readonly_impact(
                 f"status={ready_status.graph_generation_id}",
             )
 
-        nodes, edges = _read_subgraph(
+        bounded_subgraph = _read_subgraph(
             seed_list,
             depth,
             client=client,
             result_limit=result_limit,
         )
-        subgraph = _subgraph_payload(seed_list, depth, nodes, edges)
+        nodes, edges = bounded_subgraph
+        subgraph = _subgraph_payload(
+            seed_list,
+            depth,
+            result_limit,
+            nodes,
+            edges,
+            bounded_subgraph.truncation,
+        )
 
         if not nodes or not edges:
             propagation_result = _empty_propagation_result(
@@ -123,6 +131,9 @@ def simulate_readonly_impact(
         "graph_generation_id": context.graph_generation_id,
         "seed_entities": seed_list,
         "depth": depth,
+        "result_limit": result_limit,
+        "truncated": bounded_subgraph.truncated,
+        "truncation": bounded_subgraph.truncation,
         "subgraph": subgraph,
         "activated_paths": propagation_result.activated_paths,
         "impacted_entities": propagation_result.impacted_entities,
@@ -473,14 +484,19 @@ def _safe_projection_component(value: str) -> str:
 def _subgraph_payload(
     seed_entities: list[str],
     depth: int,
+    result_limit: int,
     nodes: list[dict[str, Any]],
     edges: list[dict[str, Any]],
+    truncation: Mapping[str, Any],
 ) -> dict[str, Any]:
     return {
         "seed_entities": seed_entities,
         "depth": depth,
+        "result_limit": result_limit,
         "nodes": nodes,
         "relationships": edges,
+        "truncated": bool(truncation.get("truncated")),
+        "truncation": dict(truncation),
     }
 
 

--- a/tests/unit/test_benchmark_generate.py
+++ b/tests/unit/test_benchmark_generate.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
@@ -17,6 +18,7 @@ from benchmarks.run_benchmark import (
     BenchmarkResult,
     benchmark_consistency_check,
     benchmark_gds_projection_create,
+    benchmark_read_api_queries,
     main,
     run_full_benchmark_suite,
     validate_benchmark_artifact,
@@ -199,6 +201,35 @@ def test_check_budgets_returns_true_only_when_all_budgeted_results_pass() -> Non
 
     assert check_budgets(passing_results, DEFAULT_BUDGETS) is True
     assert check_budgets(failing_results, DEFAULT_BUDGETS) is False
+
+
+def test_benchmark_read_api_queries_times_status_gated_read_apis() -> None:
+    client = MagicMock()
+
+    def execute_read(query: str, params: dict[str, Any] | None = None) -> list[dict[str, Any]]:
+        if "node_count" in query and "edge_count" in query:
+            return [{"node_count": 100, "edge_count": 200}]
+        return []
+
+    client.execute_read.side_effect = execute_read
+
+    results = benchmark_read_api_queries(
+        client,
+        "missing-entity",
+        graph_generation_id=7,
+        depth=2,
+        result_limit=5,
+    )
+
+    assert [result.operation for result in results] == [
+        "query_subgraph",
+        "query_propagation_paths",
+        "simulate_readonly_impact",
+    ]
+    assert all(result.node_count == 100 for result in results)
+    assert all(result.edge_count == 200 for result in results)
+    assert all(result.passed for result in results)
+    assert client.execute_write.call_args_list == []
 
 
 def test_write_benchmark_artifacts_records_json_and_text_report(tmp_path: Path) -> None:

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -22,9 +22,17 @@ _MUTATION_PATTERN = re.compile(r"\b(MERGE|SET|DELETE|CREATE)\b", re.IGNORECASE)
 
 
 class FakeQueryClient:
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        *,
+        nodes: list[dict[str, Any]] | None = None,
+        edges: list[dict[str, Any]] | None = None,
+    ) -> None:
+        self.nodes = _node_rows() if nodes is None else nodes
+        self.edges = _edge_rows() if edges is None else edges
         self.read_calls: list[tuple[str, dict[str, Any]]] = []
         self.write_calls: list[tuple[str, dict[str, Any]]] = []
+        self.expansion_row_counts: list[int] = []
 
     def execute_read(
         self,
@@ -34,12 +42,12 @@ class FakeQueryClient:
         call_parameters = parameters or {}
         self.read_calls.append((query, call_parameters))
         assert _MUTATION_PATTERN.search(query) is None
-        if "RETURN nodes, relationships" in query:
-            return [{"nodes": _node_rows(), "relationships": _edge_rows()}]
-        if " AS paths" in query:
-            if "RETURN [] AS paths" in query:
-                return [{"paths": []}]
-            return [{"paths": _path_rows(call_parameters.get("channels"))}]
+        assert "[*" not in query
+        assert "collect(path)" not in query
+        if "RETURN node_key," in query:
+            return self._seed_rows(call_parameters)
+        if "RETURN relationship_key," in query:
+            return self._frontier_rows(query, call_parameters)
         return []
 
     def execute_write(
@@ -49,6 +57,63 @@ class FakeQueryClient:
     ) -> list[dict[str, Any]]:
         self.write_calls.append((query, parameters or {}))
         raise AssertionError("query APIs must not call execute_write")
+
+    def _seed_rows(self, parameters: dict[str, Any]) -> list[dict[str, Any]]:
+        seed_entities = set(parameters.get("seed_entities", []))
+        rows: list[dict[str, Any]] = []
+        seen: set[str] = set()
+        for node in self.nodes:
+            node_key = _node_key(node)
+            if node_key in seen:
+                continue
+            if node.get("canonical_entity_id") in seed_entities or node.get("node_id") in seed_entities:
+                seen.add(node_key)
+                rows.append({"node_key": node_key, "node": node})
+        rows.sort(key=lambda row: str(row["node_key"]))
+        return rows[: int(parameters.get("per_depth_limit", len(rows)))]
+
+    def _frontier_rows(
+        self,
+        query: str,
+        parameters: dict[str, Any],
+    ) -> list[dict[str, Any]]:
+        frontier = set(parameters.get("frontier_node_keys", []))
+        visited_relationships = set(parameters.get("visited_relationship_keys", []))
+        nodes_by_id = {_node_key(node): node for node in self.nodes}
+        rows: list[dict[str, Any]] = []
+        for edge in self.edges:
+            edge_key = _edge_key(edge)
+            if edge_key in visited_relationships:
+                continue
+            source_key = str(edge["source_node_id"])
+            target_key = str(edge["target_node_id"])
+            if source_key not in frontier and target_key not in frontier:
+                continue
+            source = nodes_by_id[source_key]
+            target = nodes_by_id[target_key]
+            neighbor = target if source_key in frontier else source
+            row = {
+                "relationship_key": edge_key,
+                "source_key": source_key,
+                "target_key": target_key,
+                "neighbor_key": _node_key(neighbor),
+                "channel": _edge_channel(edge) if " AS channel" in query else None,
+                "source": source,
+                "target": target,
+                "neighbor": neighbor,
+                "relationship": edge,
+            }
+            rows.append(row)
+        rows.sort(
+            key=lambda row: (
+                str(row["relationship_key"]),
+                str(row["source_key"]),
+                str(row["target_key"]),
+            ),
+        )
+        limited_rows = rows[: int(parameters.get("per_depth_limit", len(rows)))]
+        self.expansion_row_counts.append(len(limited_rows))
+        return limited_rows
 
 
 class GateAwareClient(FakeQueryClient):
@@ -206,14 +271,24 @@ def test_query_subgraph_reads_inside_ready_gate_and_normalizes_result() -> None:
     assert events == ["enter", "exit"]
     assert result.graph_generation_id == 42
     assert result.status == "ready"
-    assert [node["node_id"] for node in result.subgraph_nodes] == ["node-a", "node-b"]
+    assert result.seed_entities == ["entity-b", "node-a"]
+    assert result.depth == 2
+    assert result.result_limit == 10
+    assert result.truncated is False
+    assert [node["node_id"] for node in result.subgraph_nodes] == [
+        "node-a",
+        "node-b",
+        "node-c",
+    ]
     assert result.subgraph_nodes[1]["properties"] == {"name": "Beta", "rank": 2}
     assert [edge["edge_id"] for edge in result.subgraph_edges] == ["edge-1", "edge-2"]
     assert result.subgraph_edges[0]["weight"] == 0.7
-    assert len(client.read_calls) == 1
-    query, parameters = client.read_calls[0]
-    assert "*0..2" in query
-    assert parameters == {"result_limit": 10, "seed_entities": ["entity-b", "node-a"]}
+    assert len(client.read_calls) == 3
+    assert all("[*" not in query for query, _ in client.read_calls)
+    assert client.read_calls[0][1] == {
+        "per_depth_limit": 11,
+        "seed_entities": ["entity-b", "node-a"],
+    }
 
 
 def test_query_subgraph_uses_generation_from_status_not_neo4j_rows() -> None:
@@ -312,13 +387,10 @@ def test_query_propagation_paths_filters_channels_and_normalizes_paths() -> None
         }
     ]
     query, parameters = client.read_calls[0]
-    assert "*1..2" in query
-    assert "propagation_channel" in query
-    assert parameters == {
-        "channels": ["event"],
-        "result_limit": 5,
-        "seed_entities": ["entity-a"],
-    }
+    assert "MATCH (seed)" in query
+    assert all("[*" not in read_query for read_query, _ in client.read_calls)
+    assert any("propagation_channel" in read_query for read_query, _ in client.read_calls)
+    assert parameters == {"per_depth_limit": 6, "seed_entities": ["entity-a"]}
 
 
 def test_query_propagation_paths_depth_zero_returns_empty_path_summary() -> None:
@@ -332,7 +404,52 @@ def test_query_propagation_paths_depth_zero_returns_empty_path_summary() -> None
     )
 
     assert paths == []
-    assert "*1.." not in client.read_calls[0][0]
+    assert client.read_calls == []
+
+
+def test_query_subgraph_caps_dense_cyclic_frontiers_and_reports_truncation() -> None:
+    nodes, edges = _dense_cyclic_graph(node_count=12)
+    client = FakeQueryClient(nodes=nodes, edges=edges)
+
+    result = query_subgraph(
+        ["dense-entity-0"],
+        4,
+        client=client,  # type: ignore[arg-type]
+        status_manager=_status_manager(),
+        result_limit=5,
+    )
+
+    assert result.truncated is True
+    assert result.truncation["frontier_limit_reached"] is True
+    assert 1 in result.truncation["truncated_depths"]
+    assert len(result.subgraph_nodes) <= 5
+    assert len(result.subgraph_edges) <= 5
+    returned_node_ids = {node["node_id"] for node in result.subgraph_nodes}
+    assert all(
+        edge["source_node_id"] in returned_node_ids and edge["target_node_id"] in returned_node_ids
+        for edge in result.subgraph_edges
+    )
+    assert max(client.expansion_row_counts) <= 6
+    assert all("[*" not in query and "collect(path)" not in query for query, _ in client.read_calls)
+
+
+def test_query_propagation_paths_caps_dense_cyclic_frontiers() -> None:
+    nodes, edges = _dense_cyclic_graph(node_count=12)
+    client = FakeQueryClient(nodes=nodes, edges=edges)
+
+    paths = query_propagation_paths(
+        ["dense-entity-0"],
+        4,
+        client=client,  # type: ignore[arg-type]
+        status_manager=_status_manager(),
+        result_limit=3,
+    )
+
+    assert len(paths) <= 3
+    assert paths.truncated is True  # type: ignore[attr-defined]
+    assert paths.truncation["frontier_limit_reached"] is True  # type: ignore[attr-defined]
+    assert max(client.expansion_row_counts) <= 4
+    assert all("[*" not in query and "collect(path)" not in query for query, _ in client.read_calls)
 
 
 def test_query_apis_do_not_call_execute_write() -> None:
@@ -383,6 +500,12 @@ def _node_rows() -> list[dict[str, Any]]:
                 "properties_json": '{"name": "Beta"}',
                 "rank": 2,
             },
+        },
+        {
+            "node_id": "node-c",
+            "canonical_entity_id": "entity-c",
+            "labels": ["Entity"],
+            "properties": {"name": "Gamma"},
         },
     ]
 
@@ -451,6 +574,59 @@ def _path_rows(channels: list[str] | None) -> list[dict[str, Any]]:
     if channels is None:
         return paths
     return [path for path in paths if path["channel"] in channels]
+
+
+def _dense_cyclic_graph(node_count: int) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    nodes = [
+        {
+            "node_id": f"dense-node-{index}",
+            "canonical_entity_id": f"dense-entity-{index}",
+            "labels": ["Entity"],
+            "properties": {"index": index},
+        }
+        for index in range(node_count)
+    ]
+    edges: list[dict[str, Any]] = []
+    for index in range(1, node_count):
+        edges.append(
+            {
+                "edge_id": f"dense-star-{index:02d}",
+                "source_node_id": "dense-node-0",
+                "target_node_id": f"dense-node-{index}",
+                "relationship_type": "SUPPLY_CHAIN",
+                "properties": {},
+                "weight": 1.0,
+            },
+        )
+    for index in range(node_count):
+        edges.append(
+            {
+                "edge_id": f"dense-cycle-{index:02d}",
+                "source_node_id": f"dense-node-{index}",
+                "target_node_id": f"dense-node-{(index + 1) % node_count}",
+                "relationship_type": "EVENT_IMPACT",
+                "properties": {"propagation_channel": "event"},
+                "weight": 0.5,
+            },
+        )
+    return nodes, edges
+
+
+def _node_key(node: dict[str, Any]) -> str:
+    return str(node["node_id"])
+
+
+def _edge_key(edge: dict[str, Any]) -> str:
+    return str(edge["edge_id"])
+
+
+def _edge_channel(edge: dict[str, Any]) -> str:
+    properties = edge.get("properties", {})
+    if properties.get("propagation_channel") is not None:
+        return str(properties["propagation_channel"])
+    if edge["relationship_type"] == "EVENT_IMPACT":
+        return "event"
+    return "fundamental"
 
 
 def _status_manager(

--- a/tests/unit/test_simulation.py
+++ b/tests/unit/test_simulation.py
@@ -47,10 +47,14 @@ class FakeSimulationClient:
         params = parameters or {}
         self.read_calls.append((query, params))
         assert _LIVE_MUTATION_PATTERN.search(query) is None
+        assert "[*" not in query
+        assert "collect(path)" not in query
         if self.missing_gds and "gds." in query:
             raise RuntimeError("There is no procedure with name `gds.graph.exists` registered")
-        if "RETURN nodes, relationships" in query:
-            return [{"nodes": self.nodes, "relationships": self.edges}]
+        if "RETURN node_key," in query:
+            return self._seed_rows(params)
+        if "RETURN relationship_key," in query:
+            return self._frontier_rows(params)
         if "gds.graph.exists" in query:
             return [{"exists": self.projections.get(str(params.get("graph_name")), False)}]
         if "gds.pageRank.stream" in query:
@@ -106,6 +110,58 @@ class FakeSimulationClient:
             }
             for edge in rows
         ]
+
+    def _seed_rows(self, params: dict[str, Any]) -> list[dict[str, Any]]:
+        seed_entities = set(params.get("seed_entities", []))
+        rows: list[dict[str, Any]] = []
+        seen: set[str] = set()
+        for node in self.nodes:
+            node_key = _node_key(node)
+            if node_key in seen:
+                continue
+            if node.get("canonical_entity_id") in seed_entities or node.get("node_id") in seed_entities:
+                seen.add(node_key)
+                rows.append({"node_key": node_key, "node": node})
+        rows.sort(key=lambda row: str(row["node_key"]))
+        return rows[: int(params.get("per_depth_limit", len(rows)))]
+
+    def _frontier_rows(self, params: dict[str, Any]) -> list[dict[str, Any]]:
+        frontier = set(params.get("frontier_node_keys", []))
+        visited_relationships = set(params.get("visited_relationship_keys", []))
+        nodes_by_id = {_node_key(node): node for node in self.nodes}
+        rows: list[dict[str, Any]] = []
+        for edge in self.edges:
+            edge_key = str(edge["edge_id"])
+            if edge_key in visited_relationships:
+                continue
+            source_key = str(edge["source_node_id"])
+            target_key = str(edge["target_node_id"])
+            if source_key not in frontier and target_key not in frontier:
+                continue
+            source = nodes_by_id[source_key]
+            target = nodes_by_id[target_key]
+            neighbor = target if source_key in frontier else source
+            rows.append(
+                {
+                    "relationship_key": edge_key,
+                    "source_key": source_key,
+                    "target_key": target_key,
+                    "neighbor_key": _node_key(neighbor),
+                    "channel": _edge_channel(edge),
+                    "source": source,
+                    "target": target,
+                    "neighbor": neighbor,
+                    "relationship": edge,
+                },
+            )
+        rows.sort(
+            key=lambda row: (
+                str(row["relationship_key"]),
+                str(row["source_key"]),
+                str(row["target_key"]),
+            ),
+        )
+        return rows[: int(params.get("per_depth_limit", len(rows)))]
 
     def _path_rows(
         self,
@@ -519,6 +575,45 @@ def test_readonly_projection_scopes_paths_to_seed_subgraph() -> None:
     assert project_parameters[0]["edge_ids"] == ["edge-fundamental"]
 
 
+def test_readonly_simulation_uses_bounded_subgraph_traversal_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    nodes, edges = _dense_cyclic_graph(node_count=12)
+    client = FakeSimulationClient(nodes=nodes, edges=edges)
+
+    def run_scoped(
+        request: ReadonlySimulationRequest,
+        *,
+        projection_name: str,
+        client: Any,
+        ready_status: Neo4jGraphStatus,
+    ) -> PropagationResult:
+        return PropagationResult(
+            cycle_id=request.cycle_id,
+            graph_generation_id=ready_status.graph_generation_id,
+            activated_paths=[],
+            impacted_entities=[],
+            channel_breakdown={"fundamental": {"path_count": 0}},
+        )
+
+    monkeypatch.setattr(simulation_module, "_run_scoped_propagation", run_scoped)
+
+    result = simulate_readonly_impact(
+        ["dense-entity-0"],
+        _request(result_limit=5),
+        client=client,  # type: ignore[arg-type]
+        status_manager=_status_manager(),
+    )
+
+    assert result["result_limit"] == 5
+    assert result["truncated"] is True
+    assert result["truncation"]["frontier_limit_reached"] is True
+    assert result["subgraph"]["truncated"] is True
+    assert len(result["subgraph"]["nodes"]) <= 5
+    assert len(result["subgraph"]["relationships"]) <= 5
+    assert all("[*" not in query and "collect(path)" not in query for query, _ in client.read_calls)
+
+
 def test_reflexive_tagged_ownership_is_not_counted_as_fundamental() -> None:
     client = FakeSimulationClient()
 
@@ -592,6 +687,42 @@ def _edges() -> list[dict[str, Any]]:
     ]
 
 
+def _dense_cyclic_graph(node_count: int) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    nodes = [
+        {
+            "node_id": f"dense-node-{index}",
+            "canonical_entity_id": f"dense-entity-{index}",
+            "labels": ["Entity"],
+            "properties": {"index": index},
+        }
+        for index in range(node_count)
+    ]
+    edges: list[dict[str, Any]] = []
+    for index in range(1, node_count):
+        edges.append(
+            {
+                "edge_id": f"dense-star-{index:02d}",
+                "source_node_id": "dense-node-0",
+                "target_node_id": f"dense-node-{index}",
+                "relationship_type": "SUPPLY_CHAIN",
+                "properties": {},
+                "weight": 1.0,
+            },
+        )
+    for index in range(node_count):
+        edges.append(
+            {
+                "edge_id": f"dense-cycle-{index:02d}",
+                "source_node_id": f"dense-node-{index}",
+                "target_node_id": f"dense-node-{(index + 1) % node_count}",
+                "relationship_type": "EVENT_IMPACT",
+                "properties": {"propagation_channel": "event"},
+                "weight": 0.5,
+            },
+        )
+    return nodes, edges
+
+
 def _request(
     *,
     graph_generation_id: int = 1,
@@ -651,6 +782,10 @@ def _ready_status(
         last_reload_at=None,
         writer_lock_token=writer_lock_token,
     )
+
+
+def _node_key(node: dict[str, Any]) -> str:
+    return str(node["node_id"])
 
 
 def _edge_channel(edge: dict[str, Any]) -> str:


### PR DESCRIPTION
Closes #44

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `benchmarks/artifacts/lite_target_100k_800k.json`, `benchmarks/generate_synthetic.py`, `benchmarks/run_benchmark.py`, `cross-cutting`, `examples/consumer_stream_layer.py`, `graph_engine/__pycache__/__init__.cpython-314.pyc`, `graph_engine/live_metrics.py`, `graph_engine/propagation/pipeline.py`, `graph_engine/query/service.py`, `graph_engine/query/simulation.py`


---
## 背景与目标
Milestone review for milestone-4 发现阻塞性问题，必须在进入下一阶段前修复。

## 问题描述
The subgraph query, propagation-path query, and readonly simulation all rely on variable-length path expansion that materializes paths before applying result limits. In `_subgraph_query`, Neo4j expands `[*0..depth]` and collects paths before node and relationship limits are applied; `_path_query` does the same for `[*1..depth]`. Because `simulate_readonly_impact` calls `_read_subgraph`, the same behavior affects the supposedly bounded local simulation. On dense or cyclic live graphs, this can enumerate a very large number of paths even with depth 4 or 6, causing query timeouts or heap pressure before the API can return a limited result.

## 实现范围
- 修改文件: `cross-cutting`
- Replace path-collection queries with a bounded traversal strategy that limits during expansion: iterative depth-by-depth frontier reads, uniqueness constraints for nodes/relationships, per-depth caps, and explicit truncation metadata. Add dense/cyclic graph tests and a benchmark for query_subgraph, query_propagation_paths, and simulate_readonly_impact.

## 验收标准
- [ ] 原始 P0 问题已修复
- [ ] 新增回归测试覆盖该场景
- [ ] 构建通过

## 验证命令
```bash
/Users/fanjie/Desktop/Cowork/project-ult/graph-engine/.venv/bin/python -m pytest
```
