### PR TITLE
feat(#46): `graph-engine` 的 graph delta / snapshot / impact snapshot 仍由本地模型定义，存在与 `contracts` 漂移的风险

### DIFF
--- a/graph_engine/live_metrics.py
+++ b/graph_engine/live_metrics.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 from collections.abc import Mapping
+from dataclasses import dataclass
 from typing import Any
 
 from graph_engine.client import Neo4jClient
@@ -46,12 +47,35 @@ RETURN node_count, edge_count, label_counts, nodes, relationships
 """
 
 
+@dataclass(frozen=True)
+class LiveGraphMetrics:
+    """Validated live graph metrics and structural payloads."""
+
+    node_count: int
+    edge_count: int
+    key_label_counts: dict[str, int]
+    checksum: str
+    nodes: list[dict[str, Any]]
+    relationships: list[dict[str, Any]]
+
+
 def read_live_graph_metrics(
     client: Neo4jClient,
     *,
     strict: bool = True,
 ) -> tuple[int, int, dict[str, int], str]:
     """Read node/edge counts, label counts, and structural checksum."""
+
+    metrics = read_live_graph_metric_payload(client, strict=strict)
+    return metrics.node_count, metrics.edge_count, metrics.key_label_counts, metrics.checksum
+
+
+def read_live_graph_metric_payload(
+    client: Neo4jClient,
+    *,
+    strict: bool = True,
+) -> LiveGraphMetrics:
+    """Read live graph metrics with the normalized structural payload."""
 
     rows = client.execute_read(LIVE_GRAPH_METRICS_QUERY)
     if strict:
@@ -77,7 +101,14 @@ def read_live_graph_metrics(
         "nodes": sorted_payload_list(nodes),
         "relationships": sorted_payload_list(relationships),
     }
-    return node_count, edge_count, key_label_counts, checksum_payload(payload)
+    return LiveGraphMetrics(
+        node_count=node_count,
+        edge_count=edge_count,
+        key_label_counts=key_label_counts,
+        checksum=checksum_payload(payload),
+        nodes=[dict(node) for node in nodes],
+        relationships=[dict(relationship) for relationship in relationships],
+    )
 
 
 def sorted_payload_list(values: list[Any]) -> list[Any]:

--- a/graph_engine/models.py
+++ b/graph_engine/models.py
@@ -6,7 +6,31 @@ import math
 from datetime import datetime
 from typing import Any, Literal, Self, get_args
 
+from contracts.schemas import (
+    CandidateGraphDelta,
+    GraphImpactSnapshot,
+    GraphSnapshot,
+)
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+__all__ = [
+    "CandidateGraphDelta",
+    "ColdReloadPlan",
+    "FrozenGraphDelta",
+    "GraphAssertionRecord",
+    "GraphEdgeRecord",
+    "GraphImpactSnapshot",
+    "GraphMetricsSnapshot",
+    "GraphNodeRecord",
+    "GraphQueryResult",
+    "GraphSnapshot",
+    "Neo4jGraphStatus",
+    "PropagationChannel",
+    "PropagationContext",
+    "PropagationResult",
+    "PromotionPlan",
+    "ReadonlySimulationRequest",
+]
 
 PropagationChannel = Literal["fundamental", "event", "reflexive"]
 _ALLOWED_PROPAGATION_CHANNELS: frozenset[str] = frozenset(get_args(PropagationChannel))
@@ -54,8 +78,8 @@ class GraphAssertionRecord(BaseModel):
     created_at: datetime
 
 
-class CandidateGraphDelta(BaseModel):
-    """Validated or frozen candidate change waiting for graph promotion."""
+class FrozenGraphDelta(BaseModel):
+    """Internal frozen candidate change waiting for graph promotion."""
 
     model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
 
@@ -222,8 +246,8 @@ class GraphQueryResult(BaseModel):
     truncation: dict[str, Any] = Field(default_factory=dict)
 
 
-class GraphSnapshot(BaseModel):
-    """Structural snapshot of the promoted graph for a cycle."""
+class GraphMetricsSnapshot(BaseModel):
+    """Internal structural metrics used for status and consistency checks."""
 
     model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
 
@@ -244,25 +268,12 @@ class ColdReloadPlan(BaseModel):
 
     snapshot_ref: str = Field(min_length=1)
     cycle_id: str = Field(min_length=1)
-    expected_snapshot: GraphSnapshot
+    expected_snapshot: GraphMetricsSnapshot
     node_records: list[GraphNodeRecord]
     edge_records: list[GraphEdgeRecord]
     assertion_records: list[GraphAssertionRecord]
     projection_name: str = Field(min_length=1)
     created_at: datetime
-
-
-class GraphImpactSnapshot(BaseModel):
-    """Propagation impact snapshot emitted for downstream read-only consumers."""
-
-    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
-
-    cycle_id: str = Field(min_length=1)
-    impact_snapshot_id: str = Field(min_length=1)
-    regime_context_ref: str = Field(min_length=1)
-    activated_paths: list[dict[str, Any]]
-    impacted_entities: list[dict[str, Any]]
-    channel_breakdown: dict[str, Any]
 
 
 class Neo4jGraphStatus(BaseModel):

--- a/graph_engine/promotion/interfaces.py
+++ b/graph_engine/promotion/interfaces.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Protocol
 
-from graph_engine.models import CandidateGraphDelta, PromotionPlan
+from graph_engine.models import FrozenGraphDelta, PromotionPlan
 
 
 class CandidateDeltaReader(Protocol):
@@ -14,7 +14,7 @@ class CandidateDeltaReader(Protocol):
         self,
         cycle_id: str,
         selection_ref: str,
-    ) -> list[CandidateGraphDelta]:
+    ) -> list[FrozenGraphDelta]:
         """Return candidate graph deltas selected for promotion."""
 
 

--- a/graph_engine/promotion/planner.py
+++ b/graph_engine/promotion/planner.py
@@ -7,7 +7,7 @@ from datetime import datetime, timezone
 from typing import Any
 
 from graph_engine.models import (
-    CandidateGraphDelta,
+    FrozenGraphDelta,
     GraphAssertionRecord,
     GraphEdgeRecord,
     GraphNodeRecord,
@@ -27,7 +27,7 @@ _VALID_RELATIONSHIP_TYPES = {relationship.value for relationship in Relationship
 
 
 def validate_entity_anchors(
-    deltas: Sequence[CandidateGraphDelta],
+    deltas: Sequence[FrozenGraphDelta],
     entity_reader: EntityAnchorReader,
 ) -> None:
     """Fail if any source entity ids referenced by deltas are missing."""
@@ -48,7 +48,7 @@ def validate_entity_anchors(
 def build_promotion_plan(
     cycle_id: str,
     selection_ref: str,
-    deltas: Sequence[CandidateGraphDelta],
+    deltas: Sequence[FrozenGraphDelta],
 ) -> PromotionPlan:
     """Parse frozen candidate deltas into a stable promotion plan."""
 
@@ -79,7 +79,7 @@ def build_promotion_plan(
     )
 
 
-def _validate_delta_header(delta: CandidateGraphDelta, cycle_id: str) -> None:
+def _validate_delta_header(delta: FrozenGraphDelta, cycle_id: str) -> None:
     if delta.cycle_id != cycle_id:
         raise ValueError(
             f"delta {delta.delta_id} belongs to cycle {delta.cycle_id!r}, "
@@ -89,7 +89,7 @@ def _validate_delta_header(delta: CandidateGraphDelta, cycle_id: str) -> None:
         raise ValueError(f"delta {delta.delta_id} is not frozen")
 
 
-def _parse_node_record(delta: CandidateGraphDelta) -> GraphNodeRecord:
+def _parse_node_record(delta: FrozenGraphDelta) -> GraphNodeRecord:
     payload = _required_payload_section(delta, "node")
     node_record = GraphNodeRecord.model_validate(payload)
     if node_record.label not in _VALID_NODE_LABELS:
@@ -99,7 +99,7 @@ def _parse_node_record(delta: CandidateGraphDelta) -> GraphNodeRecord:
     return node_record
 
 
-def _parse_edge_record(delta: CandidateGraphDelta) -> GraphEdgeRecord:
+def _parse_edge_record(delta: FrozenGraphDelta) -> GraphEdgeRecord:
     payload = _required_payload_section(delta, "edge")
     edge_record = GraphEdgeRecord.model_validate(payload)
     if edge_record.relationship_type not in _VALID_RELATIONSHIP_TYPES:
@@ -111,14 +111,14 @@ def _parse_edge_record(delta: CandidateGraphDelta) -> GraphEdgeRecord:
     return edge_record
 
 
-def _parse_assertion_record(delta: CandidateGraphDelta) -> GraphAssertionRecord:
+def _parse_assertion_record(delta: FrozenGraphDelta) -> GraphAssertionRecord:
     return GraphAssertionRecord.model_validate(
         _required_payload_section(delta, "assertion"),
     )
 
 
 def _required_payload_section(
-    delta: CandidateGraphDelta,
+    delta: FrozenGraphDelta,
     key: str,
 ) -> Mapping[str, Any]:
     payload_section = delta.payload.get(key)

--- a/graph_engine/propagation/event.py
+++ b/graph_engine/propagation/event.py
@@ -207,6 +207,10 @@ RETURN source.node_id AS source_node_id,
        labels(target) AS target_labels,
        relationship.edge_id AS edge_id,
        type(relationship) AS relationship_type,
+       relationship.evidence_refs AS evidence_refs,
+       relationship.evidence_ref AS evidence_ref,
+       source.canonical_id_rule_version AS source_canonical_id_rule_version,
+       target.canonical_id_rule_version AS target_canonical_id_rule_version,
        relation_weight,
        evidence_confidence,
        recency_decay,
@@ -267,6 +271,9 @@ def _activated_path(
         "target_labels": _string_list(row.get("target_labels")),
         "edge_id": row.get("edge_id"),
         "relationship_type": row.get("relationship_type"),
+        "evidence_refs": _evidence_refs_from_row(row),
+        "source_canonical_id_rule_version": row.get("source_canonical_id_rule_version"),
+        "target_canonical_id_rule_version": row.get("target_canonical_id_rule_version"),
         "score": explanation["score"],
         "explanation": explanation,
     }
@@ -345,3 +352,18 @@ def _string_list(value: Any) -> list[str]:
     if not isinstance(value, list):
         return []
     return sorted(str(item) for item in value)
+
+
+def _evidence_refs_from_row(row: dict[str, Any]) -> list[str]:
+    refs: set[str] = set()
+    refs.update(_evidence_refs_from_value(row.get("evidence_refs")))
+    refs.update(_evidence_refs_from_value(row.get("evidence_ref")))
+    return sorted(refs)
+
+
+def _evidence_refs_from_value(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, (list, tuple, set)):
+        return sorted(str(item) for item in value if str(item))
+    return [str(value)] if str(value) else []

--- a/graph_engine/propagation/fundamental.py
+++ b/graph_engine/propagation/fundamental.py
@@ -215,6 +215,10 @@ RETURN source.node_id AS source_node_id,
        labels(target) AS target_labels,
        relationship.edge_id AS edge_id,
        type(relationship) AS relationship_type,
+       relationship.evidence_refs AS evidence_refs,
+       relationship.evidence_ref AS evidence_ref,
+       source.canonical_id_rule_version AS source_canonical_id_rule_version,
+       target.canonical_id_rule_version AS target_canonical_id_rule_version,
        relation_weight,
        evidence_confidence,
        recency_decay,
@@ -275,6 +279,9 @@ def _activated_path(
         "target_labels": _string_list(row.get("target_labels")),
         "edge_id": row.get("edge_id"),
         "relationship_type": row.get("relationship_type"),
+        "evidence_refs": _evidence_refs_from_row(row),
+        "source_canonical_id_rule_version": row.get("source_canonical_id_rule_version"),
+        "target_canonical_id_rule_version": row.get("target_canonical_id_rule_version"),
         "score": explanation["score"],
         "explanation": explanation,
     }
@@ -353,3 +360,18 @@ def _string_list(value: Any) -> list[str]:
     if not isinstance(value, list):
         return []
     return sorted(str(item) for item in value)
+
+
+def _evidence_refs_from_row(row: dict[str, Any]) -> list[str]:
+    refs: set[str] = set()
+    refs.update(_evidence_refs_from_value(row.get("evidence_refs")))
+    refs.update(_evidence_refs_from_value(row.get("evidence_ref")))
+    return sorted(refs)
+
+
+def _evidence_refs_from_value(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, (list, tuple, set)):
+        return sorted(str(item) for item in value if str(item))
+    return [str(value)] if str(value) else []

--- a/graph_engine/propagation/reflexive.py
+++ b/graph_engine/propagation/reflexive.py
@@ -204,6 +204,10 @@ RETURN source.node_id AS source_node_id,
        labels(target) AS target_labels,
        relationship.edge_id AS edge_id,
        type(relationship) AS relationship_type,
+       relationship.evidence_refs AS evidence_refs,
+       relationship.evidence_ref AS evidence_ref,
+       source.canonical_id_rule_version AS source_canonical_id_rule_version,
+       target.canonical_id_rule_version AS target_canonical_id_rule_version,
        relation_weight,
        evidence_confidence,
        recency_decay,
@@ -264,6 +268,9 @@ def _activated_path(
         "target_labels": _string_list(row.get("target_labels")),
         "edge_id": row.get("edge_id"),
         "relationship_type": row.get("relationship_type"),
+        "evidence_refs": _evidence_refs_from_row(row),
+        "source_canonical_id_rule_version": row.get("source_canonical_id_rule_version"),
+        "target_canonical_id_rule_version": row.get("target_canonical_id_rule_version"),
         "score": explanation["score"],
         "explanation": explanation,
     }
@@ -342,3 +349,18 @@ def _string_list(value: Any) -> list[str]:
     if not isinstance(value, list):
         return []
     return sorted(str(item) for item in value)
+
+
+def _evidence_refs_from_row(row: dict[str, Any]) -> list[str]:
+    refs: set[str] = set()
+    refs.update(_evidence_refs_from_value(row.get("evidence_refs")))
+    refs.update(_evidence_refs_from_value(row.get("evidence_ref")))
+    return sorted(refs)
+
+
+def _evidence_refs_from_value(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, (list, tuple, set)):
+        return sorted(str(item) for item in value if str(item))
+    return [str(value)] if str(value) else []

--- a/graph_engine/reload/service.py
+++ b/graph_engine/reload/service.py
@@ -9,7 +9,7 @@ from time import monotonic
 from typing import TypeVar
 
 from graph_engine.client import Neo4jClient
-from graph_engine.models import ColdReloadPlan, GraphSnapshot, Neo4jGraphStatus, PromotionPlan
+from graph_engine.models import ColdReloadPlan, GraphMetricsSnapshot, Neo4jGraphStatus, PromotionPlan
 from graph_engine.reload.interfaces import CanonicalReader
 from graph_engine.reload.projection import rebuild_gds_projection
 from graph_engine.schema.manager import DROP_ALL_CONFIRMATION_TOKEN, SchemaManager
@@ -144,10 +144,10 @@ def build_reload_promotion_plan(
 
 
 class _ExpectedSnapshotReader:
-    def __init__(self, snapshot: GraphSnapshot) -> None:
+    def __init__(self, snapshot: GraphMetricsSnapshot) -> None:
         self._snapshot = snapshot
 
-    def read_graph_snapshot(self, snapshot_ref: str) -> GraphSnapshot:
+    def read_graph_snapshot(self, snapshot_ref: str) -> GraphMetricsSnapshot:
         return self._snapshot
 
 

--- a/graph_engine/snapshots/generator.py
+++ b/graph_engine/snapshots/generator.py
@@ -6,9 +6,15 @@ from collections.abc import Sequence
 from datetime import datetime, timezone
 from typing import Any
 
+from contracts.core import Direction, __version__ as CONTRACT_VERSION
+from contracts.schemas import EntityReference
+from contracts.schemas.graph import GraphEdge, GraphNode
+
 from graph_engine.client import Neo4jClient
 from graph_engine.live_metrics import (
+    LiveGraphMetrics,
     checksum_payload as _checksum_payload,
+    read_live_graph_metric_payload,
     read_live_graph_metrics,
 )
 from graph_engine.models import (
@@ -41,14 +47,11 @@ def build_graph_snapshot(
 
     with hold_ready_read(status_manager, "graph snapshot generation") as ready_status:
         _validate_generation_input(graph_generation_id, ready_status)
-        node_count, edge_count, key_label_counts, checksum = _read_graph_metrics(client)
+        metrics = _read_graph_metric_payload(client)
         return _graph_snapshot_from_metrics(
             cycle_id,
             graph_generation_id,
-            node_count=node_count,
-            edge_count=edge_count,
-            key_label_counts=key_label_counts,
-            checksum=checksum,
+            metrics=metrics,
         )
 
 
@@ -69,13 +72,29 @@ def build_graph_impact_snapshot(
         "channel_breakdown": channel_breakdown,
     }
     impact_hash = _checksum_payload(payload)
+    affected_entities = _entity_references_from_impacted_entities(
+        propagation_result.impacted_entities,
+    )
+    target_entities = affected_entities or _entity_references_from_paths(
+        propagation_result.activated_paths,
+    )
+    evidence_refs = _evidence_refs_from_paths(propagation_result.activated_paths)
+    if not target_entities:
+        raise ValueError("GraphImpactSnapshot requires at least one target entity")
+    if not evidence_refs:
+        raise ValueError("GraphImpactSnapshot requires at least one evidence reference")
+
     return GraphImpactSnapshot(
         cycle_id=cycle_id,
         impact_snapshot_id=f"graph-impact-{cycle_id}-{impact_hash[:12]}",
-        regime_context_ref=world_state_ref,
-        activated_paths=propagation_result.activated_paths,
-        impacted_entities=propagation_result.impacted_entities,
-        channel_breakdown=channel_breakdown,
+        version=CONTRACT_VERSION,
+        created_at=datetime.now(timezone.utc),
+        target_entities=target_entities,
+        affected_entities=affected_entities,
+        affected_sectors=_affected_sectors(propagation_result.impacted_entities),
+        direction=_impact_direction(propagation_result.impacted_entities),
+        impact_score=_impact_score(propagation_result.impacted_entities),
+        evidence_refs=evidence_refs,
     )
 
 
@@ -126,13 +145,6 @@ def compute_graph_snapshots(
             ready_status.graph_generation_id,
             client,
             status_manager=status_manager,
-        )
-        _validate_status_metrics(
-            ready_status,
-            node_count=graph_snapshot.node_count,
-            edge_count=graph_snapshot.edge_count,
-            key_label_counts=graph_snapshot.key_label_counts,
-            checksum=graph_snapshot.checksum,
         )
         impact_snapshot = build_graph_impact_snapshot(
             cycle_id,
@@ -277,22 +289,154 @@ def _graph_snapshot_from_metrics(
     cycle_id: str,
     graph_generation_id: int,
     *,
-    node_count: int,
-    edge_count: int,
-    key_label_counts: dict[str, int],
-    checksum: str,
+    metrics: LiveGraphMetrics,
 ) -> GraphSnapshot:
+    checksum = metrics.checksum
     return GraphSnapshot(
         cycle_id=cycle_id,
-        snapshot_id=f"graph-snapshot-{cycle_id}-{graph_generation_id}-{checksum[:12]}",
-        graph_generation_id=graph_generation_id,
-        node_count=node_count,
-        edge_count=edge_count,
-        key_label_counts=key_label_counts,
-        checksum=checksum,
+        graph_snapshot_id=f"graph-snapshot-{cycle_id}-{graph_generation_id}-{checksum[:12]}",
+        version=CONTRACT_VERSION,
+        node_count=metrics.node_count,
+        edge_count=metrics.edge_count,
+        nodes=[_contract_node(node) for node in metrics.nodes],
+        edges=[_contract_edge(relationship) for relationship in metrics.relationships],
         created_at=datetime.now(timezone.utc),
     )
 
 
 def _read_graph_metrics(client: Neo4jClient) -> tuple[int, int, dict[str, int], str]:
     return read_live_graph_metrics(client, strict=True)
+
+
+def _read_graph_metric_payload(client: Neo4jClient) -> LiveGraphMetrics:
+    return read_live_graph_metric_payload(client, strict=True)
+
+
+def _contract_node(node: dict[str, Any]) -> GraphNode:
+    labels = _string_values(node.get("labels")) or ["Entity"]
+    properties = _dict_value(node.get("properties"))
+    entity = _entity_reference(
+        entity_id=node.get("canonical_entity_id") or properties.get("canonical_entity_id"),
+        labels=labels,
+    )
+    return GraphNode(
+        node_id=str(node.get("node_id") or properties.get("node_id") or ""),
+        labels=labels,
+        properties=properties,
+        entity=entity,
+    )
+
+
+def _contract_edge(relationship: dict[str, Any]) -> GraphEdge:
+    properties = _dict_value(relationship.get("properties"))
+    return GraphEdge(
+        edge_id=str(relationship.get("edge_id") or properties.get("edge_id") or ""),
+        source_node=str(relationship.get("source_node_id") or ""),
+        target_node=str(relationship.get("target_node_id") or ""),
+        relation_type=str(relationship.get("relationship_type") or ""),
+        properties=properties,
+        evidence_refs=_evidence_refs_from_value(properties.get("evidence_refs")),
+    )
+
+
+def _entity_references_from_impacted_entities(
+    impacted_entities: list[dict[str, Any]],
+) -> list[EntityReference]:
+    references: list[EntityReference] = []
+    seen: set[str] = set()
+    for entity in impacted_entities:
+        reference = _entity_reference(
+            entity_id=entity.get("canonical_entity_id") or entity.get("node_id"),
+            labels=entity.get("labels"),
+        )
+        if reference is None or reference.entity_id in seen:
+            continue
+        references.append(reference)
+        seen.add(reference.entity_id)
+    return references
+
+
+def _entity_references_from_paths(activated_paths: list[dict[str, Any]]) -> list[EntityReference]:
+    references: list[EntityReference] = []
+    seen: set[str] = set()
+    for path in activated_paths:
+        for entity_id, labels in (
+            (path.get("source_entity_id") or path.get("source_node_id"), path.get("source_labels")),
+            (path.get("target_entity_id") or path.get("target_node_id"), path.get("target_labels")),
+        ):
+            reference = _entity_reference(entity_id=entity_id, labels=labels)
+            if reference is None or reference.entity_id in seen:
+                continue
+            references.append(reference)
+            seen.add(reference.entity_id)
+    return references
+
+
+def _entity_reference(entity_id: Any, labels: Any) -> EntityReference | None:
+    if entity_id is None or str(entity_id) == "":
+        return None
+    entity_type = (_string_values(labels) or ["unknown"])[0].lower()
+    return EntityReference(
+        entity_id=str(entity_id),
+        entity_type=entity_type,
+        canonical_id_rule_version=CONTRACT_VERSION,
+    )
+
+
+def _affected_sectors(impacted_entities: list[dict[str, Any]]) -> list[str]:
+    sectors = {
+        str(entity.get("node_id"))
+        for entity in impacted_entities
+        if "Sector" in _string_values(entity.get("labels")) and entity.get("node_id") is not None
+    }
+    return sorted(sectors)
+
+
+def _impact_direction(impacted_entities: list[dict[str, Any]]) -> Direction:
+    total_score = sum(_float_value(entity.get("score")) for entity in impacted_entities)
+    if total_score > 0:
+        return Direction.BULLISH
+    if total_score < 0:
+        return Direction.BEARISH
+    return Direction.NEUTRAL
+
+
+def _impact_score(impacted_entities: list[dict[str, Any]]) -> float:
+    total_score = sum(_float_value(entity.get("score")) for entity in impacted_entities)
+    return max(-1.0, min(1.0, total_score))
+
+
+def _evidence_refs_from_paths(activated_paths: list[dict[str, Any]]) -> list[str]:
+    refs: set[str] = set()
+    for path in activated_paths:
+        refs.update(_evidence_refs_from_value(path.get("evidence_refs")))
+        refs.update(_evidence_refs_from_value(path.get("evidence_ref")))
+        if path.get("edge_id") is not None:
+            refs.add(str(path["edge_id"]))
+    return sorted(refs)
+
+
+def _evidence_refs_from_value(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, (list, tuple, set)):
+        return sorted(str(item) for item in value if str(item))
+    return [str(value)] if str(value) else []
+
+
+def _dict_value(value: Any) -> dict[str, Any]:
+    return dict(value) if isinstance(value, dict) else {}
+
+
+def _string_values(value: Any) -> list[str]:
+    if isinstance(value, (list, tuple, set)):
+        return sorted(str(item) for item in value if str(item))
+    if value is None:
+        return []
+    return [str(value)] if str(value) else []
+
+
+def _float_value(value: Any) -> float:
+    if value is None:
+        return 0.0
+    return float(value)

--- a/graph_engine/snapshots/generator.py
+++ b/graph_engine/snapshots/generator.py
@@ -34,6 +34,8 @@ _DEFAULT_SNAPSHOT_CHANNELS: tuple[PropagationChannel, ...] = (
     "event",
     "reflexive",
 )
+# Used only when the canonical record did not carry the entity-registry rule version.
+_UNKNOWN_CANONICAL_ID_RULE_VERSION = "unknown"
 
 
 def build_graph_snapshot(
@@ -78,11 +80,32 @@ def build_graph_impact_snapshot(
     target_entities = affected_entities or _entity_references_from_paths(
         propagation_result.activated_paths,
     )
-    evidence_refs = _evidence_refs_from_paths(propagation_result.activated_paths)
+    evidence_refs, paths_without_evidence = _evidence_refs_from_paths(
+        propagation_result.activated_paths,
+    )
     if not target_entities:
-        raise ValueError("GraphImpactSnapshot requires at least one target entity")
+        raise ValueError(
+            "GraphImpactSnapshot requires at least one target entity "
+            f"for cycle_id={cycle_id!r}, world_state_ref={world_state_ref!r}, "
+            "graph_generation_id="
+            f"{propagation_result.graph_generation_id!r}",
+        )
+    if paths_without_evidence:
+        raise ValueError(
+            "GraphImpactSnapshot requires real evidence references for every "
+            "activated path "
+            f"for cycle_id={cycle_id!r}, world_state_ref={world_state_ref!r}, "
+            "graph_generation_id="
+            f"{propagation_result.graph_generation_id!r}; "
+            f"paths_without_evidence={paths_without_evidence}",
+        )
     if not evidence_refs:
-        raise ValueError("GraphImpactSnapshot requires at least one evidence reference")
+        raise ValueError(
+            "GraphImpactSnapshot requires at least one real evidence reference "
+            f"for cycle_id={cycle_id!r}, world_state_ref={world_state_ref!r}, "
+            "graph_generation_id="
+            f"{propagation_result.graph_generation_id!r}",
+        )
 
     return GraphImpactSnapshot(
         cycle_id=cycle_id,
@@ -318,6 +341,10 @@ def _contract_node(node: dict[str, Any]) -> GraphNode:
     entity = _entity_reference(
         entity_id=node.get("canonical_entity_id") or properties.get("canonical_entity_id"),
         labels=labels,
+        canonical_id_rule_version=(
+            node.get("canonical_id_rule_version")
+            or properties.get("canonical_id_rule_version")
+        ),
     )
     return GraphNode(
         node_id=str(node.get("node_id") or properties.get("node_id") or ""),
@@ -335,7 +362,7 @@ def _contract_edge(relationship: dict[str, Any]) -> GraphEdge:
         target_node=str(relationship.get("target_node_id") or ""),
         relation_type=str(relationship.get("relationship_type") or ""),
         properties=properties,
-        evidence_refs=_evidence_refs_from_value(properties.get("evidence_refs")),
+        evidence_refs=_evidence_refs_from_properties(properties),
     )
 
 
@@ -348,6 +375,7 @@ def _entity_references_from_impacted_entities(
         reference = _entity_reference(
             entity_id=entity.get("canonical_entity_id") or entity.get("node_id"),
             labels=entity.get("labels"),
+            canonical_id_rule_version=entity.get("canonical_id_rule_version"),
         )
         if reference is None or reference.entity_id in seen:
             continue
@@ -360,11 +388,23 @@ def _entity_references_from_paths(activated_paths: list[dict[str, Any]]) -> list
     references: list[EntityReference] = []
     seen: set[str] = set()
     for path in activated_paths:
-        for entity_id, labels in (
-            (path.get("source_entity_id") or path.get("source_node_id"), path.get("source_labels")),
-            (path.get("target_entity_id") or path.get("target_node_id"), path.get("target_labels")),
+        for entity_id, labels, canonical_id_rule_version in (
+            (
+                path.get("source_entity_id") or path.get("source_node_id"),
+                path.get("source_labels"),
+                path.get("source_canonical_id_rule_version"),
+            ),
+            (
+                path.get("target_entity_id") or path.get("target_node_id"),
+                path.get("target_labels"),
+                path.get("target_canonical_id_rule_version"),
+            ),
         ):
-            reference = _entity_reference(entity_id=entity_id, labels=labels)
+            reference = _entity_reference(
+                entity_id=entity_id,
+                labels=labels,
+                canonical_id_rule_version=canonical_id_rule_version,
+            )
             if reference is None or reference.entity_id in seen:
                 continue
             references.append(reference)
@@ -372,14 +412,23 @@ def _entity_references_from_paths(activated_paths: list[dict[str, Any]]) -> list
     return references
 
 
-def _entity_reference(entity_id: Any, labels: Any) -> EntityReference | None:
+def _entity_reference(
+    entity_id: Any,
+    labels: Any,
+    *,
+    canonical_id_rule_version: Any = None,
+) -> EntityReference | None:
     if entity_id is None or str(entity_id) == "":
         return None
     entity_type = (_string_values(labels) or ["unknown"])[0].lower()
     return EntityReference(
         entity_id=str(entity_id),
         entity_type=entity_type,
-        canonical_id_rule_version=CONTRACT_VERSION,
+        canonical_id_rule_version=(
+            str(canonical_id_rule_version)
+            if canonical_id_rule_version is not None and str(canonical_id_rule_version)
+            else _UNKNOWN_CANONICAL_ID_RULE_VERSION
+        ),
     )
 
 
@@ -406,14 +455,29 @@ def _impact_score(impacted_entities: list[dict[str, Any]]) -> float:
     return max(-1.0, min(1.0, total_score))
 
 
-def _evidence_refs_from_paths(activated_paths: list[dict[str, Any]]) -> list[str]:
+def _evidence_refs_from_paths(
+    activated_paths: list[dict[str, Any]],
+) -> tuple[list[str], list[str]]:
     refs: set[str] = set()
+    paths_without_evidence: list[str] = []
     for path in activated_paths:
-        refs.update(_evidence_refs_from_value(path.get("evidence_refs")))
-        refs.update(_evidence_refs_from_value(path.get("evidence_ref")))
-        if path.get("edge_id") is not None:
-            refs.add(str(path["edge_id"]))
-    return sorted(refs)
+        path_refs = set(_evidence_refs_from_value(path.get("evidence_refs")))
+        path_refs.update(_evidence_refs_from_value(path.get("evidence_ref")))
+        if path_refs:
+            refs.update(path_refs)
+        else:
+            paths_without_evidence.append(_path_identifier(path))
+    return sorted(refs), paths_without_evidence
+
+
+def _path_identifier(path: dict[str, Any]) -> str:
+    edge_id = path.get("edge_id")
+    if edge_id is not None and str(edge_id):
+        return str(edge_id)
+    return (
+        f"{path.get('source_node_id', '<unknown-source>')}"
+        f"->{path.get('target_node_id', '<unknown-target>')}"
+    )
 
 
 def _evidence_refs_from_value(value: Any) -> list[str]:
@@ -422,6 +486,12 @@ def _evidence_refs_from_value(value: Any) -> list[str]:
     if isinstance(value, (list, tuple, set)):
         return sorted(str(item) for item in value if str(item))
     return [str(value)] if str(value) else []
+
+
+def _evidence_refs_from_properties(properties: dict[str, Any]) -> list[str]:
+    refs = set(_evidence_refs_from_value(properties.get("evidence_refs")))
+    refs.update(_evidence_refs_from_value(properties.get("evidence_ref")))
+    return sorted(refs)
 
 
 def _dict_value(value: Any) -> dict[str, Any]:

--- a/graph_engine/status/consistency.py
+++ b/graph_engine/status/consistency.py
@@ -3,20 +3,21 @@
 from __future__ import annotations
 
 import logging
-from typing import Protocol
+from typing import Protocol, TypeAlias
 
 from graph_engine.client import Neo4jClient
-from graph_engine.live_metrics import read_live_graph_metrics
-from graph_engine.models import GraphSnapshot, Neo4jGraphStatus
+from graph_engine.live_metrics import checksum_payload, read_live_graph_metrics, sorted_payload_list
+from graph_engine.models import GraphMetricsSnapshot, GraphSnapshot, Neo4jGraphStatus
 from graph_engine.status.manager import GraphStatusManager, hold_ready_read
 
 _LOGGER = logging.getLogger(__name__)
+ConsistencySnapshot: TypeAlias = GraphMetricsSnapshot | GraphSnapshot
 
 
 class CanonicalSnapshotReader(Protocol):
     """Read canonical graph snapshots from the data-platform/Iceberg boundary."""
 
-    def read_graph_snapshot(self, snapshot_ref: str) -> GraphSnapshot:
+    def read_graph_snapshot(self, snapshot_ref: str) -> ConsistencySnapshot:
         """Return the canonical snapshot referenced by snapshot_ref."""
 
 
@@ -59,6 +60,13 @@ def _check_live_graph_consistency_after_status(
 ) -> bool:
     try:
         snapshot = snapshot_reader.read_graph_snapshot(snapshot_ref)
+        (
+            snapshot_generation_id,
+            snapshot_node_count,
+            snapshot_edge_count,
+            snapshot_labels,
+            snapshot_checksum,
+        ) = _snapshot_metric_values(snapshot)
     except Exception:
         _LOGGER.exception(
             "live graph consistency snapshot read failed",
@@ -75,13 +83,17 @@ def _check_live_graph_consistency_after_status(
         )
         return False
 
-    if status is not None and snapshot.graph_generation_id != status.graph_generation_id:
+    if (
+        status is not None
+        and snapshot_generation_id is not None
+        and snapshot_generation_id != status.graph_generation_id
+    ):
         _LOGGER.warning(
             "live graph consistency generation mismatch",
             extra={
                 "snapshot_ref": snapshot_ref,
                 "failure_stage": "result_validation",
-                "snapshot_generation_id": snapshot.graph_generation_id,
+                "snapshot_generation_id": snapshot_generation_id,
                 "status_generation_id": status.graph_generation_id,
             },
         )
@@ -90,10 +102,10 @@ def _check_live_graph_consistency_after_status(
     mismatches = [
         field_name
         for field_name, snapshot_value, live_value in (
-            ("node_count", snapshot.node_count, node_count),
-            ("edge_count", snapshot.edge_count, edge_count),
-            ("key_label_counts", snapshot.key_label_counts, key_label_counts),
-            ("checksum", snapshot.checksum, checksum),
+            ("node_count", snapshot_node_count, node_count),
+            ("edge_count", snapshot_edge_count, edge_count),
+            ("key_label_counts", snapshot_labels, key_label_counts),
+            ("checksum", snapshot_checksum, checksum),
         )
         if snapshot_value != live_value
     ]
@@ -123,3 +135,60 @@ def _resolve_status(
 
 def _read_live_graph_metrics(client: Neo4jClient) -> tuple[int, int, dict[str, int], str]:
     return read_live_graph_metrics(client, strict=True)
+
+
+def _snapshot_metric_values(
+    snapshot: ConsistencySnapshot,
+) -> tuple[int | None, int, int, dict[str, int], str]:
+    if isinstance(snapshot, GraphMetricsSnapshot):
+        return (
+            snapshot.graph_generation_id,
+            snapshot.node_count,
+            snapshot.edge_count,
+            snapshot.key_label_counts,
+            snapshot.checksum,
+        )
+
+    key_label_counts: dict[str, int] = {}
+    nodes = []
+    for node in snapshot.nodes:
+        labels = sorted(str(label) for label in node.labels)
+        for label in labels:
+            key_label_counts[label] = key_label_counts.get(label, 0) + 1
+        properties = dict(node.properties)
+        nodes.append(
+            {
+                "labels": labels,
+                "node_id": node.node_id,
+                "canonical_entity_id": (
+                    node.entity.entity_id
+                    if node.entity is not None
+                    else properties.get("canonical_entity_id")
+                ),
+                "properties": properties,
+            }
+        )
+
+    relationships = [
+        {
+            "source_node_id": edge.source_node,
+            "target_node_id": edge.target_node,
+            "relationship_type": edge.relation_type,
+            "edge_id": edge.edge_id,
+            "properties": dict(edge.properties),
+        }
+        for edge in snapshot.edges
+    ]
+    payload = {
+        "node_count": snapshot.node_count,
+        "edge_count": snapshot.edge_count,
+        "nodes": sorted_payload_list(nodes),
+        "relationships": sorted_payload_list(relationships),
+    }
+    return (
+        None,
+        snapshot.node_count,
+        snapshot.edge_count,
+        key_label_counts,
+        checksum_payload(payload),
+    )

--- a/graph_engine/status/manager.py
+++ b/graph_engine/status/manager.py
@@ -6,7 +6,7 @@ from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from datetime import datetime, timezone
 
-from graph_engine.models import GraphSnapshot, Neo4jGraphStatus
+from graph_engine.models import GraphMetricsSnapshot, Neo4jGraphStatus
 from graph_engine.status.store import StatusStore
 
 _SYNC_WRITER_LOCK_TOKEN = "incremental-sync"
@@ -221,7 +221,7 @@ class GraphStatusManager:
         self._commit_transition(current, status)
         return status
 
-    def mark_verified(self, snapshot: GraphSnapshot) -> Neo4jGraphStatus:
+    def mark_verified(self, snapshot: GraphMetricsSnapshot) -> Neo4jGraphStatus:
         """Refresh ready metrics from a canonical snapshot without bumping generation."""
 
         current = self.require_ready()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,15 +10,20 @@ readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
     "neo4j>=5.0",
+    "project-ult-contracts>=0.1.0",
     "pydantic>=2.0",
 ]
 
 [project.optional-dependencies]
 dev = [
     "mypy",
+    "psycopg>=3.0",
     "pytest-asyncio",
     "pytest>=8.0",
     "ruff",
+]
+postgres = [
+    "psycopg>=3.0",
 ]
 
 [tool.setuptools.packages.find]
@@ -33,6 +38,7 @@ python_version = "3.11"
 warn_unused_configs = true
 disallow_untyped_defs = true
 no_implicit_optional = true
+mypy_path = "../contracts/src"
 
 [tool.ruff]
 line-length = 100

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,17 @@
 from __future__ import annotations
 
+import sys
+from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
 
-from graph_engine.client import Neo4jClient
-from graph_engine.config import Neo4jConfig
+_CONTRACTS_SRC = Path(__file__).resolve().parents[2] / "contracts" / "src"
+if _CONTRACTS_SRC.exists():
+    sys.path.insert(0, str(_CONTRACTS_SRC))
+
+from graph_engine.client import Neo4jClient  # noqa: E402
+from graph_engine.config import Neo4jConfig  # noqa: E402
 
 
 @pytest.fixture

--- a/tests/integration/test_full_propagation.py
+++ b/tests/integration/test_full_propagation.py
@@ -9,6 +9,7 @@ import pytest
 
 from graph_engine.client import Neo4jClient
 from graph_engine.config import load_config_from_env
+from graph_engine.live_metrics import read_live_graph_metrics
 from graph_engine.models import (
     GraphEdgeRecord,
     GraphImpactSnapshot,
@@ -19,7 +20,7 @@ from graph_engine.models import (
 )
 from graph_engine.schema.definitions import NodeLabel, RelationshipType
 from graph_engine.schema.manager import SchemaManager
-from graph_engine.snapshots import build_graph_snapshot, compute_graph_snapshots
+from graph_engine.snapshots import compute_graph_snapshots
 from graph_engine.status import GraphStatusManager
 from graph_engine.sync import sync_live_graph
 from tests.fakes import InMemoryStatusStore
@@ -102,21 +103,14 @@ def test_compute_graph_snapshots_generates_three_channel_impact_snapshot() -> No
                 ),
                 client,
             )
-            live_snapshot = build_graph_snapshot(
-                "cycle-1",
-                1,
-                client,
-                status_manager=GraphStatusManager(
-                    InMemoryStatusStore(_status_for_generation(1)),
-                ),
-            )
+            node_count, edge_count, key_label_counts, checksum = read_live_graph_metrics(client)
             graph_status = Neo4jGraphStatus(
                 graph_status="ready",
-                graph_generation_id=live_snapshot.graph_generation_id,
-                node_count=live_snapshot.node_count,
-                edge_count=live_snapshot.edge_count,
-                key_label_counts=live_snapshot.key_label_counts,
-                checksum=live_snapshot.checksum,
+                graph_generation_id=1,
+                node_count=node_count,
+                edge_count=edge_count,
+                key_label_counts=key_label_counts,
+                checksum=checksum,
                 last_verified_at=NOW,
                 last_reload_at=None,
             )
@@ -143,35 +137,11 @@ def test_compute_graph_snapshots_generates_three_channel_impact_snapshot() -> No
                 {"node_ids": node_ids},
             )
 
-    path_channels_by_edge = {
-        (path["edge_id"], path["channel"])
-        for path in impact_snapshot.activated_paths
-    }
-    channels_by_edge_id: dict[str, set[str]] = {}
-    for path in impact_snapshot.activated_paths:
-        channels_by_edge_id.setdefault(str(path["edge_id"]), set()).add(str(path["channel"]))
-
-    assert (supply_edge_id, "fundamental") in path_channels_by_edge
-    assert (event_edge_id, "event") in path_channels_by_edge
-    assert (reflexive_edge_id, "reflexive") in path_channels_by_edge
-    assert channels_by_edge_id[reflexive_edge_id] == {"reflexive"}
-    duplicated_edges = {
-        edge_id: channels
-        for edge_id, channels in channels_by_edge_id.items()
-        if len(channels) > 1
-    }
-    assert duplicated_edges == {}
-    assert set(impact_snapshot.channel_breakdown) == {
-        "fundamental",
-        "event",
-        "reflexive",
-        "merged",
-    }
-    assert impact_snapshot.channel_breakdown["merged"]["enabled_channels"] == [
-        "event",
-        "fundamental",
-        "reflexive",
-    ]
+    assert {supply_edge_id, event_edge_id, reflexive_edge_id} <= set(
+        impact_snapshot.evidence_refs
+    )
+    assert impact_snapshot.affected_entities
+    assert impact_snapshot.direction == "bullish"
     assert graph_snapshot.node_count >= 4
     assert writer.calls == [(graph_snapshot, impact_snapshot)]
 
@@ -222,19 +192,6 @@ def _promotion_plan(
         ],
         assertion_records=[],
         created_at=NOW,
-    )
-
-
-def _status_for_generation(graph_generation_id: int) -> Neo4jGraphStatus:
-    return Neo4jGraphStatus(
-        graph_status="ready",
-        graph_generation_id=graph_generation_id,
-        node_count=0,
-        edge_count=0,
-        key_label_counts={},
-        checksum="pending",
-        last_verified_at=NOW,
-        last_reload_at=None,
     )
 
 

--- a/tests/integration/test_full_propagation.py
+++ b/tests/integration/test_full_propagation.py
@@ -74,6 +74,9 @@ def test_compute_graph_snapshots_generates_three_channel_impact_snapshot() -> No
     supply_edge_id = f"{prefix}-supply-edge"
     event_edge_id = f"{prefix}-event-edge"
     reflexive_edge_id = f"{prefix}-reflexive-edge"
+    supply_evidence_ref = f"{prefix}-supply-fact"
+    event_evidence_ref = f"{prefix}-event-fact"
+    reflexive_evidence_ref = f"{prefix}-reflexive-fact"
     node_ids = [
         source_node_id,
         fundamental_target_id,
@@ -100,6 +103,9 @@ def test_compute_graph_snapshots_generates_three_channel_impact_snapshot() -> No
                     supply_edge_id=supply_edge_id,
                     event_edge_id=event_edge_id,
                     reflexive_edge_id=reflexive_edge_id,
+                    supply_evidence_ref=supply_evidence_ref,
+                    event_evidence_ref=event_evidence_ref,
+                    reflexive_evidence_ref=reflexive_evidence_ref,
                 ),
                 client,
             )
@@ -137,7 +143,7 @@ def test_compute_graph_snapshots_generates_three_channel_impact_snapshot() -> No
                 {"node_ids": node_ids},
             )
 
-    assert {supply_edge_id, event_edge_id, reflexive_edge_id} <= set(
+    assert {supply_evidence_ref, event_evidence_ref, reflexive_evidence_ref} <= set(
         impact_snapshot.evidence_refs
     )
     assert impact_snapshot.affected_entities
@@ -155,6 +161,9 @@ def _promotion_plan(
     supply_edge_id: str,
     event_edge_id: str,
     reflexive_edge_id: str,
+    supply_evidence_ref: str,
+    event_evidence_ref: str,
+    reflexive_evidence_ref: str,
 ) -> PromotionPlan:
     return PromotionPlan(
         cycle_id="cycle-1",
@@ -173,6 +182,7 @@ def _promotion_plan(
                 supply_edge_id,
                 RelationshipType.SUPPLY_CHAIN.value,
                 weight=2.0,
+                evidence_ref=supply_evidence_ref,
             ),
             _edge_record(
                 source_node_id,
@@ -180,6 +190,7 @@ def _promotion_plan(
                 event_edge_id,
                 RelationshipType.EVENT_IMPACT.value,
                 weight=3.0,
+                evidence_ref=event_evidence_ref,
             ),
             _edge_record(
                 source_node_id,
@@ -187,6 +198,7 @@ def _promotion_plan(
                 reflexive_edge_id,
                 RelationshipType.OWNERSHIP.value,
                 weight=4.0,
+                evidence_ref=reflexive_evidence_ref,
                 extra_properties={"propagation_channel": "reflexive"},
             ),
         ],
@@ -213,11 +225,13 @@ def _edge_record(
     relationship_type: str,
     *,
     weight: float,
+    evidence_ref: str,
     extra_properties: dict[str, Any] | None = None,
 ) -> GraphEdgeRecord:
     properties = {
         "integration_prefix": edge_id,
         "evidence_confidence": 1.0,
+        "evidence_refs": [evidence_ref],
         "recency_decay": 1.0,
     }
     properties.update(extra_properties or {})

--- a/tests/integration/test_promotion_sync.py
+++ b/tests/integration/test_promotion_sync.py
@@ -10,7 +10,7 @@ import pytest
 from graph_engine.client import Neo4jClient
 from graph_engine.config import load_config_from_env
 from graph_engine.models import (
-    CandidateGraphDelta,
+    FrozenGraphDelta,
     GraphEdgeRecord,
     GraphNodeRecord,
     Neo4jGraphStatus,
@@ -32,14 +32,14 @@ NOW = datetime(2026, 4, 17, 1, 2, 3, tzinfo=timezone.utc)
 
 
 class StaticCandidateReader:
-    def __init__(self, deltas: list[CandidateGraphDelta]) -> None:
+    def __init__(self, deltas: list[FrozenGraphDelta]) -> None:
         self.deltas = deltas
 
     def read_candidate_graph_deltas(
         self,
         cycle_id: str,
         selection_ref: str,
-    ) -> list[CandidateGraphDelta]:
+    ) -> list[FrozenGraphDelta]:
         return self.deltas
 
 
@@ -356,8 +356,8 @@ def _node_delta(
     delta_id: str,
     node_id: str,
     canonical_entity_id: str,
-) -> CandidateGraphDelta:
-    return CandidateGraphDelta(
+) -> FrozenGraphDelta:
+    return FrozenGraphDelta(
         delta_id=delta_id,
         cycle_id="cycle-1",
         delta_type="node_add",
@@ -382,8 +382,8 @@ def _edge_delta(
     source_node_id: str,
     target_node_id: str,
     source_entity_ids: list[str],
-) -> CandidateGraphDelta:
-    return CandidateGraphDelta(
+) -> FrozenGraphDelta:
+    return FrozenGraphDelta(
         delta_id=delta_id,
         cycle_id="cycle-1",
         delta_type="edge_add",
@@ -410,8 +410,8 @@ def _assertion_delta(
     source_node_id: str,
     target_node_id: str,
     source_entity_ids: list[str],
-) -> CandidateGraphDelta:
-    return CandidateGraphDelta(
+) -> FrozenGraphDelta:
+    return FrozenGraphDelta(
         delta_id=delta_id,
         cycle_id="cycle-1",
         delta_type="assertion_add",

--- a/tests/integration/test_propagation_snapshot.py
+++ b/tests/integration/test_propagation_snapshot.py
@@ -62,6 +62,7 @@ def test_compute_graph_snapshots_runs_fundamental_pagerank_on_promoted_graph() -
     source_node_id = f"{prefix}-source"
     target_node_id = f"{prefix}-target"
     edge_id = f"{prefix}-edge"
+    evidence_ref = f"{prefix}-fact-1"
     node_ids = [source_node_id, target_node_id]
     writer = CapturingSnapshotWriter()
 
@@ -74,7 +75,10 @@ def test_compute_graph_snapshots_runs_fundamental_pagerank_on_promoted_graph() -
         assert manager.verify_schema() is True
 
         try:
-            sync_live_graph(_promotion_plan(source_node_id, target_node_id, edge_id), client)
+            sync_live_graph(
+                _promotion_plan(source_node_id, target_node_id, edge_id, evidence_ref),
+                client,
+            )
             node_count, edge_count, key_label_counts, checksum = read_live_graph_metrics(client)
             graph_status = Neo4jGraphStatus(
                 graph_status="ready",
@@ -112,7 +116,7 @@ def test_compute_graph_snapshots_runs_fundamental_pagerank_on_promoted_graph() -
     assert graph_snapshot.node_count >= 2
     assert graph_snapshot.edge_count >= 1
     assert impact_snapshot.affected_entities
-    assert edge_id in impact_snapshot.evidence_refs
+    assert impact_snapshot.evidence_refs == [evidence_ref]
     assert writer.calls == [(graph_snapshot, impact_snapshot)]
 
 
@@ -120,6 +124,7 @@ def _promotion_plan(
     source_node_id: str,
     target_node_id: str,
     edge_id: str,
+    evidence_ref: str,
 ) -> PromotionPlan:
     return PromotionPlan(
         cycle_id="cycle-1",
@@ -129,7 +134,7 @@ def _promotion_plan(
             _node_record(source_node_id, f"{source_node_id}-entity"),
             _node_record(target_node_id, f"{target_node_id}-entity"),
         ],
-        edge_records=[_edge_record(source_node_id, target_node_id, edge_id)],
+        edge_records=[_edge_record(source_node_id, target_node_id, edge_id, evidence_ref)],
         assertion_records=[],
         created_at=NOW,
     )
@@ -150,6 +155,7 @@ def _edge_record(
     source_node_id: str,
     target_node_id: str,
     edge_id: str,
+    evidence_ref: str,
 ) -> GraphEdgeRecord:
     return GraphEdgeRecord(
         edge_id=edge_id,
@@ -159,6 +165,7 @@ def _edge_record(
         properties={
             "integration_prefix": edge_id,
             "evidence_confidence": 0.9,
+            "evidence_refs": [evidence_ref],
             "recency_decay": 1.0,
         },
         weight=10.0,

--- a/tests/integration/test_propagation_snapshot.py
+++ b/tests/integration/test_propagation_snapshot.py
@@ -9,6 +9,7 @@ import pytest
 
 from graph_engine.client import Neo4jClient
 from graph_engine.config import load_config_from_env
+from graph_engine.live_metrics import read_live_graph_metrics
 from graph_engine.models import (
     GraphEdgeRecord,
     GraphImpactSnapshot,
@@ -19,7 +20,7 @@ from graph_engine.models import (
 )
 from graph_engine.schema.definitions import NodeLabel, RelationshipType
 from graph_engine.schema.manager import SchemaManager
-from graph_engine.snapshots import build_graph_snapshot, compute_graph_snapshots
+from graph_engine.snapshots import compute_graph_snapshots
 from graph_engine.status import GraphStatusManager
 from graph_engine.sync import sync_live_graph
 from tests.fakes import InMemoryStatusStore
@@ -74,21 +75,14 @@ def test_compute_graph_snapshots_runs_fundamental_pagerank_on_promoted_graph() -
 
         try:
             sync_live_graph(_promotion_plan(source_node_id, target_node_id, edge_id), client)
-            live_snapshot = build_graph_snapshot(
-                "cycle-1",
-                1,
-                client,
-                status_manager=GraphStatusManager(
-                    InMemoryStatusStore(_status_for_generation(1)),
-                ),
-            )
+            node_count, edge_count, key_label_counts, checksum = read_live_graph_metrics(client)
             graph_status = Neo4jGraphStatus(
                 graph_status="ready",
-                graph_generation_id=live_snapshot.graph_generation_id,
-                node_count=live_snapshot.node_count,
-                edge_count=live_snapshot.edge_count,
-                key_label_counts=live_snapshot.key_label_counts,
-                checksum=live_snapshot.checksum,
+                graph_generation_id=1,
+                node_count=node_count,
+                edge_count=edge_count,
+                key_label_counts=key_label_counts,
+                checksum=checksum,
                 last_verified_at=NOW,
                 last_reload_at=None,
             )
@@ -117,9 +111,8 @@ def test_compute_graph_snapshots_runs_fundamental_pagerank_on_promoted_graph() -
 
     assert graph_snapshot.node_count >= 2
     assert graph_snapshot.edge_count >= 1
-    assert impact_snapshot.regime_context_ref == "world-state-1"
-    assert impact_snapshot.impacted_entities
-    assert any(path["edge_id"] == edge_id for path in impact_snapshot.activated_paths)
+    assert impact_snapshot.affected_entities
+    assert edge_id in impact_snapshot.evidence_refs
     assert writer.calls == [(graph_snapshot, impact_snapshot)]
 
 
@@ -139,19 +132,6 @@ def _promotion_plan(
         edge_records=[_edge_record(source_node_id, target_node_id, edge_id)],
         assertion_records=[],
         created_at=NOW,
-    )
-
-
-def _status_for_generation(graph_generation_id: int) -> Neo4jGraphStatus:
-    return Neo4jGraphStatus(
-        graph_status="ready",
-        graph_generation_id=graph_generation_id,
-        node_count=0,
-        edge_count=0,
-        key_label_counts={},
-        checksum="pending",
-        last_verified_at=NOW,
-        last_reload_at=None,
     )
 
 

--- a/tests/integration/test_reload.py
+++ b/tests/integration/test_reload.py
@@ -8,18 +8,18 @@ import pytest
 
 from graph_engine.client import Neo4jClient
 from graph_engine.config import load_config_from_env
+from graph_engine.live_metrics import read_live_graph_metrics
 from graph_engine.models import (
     ColdReloadPlan,
     GraphEdgeRecord,
+    GraphMetricsSnapshot,
     GraphNodeRecord,
-    GraphSnapshot,
     Neo4jGraphStatus,
     PromotionPlan,
 )
 from graph_engine.reload import cold_reload
 from graph_engine.schema.definitions import NodeLabel, RelationshipType
 from graph_engine.schema.manager import DROP_ALL_CONFIRMATION_TOKEN, SchemaManager
-from graph_engine.snapshots import build_graph_snapshot
 from graph_engine.status import GraphStatusManager, check_live_graph_consistency
 from graph_engine.sync import sync_live_graph
 from tests.fakes import InMemoryStatusStore
@@ -41,10 +41,10 @@ class StaticCanonicalReader:
 
 
 class StaticSnapshotReader:
-    def __init__(self, snapshot: GraphSnapshot) -> None:
+    def __init__(self, snapshot: GraphMetricsSnapshot) -> None:
         self.snapshot = snapshot
 
-    def read_graph_snapshot(self, snapshot_ref: str) -> GraphSnapshot:
+    def read_graph_snapshot(self, snapshot_ref: str) -> GraphMetricsSnapshot:
         return self.snapshot
 
 
@@ -74,14 +74,7 @@ def test_cold_reload_rebuilds_live_graph_and_gds_projection() -> None:
 
         try:
             sync_live_graph(promotion_plan, client)
-            expected_snapshot = build_graph_snapshot(
-                "cycle-reload",
-                7,
-                client,
-                status_manager=GraphStatusManager(
-                    InMemoryStatusStore(_status(graph_generation_id=7)),
-                ),
-            )
+            expected_snapshot = _snapshot_from_live_graph(client, graph_generation_id=7)
             plan = ColdReloadPlan(
                 snapshot_ref="snapshot-ref-reload",
                 cycle_id="cycle-reload",
@@ -164,6 +157,24 @@ def _promotion_plan(
         ],
         edge_records=[_edge_record(source_node_id, target_node_id, edge_id)],
         assertion_records=[],
+        created_at=NOW,
+    )
+
+
+def _snapshot_from_live_graph(
+    client: Neo4jClient,
+    *,
+    graph_generation_id: int,
+) -> GraphMetricsSnapshot:
+    node_count, edge_count, key_label_counts, checksum = read_live_graph_metrics(client)
+    return GraphMetricsSnapshot(
+        cycle_id="cycle-reload",
+        snapshot_id=f"graph-snapshot-cycle-reload-{graph_generation_id}-{checksum[:12]}",
+        graph_generation_id=graph_generation_id,
+        node_count=node_count,
+        edge_count=edge_count,
+        key_label_counts=key_label_counts,
+        checksum=checksum,
         created_at=NOW,
     )
 

--- a/tests/integration/test_status.py
+++ b/tests/integration/test_status.py
@@ -8,6 +8,7 @@ import pytest
 
 from graph_engine.client import Neo4jClient
 from graph_engine.config import load_config_from_env
+from graph_engine.live_metrics import read_live_graph_metrics
 from graph_engine.models import GraphSnapshot, Neo4jGraphStatus
 from graph_engine.schema.manager import SchemaManager
 from graph_engine.snapshots import build_graph_snapshot
@@ -84,8 +85,17 @@ CREATE (source)-[:SUPPLY_CHAIN {
                     InMemoryStatusStore(_status_for_generation(11)),
                 ),
             )
+            node_count, edge_count, key_label_counts, checksum = read_live_graph_metrics(client)
             status_manager = GraphStatusManager(
-                InMemoryStatusStore(_status_from_snapshot(snapshot)),
+                InMemoryStatusStore(
+                    _status_from_metrics(
+                        graph_generation_id=11,
+                        node_count=node_count,
+                        edge_count=edge_count,
+                        key_label_counts=key_label_counts,
+                        checksum=checksum,
+                    )
+                ),
                 clock=lambda: NOW,
             )
             snapshot_reader = StaticSnapshotReader(snapshot)
@@ -121,14 +131,21 @@ CREATE (source)-[:SUPPLY_CHAIN {
             )
 
 
-def _status_from_snapshot(snapshot: GraphSnapshot) -> Neo4jGraphStatus:
+def _status_from_metrics(
+    *,
+    graph_generation_id: int,
+    node_count: int,
+    edge_count: int,
+    key_label_counts: dict[str, int],
+    checksum: str,
+) -> Neo4jGraphStatus:
     return Neo4jGraphStatus(
         graph_status="ready",
-        graph_generation_id=snapshot.graph_generation_id,
-        node_count=snapshot.node_count,
-        edge_count=snapshot.edge_count,
-        key_label_counts=snapshot.key_label_counts,
-        checksum=snapshot.checksum,
+        graph_generation_id=graph_generation_id,
+        node_count=node_count,
+        edge_count=edge_count,
+        key_label_counts=key_label_counts,
+        checksum=checksum,
         last_verified_at=NOW,
         last_reload_at=None,
     )

--- a/tests/unit/test_contract_schemas.py
+++ b/tests/unit/test_contract_schemas.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import contracts.schemas as contract_schemas
+
+import graph_engine
+from graph_engine import models
+
+
+def test_public_graph_contracts_are_reexported_from_contracts() -> None:
+    assert models.CandidateGraphDelta is contract_schemas.CandidateGraphDelta
+    assert models.GraphSnapshot is contract_schemas.GraphSnapshot
+    assert models.GraphImpactSnapshot is contract_schemas.GraphImpactSnapshot
+    assert graph_engine.CandidateGraphDelta is contract_schemas.CandidateGraphDelta
+    assert graph_engine.GraphSnapshot is contract_schemas.GraphSnapshot
+    assert graph_engine.GraphImpactSnapshot is contract_schemas.GraphImpactSnapshot
+
+
+def test_public_graph_contract_json_schemas_match_contracts() -> None:
+    assert (
+        models.CandidateGraphDelta.model_json_schema()
+        == contract_schemas.CandidateGraphDelta.model_json_schema()
+    )
+    assert models.GraphSnapshot.model_json_schema() == contract_schemas.GraphSnapshot.model_json_schema()
+    assert (
+        models.GraphImpactSnapshot.model_json_schema()
+        == contract_schemas.GraphImpactSnapshot.model_json_schema()
+    )
+
+
+def test_public_graph_contract_field_sets_are_pinned() -> None:
+    assert set(models.CandidateGraphDelta.model_fields) == {
+        "delta_id",
+        "delta_type",
+        "source_node",
+        "target_node",
+        "relation_type",
+        "properties",
+        "evidence",
+        "subsystem_id",
+    }
+    assert set(models.GraphSnapshot.model_fields) == {
+        "graph_snapshot_id",
+        "cycle_id",
+        "version",
+        "created_at",
+        "node_count",
+        "edge_count",
+        "nodes",
+        "edges",
+    }
+    assert set(models.GraphImpactSnapshot.model_fields) == {
+        "impact_snapshot_id",
+        "cycle_id",
+        "version",
+        "created_at",
+        "target_entities",
+        "affected_entities",
+        "affected_sectors",
+        "direction",
+        "impact_score",
+        "evidence_refs",
+    }
+
+
+def test_internal_metric_and_frozen_delta_models_are_not_public_contracts() -> None:
+    assert models.FrozenGraphDelta is not contract_schemas.CandidateGraphDelta
+    assert models.GraphMetricsSnapshot is not contract_schemas.GraphSnapshot
+    assert "FrozenGraphDelta" not in graph_engine.__all__
+    assert "GraphMetricsSnapshot" not in graph_engine.__all__

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -9,9 +9,11 @@ from pydantic import BaseModel, ValidationError
 from graph_engine.models import (
     CandidateGraphDelta,
     ColdReloadPlan,
+    FrozenGraphDelta,
     GraphAssertionRecord,
     GraphEdgeRecord,
     GraphImpactSnapshot,
+    GraphMetricsSnapshot,
     GraphNodeRecord,
     GraphSnapshot,
     Neo4jGraphStatus,
@@ -66,6 +68,19 @@ def _model_payloads() -> list[tuple[type[BaseModel], dict[str, Any]]]:
             CandidateGraphDelta,
             {
                 "delta_id": "delta-1",
+                "delta_type": "upsert_edge",
+                "source_node": "node-1",
+                "target_node": "node-2",
+                "relation_type": "SUPPLY_CHAIN",
+                "properties": {"weight": 1.0},
+                "evidence": ["fact-1"],
+                "subsystem_id": "subsystem-news",
+            },
+        ),
+        (
+            FrozenGraphDelta,
+            {
+                "delta_id": "delta-1",
                 "cycle_id": "cycle-1",
                 "delta_type": "node_add",
                 "source_entity_ids": ["entity-1"],
@@ -75,6 +90,29 @@ def _model_payloads() -> list[tuple[type[BaseModel], dict[str, Any]]]:
         ),
         (
             GraphSnapshot,
+            {
+                "cycle_id": "cycle-1",
+                "graph_snapshot_id": "snapshot-1",
+                "version": "0.1.0",
+                "node_count": 2,
+                "edge_count": 1,
+                "nodes": [
+                    {"node_id": "node-1", "labels": ["Entity"]},
+                    {"node_id": "node-2", "labels": ["Entity"]},
+                ],
+                "edges": [
+                    {
+                        "edge_id": "edge-1",
+                        "source_node": "node-1",
+                        "target_node": "node-2",
+                        "relation_type": "SUPPLY_CHAIN",
+                    }
+                ],
+                "created_at": NOW,
+            },
+        ),
+        (
+            GraphMetricsSnapshot,
             {
                 "cycle_id": "cycle-1",
                 "snapshot_id": "snapshot-1",
@@ -139,10 +177,26 @@ def _model_payloads() -> list[tuple[type[BaseModel], dict[str, Any]]]:
             {
                 "cycle_id": "cycle-1",
                 "impact_snapshot_id": "impact-1",
-                "regime_context_ref": "world-state-1",
-                "activated_paths": [{"path": ["node-1", "node-2"]}],
-                "impacted_entities": [{"entity_id": "entity-2", "score": 0.5}],
-                "channel_breakdown": {"fundamental": {"score": 0.5}},
+                "version": "0.1.0",
+                "created_at": NOW,
+                "target_entities": [
+                    {
+                        "entity_id": "entity-1",
+                        "entity_type": "equity",
+                        "canonical_id_rule_version": "0.1.0",
+                    }
+                ],
+                "affected_entities": [
+                    {
+                        "entity_id": "entity-2",
+                        "entity_type": "equity",
+                        "canonical_id_rule_version": "0.1.0",
+                    }
+                ],
+                "affected_sectors": ["technology"],
+                "direction": "bullish",
+                "impact_score": 0.5,
+                "evidence_refs": ["fact-1"],
             },
         ),
         (
@@ -238,7 +292,7 @@ def test_edge_weight_defaults_to_one() -> None:
 
 def test_candidate_delta_rejects_invalid_validation_status() -> None:
     with pytest.raises(ValidationError):
-        CandidateGraphDelta(
+        FrozenGraphDelta(
             delta_id="delta-1",
             cycle_id="cycle-1",
             delta_type="node_add",
@@ -250,7 +304,7 @@ def test_candidate_delta_rejects_invalid_validation_status() -> None:
 
 def test_candidate_delta_rejects_invalid_delta_type() -> None:
     with pytest.raises(ValidationError):
-        CandidateGraphDelta(
+        FrozenGraphDelta(
             delta_id="delta-1",
             cycle_id="cycle-1",
             delta_type="node_delete",
@@ -306,12 +360,12 @@ def test_graph_snapshot_rejects_negative_counts() -> None:
     with pytest.raises(ValidationError):
         GraphSnapshot(
             cycle_id="cycle-1",
-            snapshot_id="snapshot-1",
-            graph_generation_id=1,
+            graph_snapshot_id="snapshot-1",
+            version="0.1.0",
             node_count=-1,
             edge_count=0,
-            key_label_counts={},
-            checksum="abc123",
+            nodes=[],
+            edges=[],
             created_at=NOW,
         )
 

--- a/tests/unit/test_promotion.py
+++ b/tests/unit/test_promotion.py
@@ -9,7 +9,7 @@ import pytest
 
 import graph_engine.promotion.service as service_module
 from graph_engine.client import Neo4jClient
-from graph_engine.models import CandidateGraphDelta, Neo4jGraphStatus, PromotionPlan
+from graph_engine.models import FrozenGraphDelta, Neo4jGraphStatus, PromotionPlan
 from graph_engine.promotion import build_promotion_plan, promote_graph_deltas
 from graph_engine.promotion.planner import validate_entity_anchors
 from graph_engine.schema.definitions import NodeLabel, RelationshipType
@@ -20,7 +20,7 @@ NOW = datetime(2026, 4, 17, 1, 2, 3, tzinfo=timezone.utc)
 
 
 class FakeCandidateReader:
-    def __init__(self, deltas: list[CandidateGraphDelta]) -> None:
+    def __init__(self, deltas: list[FrozenGraphDelta]) -> None:
         self.deltas = deltas
         self.calls: list[tuple[str, str]] = []
 
@@ -28,7 +28,7 @@ class FakeCandidateReader:
         self,
         cycle_id: str,
         selection_ref: str,
-    ) -> list[CandidateGraphDelta]:
+    ) -> list[FrozenGraphDelta]:
         self.calls.append((cycle_id, selection_ref))
         return self.deltas
 
@@ -179,7 +179,7 @@ def test_build_promotion_plan_parses_frozen_deltas_in_stable_order() -> None:
     ],
 )
 def test_build_promotion_plan_rejects_invalid_delta_contracts(
-    delta_factory: Callable[[], CandidateGraphDelta],
+    delta_factory: Callable[[], FrozenGraphDelta],
     match: str,
 ) -> None:
     with pytest.raises(ValueError, match=match):
@@ -449,8 +449,8 @@ def _delta(
     *,
     cycle_id: str = "cycle-1",
     validation_status: str = "frozen",
-) -> CandidateGraphDelta:
-    return CandidateGraphDelta(
+) -> FrozenGraphDelta:
+    return FrozenGraphDelta(
         delta_id=delta_id,
         cycle_id=cycle_id,
         delta_type=delta_type,

--- a/tests/unit/test_propagation.py
+++ b/tests/unit/test_propagation.py
@@ -288,6 +288,7 @@ def test_run_fundamental_propagation_uses_gds_projection_and_explains_paths() ->
     ]
     assert result.impacted_entities[0]["pagerank_score"] == pytest.approx(0.2)
     assert result.activated_paths[0]["edge_id"] == "edge-1"
+    assert result.activated_paths[0]["evidence_refs"] == ["fact-edge-1"]
     assert result.activated_paths[0]["score"] == pytest.approx(0.5)
     assert result.activated_paths[0]["explanation"] == {
         "relation_weight": 0.5,
@@ -598,6 +599,7 @@ def _path_row(
     propagation_channel: str | None = None,
     channel: str | None = None,
     impact_channel: str | None = None,
+    evidence_refs: list[str] | None = None,
 ) -> dict[str, Any]:
     return {
         "source_node_id": "node-a",
@@ -614,6 +616,7 @@ def _path_row(
         "propagation_channel": propagation_channel,
         "channel": channel,
         "impact_channel": impact_channel,
+        "evidence_refs": [f"fact-{edge_id}"] if evidence_refs is None else evidence_refs,
     }
 
 

--- a/tests/unit/test_propagation_event.py
+++ b/tests/unit/test_propagation_event.py
@@ -216,6 +216,7 @@ def test_run_event_propagation_uses_projection_and_explains_paths() -> None:
 
     assert [path["edge_id"] for path in result.activated_paths] == ["edge-top", "edge-mid"]
     assert result.activated_paths[0]["channel"] == "event"
+    assert result.activated_paths[0]["evidence_refs"] == ["fact-edge-top"]
     assert result.activated_paths[0]["explanation"] == {
         "relation_weight": 2.0,
         "evidence_confidence": 1.0,
@@ -334,6 +335,7 @@ def _path_row(
     propagation_channel: str | None = None,
     channel: str | None = None,
     impact_channel: str | None = None,
+    evidence_refs: list[str] | None = None,
 ) -> dict[str, Any]:
     return {
         "source_node_id": "node-a",
@@ -350,6 +352,7 @@ def _path_row(
         "propagation_channel": propagation_channel,
         "channel": channel,
         "impact_channel": impact_channel,
+        "evidence_refs": [f"fact-{edge_id}"] if evidence_refs is None else evidence_refs,
     }
 
 

--- a/tests/unit/test_propagation_reflexive.py
+++ b/tests/unit/test_propagation_reflexive.py
@@ -213,6 +213,7 @@ def test_run_reflexive_propagation_filters_tagged_paths_and_explains_scores() ->
     assert [path["edge_id"] for path in result.activated_paths] == ["edge-top", "edge-mid"]
     assert {path["edge_id"] for path in result.activated_paths}.isdisjoint({"edge-untagged"})
     assert result.activated_paths[0]["channel"] == "reflexive"
+    assert result.activated_paths[0]["evidence_refs"] == ["fact-edge-top"]
     assert result.activated_paths[0]["explanation"] == {
         "relation_weight": 2.0,
         "evidence_confidence": 1.0,
@@ -326,6 +327,7 @@ def _path_row(
     propagation_channel: str | None = None,
     channel: str | None = None,
     impact_channel: str | None = None,
+    evidence_refs: list[str] | None = None,
 ) -> dict[str, Any]:
     return {
         "source_node_id": "node-a",
@@ -342,6 +344,7 @@ def _path_row(
         "propagation_channel": propagation_channel,
         "channel": channel,
         "impact_channel": impact_channel,
+        "evidence_refs": [f"fact-{edge_id}"] if evidence_refs is None else evidence_refs,
     }
 
 

--- a/tests/unit/test_reload.py
+++ b/tests/unit/test_reload.py
@@ -11,8 +11,8 @@ from graph_engine.client import Neo4jClient
 from graph_engine.models import (
     ColdReloadPlan,
     GraphEdgeRecord,
+    GraphMetricsSnapshot as GraphSnapshot,
     GraphNodeRecord,
-    GraphSnapshot,
     Neo4jGraphStatus,
     PromotionPlan,
 )

--- a/tests/unit/test_snapshots.py
+++ b/tests/unit/test_snapshots.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock
 import pytest
 
 import graph_engine.snapshots.generator as snapshot_generator
+from graph_engine.live_metrics import LiveGraphMetrics
 from graph_engine.models import (
     GraphImpactSnapshot,
     GraphSnapshot,
@@ -172,9 +173,11 @@ def test_build_graph_snapshot_reads_metrics_and_stable_checksum() -> None:
 
     assert first.node_count == 2
     assert first.edge_count == 1
-    assert first.key_label_counts == {"Entity": 2, "Sector": 1}
-    assert first.checksum == second.checksum
-    assert first.snapshot_id == second.snapshot_id
+    assert [node.node_id for node in first.nodes] == ["node-b", "node-a"]
+    assert first.nodes[0].entity is not None
+    assert first.nodes[0].entity.entity_id == "entity-b"
+    assert first.edges[0].relation_type == "SUPPLY_CHAIN"
+    assert first.graph_snapshot_id == second.graph_snapshot_id
     assert len(client.read_calls) == 2
 
     client.relationships[0] = {
@@ -187,7 +190,7 @@ def test_build_graph_snapshot_reads_metrics_and_stable_checksum() -> None:
         client,
         status_manager=status_manager,
     )
-    assert changed.checksum != first.checksum
+    assert changed.graph_snapshot_id != first.graph_snapshot_id
     assert len(client.read_calls) == 3
 
 
@@ -223,7 +226,7 @@ def test_build_graph_snapshot_blocks_active_writer_lock_before_reading() -> None
     client.execute_read.assert_not_called()
 
 
-def test_build_graph_impact_snapshot_preserves_propagation_payload() -> None:
+def test_build_graph_impact_snapshot_returns_contract_payload() -> None:
     propagation_result = _propagation_result()
 
     impact_snapshot = build_graph_impact_snapshot(
@@ -232,15 +235,12 @@ def test_build_graph_impact_snapshot_preserves_propagation_payload() -> None:
         propagation_result,
     )
 
-    assert impact_snapshot.regime_context_ref == "world-state-1"
-    assert impact_snapshot.activated_paths == propagation_result.activated_paths
-    assert impact_snapshot.impacted_entities == propagation_result.impacted_entities
-    assert impact_snapshot.channel_breakdown == {
-        "fundamental": {"path_count": 1},
-        "event": {},
-        "reflexive": {},
-        "merged": {},
-    }
+    assert impact_snapshot.version == "0.1.0"
+    assert [entity.entity_id for entity in impact_snapshot.target_entities] == ["node-2"]
+    assert [entity.entity_id for entity in impact_snapshot.affected_entities] == ["node-2"]
+    assert impact_snapshot.direction == "bullish"
+    assert impact_snapshot.impact_score == pytest.approx(0.4)
+    assert impact_snapshot.evidence_refs == ["edge-1"]
 
 
 def test_build_graph_impact_snapshot_id_tracks_full_propagation_payload() -> None:
@@ -405,12 +405,10 @@ def test_compute_graph_snapshots_uses_status_manager_and_derives_generation(
     )
 
     assert status_store.calls == 3
-    assert graph_snapshot.graph_generation_id == 7
+    assert graph_snapshot.graph_snapshot_id.startswith("graph-snapshot-cycle-1-7-")
     assert graph_snapshot.node_count == 2
     assert graph_snapshot.edge_count == 1
-    assert graph_snapshot.key_label_counts == {"Entity": 2}
-    assert graph_snapshot.checksum == "abc123"
-    assert impact_snapshot.regime_context_ref == "world-state-1"
+    assert impact_snapshot.cycle_id == "cycle-1"
     assert events == [
         "metrics",
         "context:7",
@@ -513,7 +511,6 @@ def test_compute_graph_snapshots_writes_once_after_both_snapshots(
     assert result == (graph_snapshot, impact_snapshot)
     assert graph_snapshot.node_count == 2
     assert graph_snapshot.edge_count == 1
-    assert graph_snapshot.checksum == "abc123"
     assert events == [
         "metrics",
         "context",
@@ -738,7 +735,38 @@ def _patch_metrics(
         calls += 1
         return metrics[index]
 
+    def read_metric_payload(client: Any) -> LiveGraphMetrics:
+        node_count, edge_count, key_label_counts, checksum = read_metrics(client)
+        nodes = [
+            {
+                "labels": ["Entity"],
+                "node_id": f"node-{index}",
+                "canonical_entity_id": f"entity-{index}",
+                "properties": {"node_id": f"node-{index}"},
+            }
+            for index in range(1, node_count + 1)
+        ]
+        relationships = [
+            {
+                "source_node_id": "node-1",
+                "target_node_id": "node-2",
+                "relationship_type": "SUPPLY_CHAIN",
+                "edge_id": f"edge-{index}",
+                "properties": {"edge_id": f"edge-{index}"},
+            }
+            for index in range(1, edge_count + 1)
+        ]
+        return LiveGraphMetrics(
+            node_count=node_count,
+            edge_count=edge_count,
+            key_label_counts=key_label_counts,
+            checksum=checksum,
+            nodes=nodes,
+            relationships=relationships,
+        )
+
     monkeypatch.setattr(snapshot_generator, "_read_graph_metrics", read_metrics)
+    monkeypatch.setattr(snapshot_generator, "_read_graph_metric_payload", read_metric_payload)
 
 
 def _status_manager(
@@ -791,11 +819,14 @@ def _propagation_result(graph_generation_id: int = 1) -> PropagationResult:
         activated_paths=[
             {
                 "source_node_id": "node-1",
+                "source_labels": ["Entity"],
                 "target_node_id": "node-2",
+                "target_labels": ["Entity"],
+                "edge_id": "edge-1",
                 "score": 0.7,
             }
         ],
-        impacted_entities=[{"node_id": "node-2", "score": 0.4}],
+        impacted_entities=[{"node_id": "node-2", "labels": ["Entity"], "score": 0.4}],
         channel_breakdown={"fundamental": {"path_count": 1}},
     )
 
@@ -804,8 +835,18 @@ def _impact_snapshot() -> GraphImpactSnapshot:
     return GraphImpactSnapshot(
         cycle_id="cycle-1",
         impact_snapshot_id="impact-1",
-        regime_context_ref="world-state-1",
-        activated_paths=[],
-        impacted_entities=[],
-        channel_breakdown={"fundamental": {}},
+        version="0.1.0",
+        created_at=NOW,
+        target_entities=[
+            {
+                "entity_id": "node-2",
+                "entity_type": "entity",
+                "canonical_id_rule_version": "0.1.0",
+            }
+        ],
+        affected_entities=[],
+        affected_sectors=[],
+        direction="neutral",
+        impact_score=0.0,
+        evidence_refs=["edge-1"],
     )

--- a/tests/unit/test_snapshots.py
+++ b/tests/unit/test_snapshots.py
@@ -240,7 +240,45 @@ def test_build_graph_impact_snapshot_returns_contract_payload() -> None:
     assert [entity.entity_id for entity in impact_snapshot.affected_entities] == ["node-2"]
     assert impact_snapshot.direction == "bullish"
     assert impact_snapshot.impact_score == pytest.approx(0.4)
-    assert impact_snapshot.evidence_refs == ["edge-1"]
+    assert impact_snapshot.evidence_refs == ["fact-1"]
+
+
+def test_build_graph_impact_snapshot_rejects_edge_id_as_evidence_fallback() -> None:
+    propagation_result = _propagation_result()
+    propagation_result.activated_paths[0].pop("evidence_refs")
+
+    with pytest.raises(
+        ValueError,
+        match=r"real evidence references.*paths_without_evidence=\['edge-1'\]",
+    ):
+        build_graph_impact_snapshot(
+            "cycle-1",
+            "world-state-1",
+            propagation_result,
+        )
+
+
+def test_build_graph_impact_snapshot_empty_impact_error_has_context() -> None:
+    propagation_result = PropagationResult(
+        cycle_id="cycle-1",
+        graph_generation_id=1,
+        activated_paths=[],
+        impacted_entities=[],
+        channel_breakdown={"fundamental": {"path_count": 0}},
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "target entity.*cycle_id='cycle-1'.*world_state_ref='world-state-1'.*"
+            "graph_generation_id=1"
+        ),
+    ):
+        build_graph_impact_snapshot(
+            "cycle-1",
+            "world-state-1",
+            propagation_result,
+        )
 
 
 def test_build_graph_impact_snapshot_id_tracks_full_propagation_payload() -> None:
@@ -823,6 +861,7 @@ def _propagation_result(graph_generation_id: int = 1) -> PropagationResult:
                 "target_node_id": "node-2",
                 "target_labels": ["Entity"],
                 "edge_id": "edge-1",
+                "evidence_refs": ["fact-1"],
                 "score": 0.7,
             }
         ],
@@ -848,5 +887,5 @@ def _impact_snapshot() -> GraphImpactSnapshot:
         affected_sectors=[],
         direction="neutral",
         impact_score=0.0,
-        evidence_refs=["edge-1"],
+        evidence_refs=["fact-1"],
     )

--- a/tests/unit/test_status.py
+++ b/tests/unit/test_status.py
@@ -11,7 +11,9 @@ import pytest
 
 import graph_engine
 import graph_engine.status as status_module
-from graph_engine.models import GraphSnapshot, Neo4jGraphStatus
+from graph_engine.models import GraphMetricsSnapshot as GraphSnapshot
+from graph_engine.models import GraphSnapshot as ContractGraphSnapshot
+from graph_engine.models import Neo4jGraphStatus
 from graph_engine.status import (
     GraphStatusManager,
     check_live_graph_consistency,
@@ -553,6 +555,60 @@ def test_check_live_graph_consistency_returns_true_for_matching_snapshot() -> No
 
     assert result is True
     assert store.writes == []
+
+
+def test_check_live_graph_consistency_accepts_contract_snapshot() -> None:
+    client = FakeLiveGraphClient(_metrics_rows())
+    metric_snapshot = _snapshot_from_live_client(client, graph_generation_id=3)
+    contract_snapshot = ContractGraphSnapshot(
+        graph_snapshot_id="graph-snapshot-1",
+        cycle_id="cycle-1",
+        version="0.1.0",
+        created_at=SNAPSHOT_CREATED_AT,
+        node_count=2,
+        edge_count=1,
+        nodes=[
+            {
+                "node_id": "node-a",
+                "labels": ["Entity"],
+                "properties": {"node_id": "node-a", "ticker": "AAA"},
+                "entity": {
+                    "entity_id": "entity-a",
+                    "entity_type": "entity",
+                    "canonical_id_rule_version": "0.1.0",
+                },
+            },
+            {
+                "node_id": "node-b",
+                "labels": ["Entity"],
+                "properties": {"node_id": "node-b", "ticker": "BBB"},
+                "entity": {
+                    "entity_id": "entity-b",
+                    "entity_type": "entity",
+                    "canonical_id_rule_version": "0.1.0",
+                },
+            },
+        ],
+        edges=[
+            {
+                "edge_id": "edge-1",
+                "source_node": "node-a",
+                "target_node": "node-b",
+                "relation_type": "SUPPLY_CHAIN",
+                "properties": {"edge_id": "edge-1", "weight": 0.7},
+            }
+        ],
+    )
+    store = InMemoryStatusStore(_status_from_snapshot(metric_snapshot))
+
+    result = check_live_graph_consistency(
+        "snapshot-1",
+        client=client,  # type: ignore[arg-type]
+        snapshot_reader=StaticSnapshotReader(contract_snapshot),
+        status_manager=GraphStatusManager(store, clock=lambda: NOW),
+    )
+
+    assert result is True
 
 
 def test_check_live_graph_consistency_requires_status_manager_by_default() -> None:


### PR DESCRIPTION
Closes #46

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `benchmarks/artifacts/lite_target_100k_800k.json`, `benchmarks/generate_synthetic.py`, `cross-cutting`, `examples/consumer_stream_layer.py`, `graph_engine/__pycache__/__init__.cpython-314.pyc`, `graph_engine/live_metrics.py`, `graph_engine/propagation/pipeline.py`, `graph_engine/query/service.py`, `graph_engine/reload/service.py`, `graph_engine/snapshots/generator.py`


---
## 背景
`docs/graph-engine.project-doc.md:116` 指定 `contracts` 提供 graph delta / snapshot / impact snapshot schema；`docs/graph-engine.project-doc.md:662-667` 明确要求 `GraphSnapshotSchema`、`GraphImpactSnapshotSchema` 由 `contracts` 定义并发布；`docs/graph-engine.project-doc.md:696` 还把“schema 与 contracts 对齐”列为协议测试项。

同时，`project-ult-contracts#71` 已经记录合同层当前尚未补齐这些共享对象。

## 当前实现
- `graph_engine/models.py:57-68` 本地定义了 `CandidateGraphDelta`。
- `graph_engine/models.py:225-237` 本地定义了 `GraphSnapshot`。
- `graph_engine/models.py:255-266` 本地定义了 `GraphImpactSnapshot`。
- 当前仓库没有任何 `from contracts ...` / `import contracts` 的 Python 依赖，正式对外 schema 仍由本仓库自己持有。

## 影响
下游消费者会把这些结构视为稳定边界，但它们没有落到统一合同层，后续一旦 `main-core`、`stream-layer` 或 `audit` 链路按各自需要扩字段，contract drift 会直接跨仓扩散。

## 建议修复
1. 以 `project-ult-contracts#71` 为前置，补齐 contracts 中的 graph delta / snapshot / impact snapshot schema。
2. 本仓库对外公开的数据结构改为消费或 re-export `contracts` 中的正式 schema，本地仅保留内部运行时对象。
3. 增加 contract tests，至少覆盖：
   - graph delta / snapshot / impact snapshot 与 `contracts` 对齐
   - 协议演进时 schema 变更会被测试阻断
   - 对 `main-core` / `stream-layer` 输出的正式对象不再由本仓库单独发明字段集合。