### PR TITLE
feat(#48): [milestone-5 review] P0: Promotion still uses a local graph delta schema

### DIFF
--- a/graph_engine/promotion/interfaces.py
+++ b/graph_engine/promotion/interfaces.py
@@ -27,6 +27,13 @@ class EntityAnchorReader(Protocol):
         """Return the subset of entity ids that already exist as canonical anchors."""
 
 
+class GraphEndpointResolver(Protocol):
+    """Resolve graph endpoint node ids to their canonical entity anchors."""
+
+    def canonical_entity_ids_for_node_ids(self, node_ids: set[str]) -> dict[str, str]:
+        """Return canonical entity ids for existing graph endpoint node ids."""
+
+
 class CanonicalWriter(Protocol):
     """Persist promoted records into Layer A canonical storage."""
 

--- a/graph_engine/promotion/interfaces.py
+++ b/graph_engine/promotion/interfaces.py
@@ -4,17 +4,19 @@ from __future__ import annotations
 
 from typing import Protocol
 
-from graph_engine.models import FrozenGraphDelta, PromotionPlan
+from contracts.schemas import CandidateGraphDelta
+
+from graph_engine.models import PromotionPlan
 
 
 class CandidateDeltaReader(Protocol):
-    """Read frozen candidate deltas from the upstream canonical input surface."""
+    """Read contract candidate graph deltas from the upstream input surface."""
 
     def read_candidate_graph_deltas(
         self,
         cycle_id: str,
         selection_ref: str,
-    ) -> list[FrozenGraphDelta]:
+    ) -> list[CandidateGraphDelta]:
         """Return candidate graph deltas selected for promotion."""
 
 

--- a/graph_engine/promotion/planner.py
+++ b/graph_engine/promotion/planner.py
@@ -1,10 +1,12 @@
-"""Build canonical graph promotion plans from frozen candidate deltas."""
+"""Adapt contract candidate deltas into canonical graph promotion plans."""
 
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 from datetime import datetime, timezone
-from typing import Any
+from typing import Any, Literal
+
+from contracts.schemas import CandidateGraphDelta
 
 from graph_engine.models import (
     FrozenGraphDelta,
@@ -24,6 +26,57 @@ _FORBIDDEN_PAYLOAD_FIELDS = {
 }
 _VALID_NODE_LABELS = {label.value for label in NodeLabel}
 _VALID_RELATIONSHIP_TYPES = {relationship.value for relationship in RelationshipType}
+_PromotionDeltaType = Literal["node_add", "edge_add", "edge_update", "assertion_add"]
+_CONTRACT_DELTA_TYPES: dict[str, _PromotionDeltaType] = {
+    "add_relation": "edge_add",
+    "create_relation": "edge_add",
+    "edge_add": "edge_add",
+    "edge_update": "edge_update",
+    "update_relation": "edge_update",
+    "upsert_edge": "edge_update",
+    "upsert_relation": "edge_update",
+}
+_CONTRACT_RELATIONSHIP_TYPES = {
+    "assertion_link": RelationshipType.ASSERTION_LINK.value,
+    "belongs_to_sector": RelationshipType.SECTOR_MEMBERSHIP.value,
+    "event_impact": RelationshipType.EVENT_IMPACT.value,
+    "industry_chain": RelationshipType.INDUSTRY_CHAIN.value,
+    "ownership": RelationshipType.OWNERSHIP.value,
+    "sector_membership": RelationshipType.SECTOR_MEMBERSHIP.value,
+    "supply_chain": RelationshipType.SUPPLY_CHAIN.value,
+}
+
+
+def adapt_candidate_graph_delta(
+    delta: CandidateGraphDelta,
+    cycle_id: str,
+) -> FrozenGraphDelta:
+    """Translate a contracts-defined delta into the internal promotion record."""
+
+    promotion_delta_type = _contract_promotion_delta_type(delta)
+    relationship_type = _contract_relationship_type(delta)
+    created_at = datetime.now(timezone.utc)
+    properties = _contract_edge_properties(delta)
+
+    return FrozenGraphDelta(
+        delta_id=delta.delta_id,
+        cycle_id=cycle_id,
+        delta_type=promotion_delta_type,
+        source_entity_ids=_contract_source_entity_ids(delta),
+        payload={
+            "edge": {
+                "edge_id": _contract_edge_id(delta, relationship_type),
+                "source_node_id": delta.source_node,
+                "target_node_id": delta.target_node,
+                "relationship_type": relationship_type,
+                "properties": properties,
+                "weight": _contract_edge_weight(delta, properties),
+                "created_at": created_at,
+                "updated_at": created_at,
+            },
+        },
+        validation_status="frozen",
+    )
 
 
 def validate_entity_anchors(
@@ -43,6 +96,57 @@ def validate_entity_anchors(
         raise ValueError(
             "missing entity anchors: " + ", ".join(missing_entity_ids),
         )
+
+
+def _contract_promotion_delta_type(delta: CandidateGraphDelta) -> _PromotionDeltaType:
+    delta_type = _CONTRACT_DELTA_TYPES.get(delta.delta_type.strip().lower())
+    if delta_type is None:
+        raise ValueError(
+            f"contract delta {delta.delta_id} uses unsupported delta_type "
+            f"{delta.delta_type!r}",
+        )
+    return delta_type
+
+
+def _contract_relationship_type(delta: CandidateGraphDelta) -> str:
+    relation_type = delta.relation_type.strip()
+    if relation_type in _VALID_RELATIONSHIP_TYPES:
+        return relation_type
+
+    mapped_relation_type = _CONTRACT_RELATIONSHIP_TYPES.get(relation_type.lower())
+    if mapped_relation_type is not None:
+        return mapped_relation_type
+
+    return relation_type
+
+
+def _contract_edge_id(delta: CandidateGraphDelta, relationship_type: str) -> str:
+    return "|".join((delta.source_node, relationship_type, delta.target_node))
+
+
+def _contract_source_entity_ids(delta: CandidateGraphDelta) -> list[str]:
+    return [delta.source_node]
+
+
+def _contract_edge_properties(delta: CandidateGraphDelta) -> dict[str, Any]:
+    properties = dict(delta.properties)
+    properties["contract_delta_id"] = delta.delta_id
+    properties["contract_delta_type"] = delta.delta_type
+    properties["evidence_refs"] = list(delta.evidence)
+    properties["subsystem_id"] = delta.subsystem_id
+    return properties
+
+
+def _contract_edge_weight(
+    delta: CandidateGraphDelta,
+    properties: Mapping[str, Any],
+) -> float:
+    weight = properties.get("weight", 1.0)
+    if isinstance(weight, bool) or not isinstance(weight, int | float):
+        raise ValueError(
+            f"contract delta {delta.delta_id} property 'weight' must be numeric",
+        )
+    return float(weight)
 
 
 def build_promotion_plan(

--- a/graph_engine/promotion/planner.py
+++ b/graph_engine/promotion/planner.py
@@ -62,7 +62,7 @@ def adapt_candidate_graph_delta(
         delta_id=delta.delta_id,
         cycle_id=cycle_id,
         delta_type=promotion_delta_type,
-        source_entity_ids=_contract_source_entity_ids(delta),
+        source_entity_ids=_contract_endpoint_entity_ids(delta),
         payload={
             "edge": {
                 "edge_id": _contract_edge_id(delta, relationship_type),
@@ -83,7 +83,7 @@ def validate_entity_anchors(
     deltas: Sequence[FrozenGraphDelta],
     entity_reader: EntityAnchorReader,
 ) -> None:
-    """Fail if any source entity ids referenced by deltas are missing."""
+    """Fail if any entity anchors referenced by deltas are missing."""
 
     entity_ids = {
         entity_id
@@ -124,8 +124,10 @@ def _contract_edge_id(delta: CandidateGraphDelta, relationship_type: str) -> str
     return "|".join((delta.source_node, relationship_type, delta.target_node))
 
 
-def _contract_source_entity_ids(delta: CandidateGraphDelta) -> list[str]:
-    return [delta.source_node]
+def _contract_endpoint_entity_ids(delta: CandidateGraphDelta) -> list[str]:
+    if delta.source_node == delta.target_node:
+        return [delta.source_node]
+    return [delta.source_node, delta.target_node]
 
 
 def _contract_edge_properties(delta: CandidateGraphDelta) -> dict[str, Any]:

--- a/graph_engine/promotion/planner.py
+++ b/graph_engine/promotion/planner.py
@@ -15,7 +15,7 @@ from graph_engine.models import (
     GraphNodeRecord,
     PromotionPlan,
 )
-from graph_engine.promotion.interfaces import EntityAnchorReader
+from graph_engine.promotion.interfaces import EntityAnchorReader, GraphEndpointResolver
 from graph_engine.schema.definitions import NodeLabel, RelationshipType
 
 _FORBIDDEN_PAYLOAD_FIELDS = {
@@ -50,6 +50,7 @@ _CONTRACT_RELATIONSHIP_TYPES = {
 def adapt_candidate_graph_delta(
     delta: CandidateGraphDelta,
     cycle_id: str,
+    endpoint_entity_ids: Mapping[str, str],
 ) -> FrozenGraphDelta:
     """Translate a contracts-defined delta into the internal promotion record."""
 
@@ -62,7 +63,7 @@ def adapt_candidate_graph_delta(
         delta_id=delta.delta_id,
         cycle_id=cycle_id,
         delta_type=promotion_delta_type,
-        source_entity_ids=_contract_endpoint_entity_ids(delta),
+        source_entity_ids=_contract_endpoint_entity_ids(delta, endpoint_entity_ids),
         payload={
             "edge": {
                 "edge_id": _contract_edge_id(delta, relationship_type),
@@ -77,6 +78,46 @@ def adapt_candidate_graph_delta(
         },
         validation_status="frozen",
     )
+
+
+def resolve_contract_endpoint_entity_ids(
+    deltas: Sequence[CandidateGraphDelta],
+    endpoint_resolver: GraphEndpointResolver,
+) -> dict[str, str]:
+    """Map contract graph endpoint node ids to canonical entity anchors."""
+
+    node_ids = {
+        node_id
+        for delta in deltas
+        for node_id in _contract_endpoint_node_ids(delta)
+    }
+    if not node_ids:
+        return {}
+
+    endpoint_entity_ids = endpoint_resolver.canonical_entity_ids_for_node_ids(node_ids)
+    missing_node_ids = sorted(node_ids - set(endpoint_entity_ids))
+    if missing_node_ids:
+        raise ValueError(
+            "missing graph endpoint nodes: " + ", ".join(missing_node_ids),
+        )
+
+    resolved_endpoint_entity_ids: dict[str, str] = {}
+    invalid_anchor_node_ids: list[str] = []
+    for node_id in node_ids:
+        entity_id = endpoint_entity_ids[node_id]
+        if not isinstance(entity_id, str) or not entity_id.strip():
+            invalid_anchor_node_ids.append(node_id)
+            continue
+        resolved_endpoint_entity_ids[node_id] = entity_id.strip()
+
+    invalid_anchor_node_ids.sort()
+    if invalid_anchor_node_ids:
+        raise ValueError(
+            "graph endpoint nodes missing canonical entity anchors: "
+            + ", ".join(invalid_anchor_node_ids),
+        )
+
+    return resolved_endpoint_entity_ids
 
 
 def validate_entity_anchors(
@@ -124,10 +165,24 @@ def _contract_edge_id(delta: CandidateGraphDelta, relationship_type: str) -> str
     return "|".join((delta.source_node, relationship_type, delta.target_node))
 
 
-def _contract_endpoint_entity_ids(delta: CandidateGraphDelta) -> list[str]:
+def _contract_endpoint_node_ids(delta: CandidateGraphDelta) -> list[str]:
     if delta.source_node == delta.target_node:
         return [delta.source_node]
     return [delta.source_node, delta.target_node]
+
+
+def _contract_endpoint_entity_ids(
+    delta: CandidateGraphDelta,
+    endpoint_entity_ids: Mapping[str, str],
+) -> list[str]:
+    entity_ids: list[str] = []
+    for node_id in _contract_endpoint_node_ids(delta):
+        entity_id = endpoint_entity_ids.get(node_id)
+        if entity_id is None:
+            raise ValueError(f"missing graph endpoint nodes: {node_id}")
+        if entity_id not in entity_ids:
+            entity_ids.append(entity_id)
+    return entity_ids
 
 
 def _contract_edge_properties(delta: CandidateGraphDelta) -> dict[str, Any]:

--- a/graph_engine/promotion/service.py
+++ b/graph_engine/promotion/service.py
@@ -9,7 +9,11 @@ from graph_engine.promotion.interfaces import (
     CanonicalWriter,
     EntityAnchorReader,
 )
-from graph_engine.promotion.planner import build_promotion_plan, validate_entity_anchors
+from graph_engine.promotion.planner import (
+    adapt_candidate_graph_delta,
+    build_promotion_plan,
+    validate_entity_anchors,
+)
 from graph_engine.status import GraphStatusManager
 from graph_engine.sync import sync_live_graph
 
@@ -25,14 +29,18 @@ def promote_graph_deltas(
     status_manager: GraphStatusManager | None = None,
     sync_to_live_graph: bool = True,
 ) -> PromotionPlan:
-    """Promote selected frozen graph deltas, then optionally mirror them to Neo4j."""
+    """Promote selected contract graph deltas, then optionally mirror them to Neo4j."""
 
     if sync_to_live_graph and client is None:
         raise ValueError("client is required when sync_to_live_graph is True")
     if sync_to_live_graph and status_manager is None:
         raise ValueError("status_manager is required when sync_to_live_graph is True")
 
-    deltas = candidate_reader.read_candidate_graph_deltas(cycle_id, selection_ref)
+    candidate_deltas = candidate_reader.read_candidate_graph_deltas(cycle_id, selection_ref)
+    deltas = [
+        adapt_candidate_graph_delta(delta, cycle_id)
+        for delta in candidate_deltas
+    ]
     validate_entity_anchors(deltas, entity_reader)
     plan = build_promotion_plan(cycle_id, selection_ref, deltas)
 

--- a/graph_engine/promotion/service.py
+++ b/graph_engine/promotion/service.py
@@ -8,10 +8,12 @@ from graph_engine.promotion.interfaces import (
     CandidateDeltaReader,
     CanonicalWriter,
     EntityAnchorReader,
+    GraphEndpointResolver,
 )
 from graph_engine.promotion.planner import (
     adapt_candidate_graph_delta,
     build_promotion_plan,
+    resolve_contract_endpoint_entity_ids,
     validate_entity_anchors,
 )
 from graph_engine.status import GraphStatusManager
@@ -24,6 +26,7 @@ def promote_graph_deltas(
     *,
     candidate_reader: CandidateDeltaReader,
     entity_reader: EntityAnchorReader,
+    endpoint_resolver: GraphEndpointResolver,
     canonical_writer: CanonicalWriter,
     client: Neo4jClient | None = None,
     status_manager: GraphStatusManager | None = None,
@@ -37,8 +40,12 @@ def promote_graph_deltas(
         raise ValueError("status_manager is required when sync_to_live_graph is True")
 
     candidate_deltas = candidate_reader.read_candidate_graph_deltas(cycle_id, selection_ref)
+    endpoint_entity_ids = resolve_contract_endpoint_entity_ids(
+        candidate_deltas,
+        endpoint_resolver,
+    )
     deltas = [
-        adapt_candidate_graph_delta(delta, cycle_id)
+        adapt_candidate_graph_delta(delta, cycle_id, endpoint_entity_ids)
         for delta in candidate_deltas
     ]
     validate_entity_anchors(deltas, entity_reader)

--- a/tests/integration/test_promotion_sync.py
+++ b/tests/integration/test_promotion_sync.py
@@ -97,7 +97,7 @@ def test_repeated_promotion_sync_is_idempotent_in_live_graph() -> None:
                     "selection-1",
                     candidate_reader=StaticCandidateReader(deltas),
                     entity_reader=StaticEntityReader(
-                        {source_node_id},
+                        {source_node_id, target_node_id},
                     ),
                     canonical_writer=writer,
                     client=client,

--- a/tests/integration/test_promotion_sync.py
+++ b/tests/integration/test_promotion_sync.py
@@ -51,6 +51,18 @@ class StaticEntityReader:
         return entity_ids & self.entity_ids
 
 
+class StaticGraphEndpointResolver:
+    def __init__(self, entity_ids_by_node_id: dict[str, str]) -> None:
+        self.entity_ids_by_node_id = entity_ids_by_node_id
+
+    def canonical_entity_ids_for_node_ids(self, node_ids: set[str]) -> dict[str, str]:
+        return {
+            node_id: entity_id
+            for node_id, entity_id in self.entity_ids_by_node_id.items()
+            if node_id in node_ids
+        }
+
+
 class CapturingCanonicalWriter:
     def __init__(self) -> None:
         self.plans: list[PromotionPlan] = []
@@ -97,7 +109,13 @@ def test_repeated_promotion_sync_is_idempotent_in_live_graph() -> None:
                     "selection-1",
                     candidate_reader=StaticCandidateReader(deltas),
                     entity_reader=StaticEntityReader(
-                        {source_node_id, target_node_id},
+                        {f"{source_node_id}-entity", f"{target_node_id}-entity"},
+                    ),
+                    endpoint_resolver=StaticGraphEndpointResolver(
+                        {
+                            source_node_id: f"{source_node_id}-entity",
+                            target_node_id: f"{target_node_id}-entity",
+                        },
                     ),
                     canonical_writer=writer,
                     client=client,

--- a/tests/integration/test_promotion_sync.py
+++ b/tests/integration/test_promotion_sync.py
@@ -10,7 +10,7 @@ import pytest
 from graph_engine.client import Neo4jClient
 from graph_engine.config import load_config_from_env
 from graph_engine.models import (
-    FrozenGraphDelta,
+    CandidateGraphDelta,
     GraphEdgeRecord,
     GraphNodeRecord,
     Neo4jGraphStatus,
@@ -32,14 +32,14 @@ NOW = datetime(2026, 4, 17, 1, 2, 3, tzinfo=timezone.utc)
 
 
 class StaticCandidateReader:
-    def __init__(self, deltas: list[FrozenGraphDelta]) -> None:
+    def __init__(self, deltas: list[CandidateGraphDelta]) -> None:
         self.deltas = deltas
 
     def read_candidate_graph_deltas(
         self,
         cycle_id: str,
         selection_ref: str,
-    ) -> list[FrozenGraphDelta]:
+    ) -> list[CandidateGraphDelta]:
         return self.deltas
 
 
@@ -64,27 +64,20 @@ def test_repeated_promotion_sync_is_idempotent_in_live_graph() -> None:
     prefix = f"promotion-sync-{uuid4().hex}"
     source_node_id = f"{prefix}-source"
     target_node_id = f"{prefix}-target"
-    assertion_id = f"{prefix}-assertion"
-    edge_id = f"{prefix}-edge"
-    node_ids = [source_node_id, target_node_id, assertion_id]
+    edge_id = f"{source_node_id}|{RelationshipType.SUPPLY_CHAIN.value}|{target_node_id}"
+    node_ids = [source_node_id, target_node_id]
     deltas = [
-        _node_delta("delta-1", source_node_id, f"{prefix}-entity-source"),
-        _node_delta("delta-2", target_node_id, f"{prefix}-entity-target"),
-        _edge_delta(
-            "delta-3",
-            edge_id,
+        _contract_delta(
+            "delta-1",
             source_node_id,
             target_node_id,
-            [f"{prefix}-entity-source", f"{prefix}-entity-target"],
-        ),
-        _assertion_delta(
-            "delta-4",
-            assertion_id,
-            source_node_id,
-            target_node_id,
-            [f"{prefix}-entity-source", f"{prefix}-entity-target"],
+            {
+                **_edge_properties(edge_id),
+                "weight": 0.7,
+            },
         ),
     ]
+    endpoint_plan = _direct_node_sync_plan(source_node_id, target_node_id)
     writer = CapturingCanonicalWriter()
 
     with Neo4jClient(load_config_from_env()) as client:
@@ -97,25 +90,25 @@ def test_repeated_promotion_sync_is_idempotent_in_live_graph() -> None:
         status_manager = GraphStatusManager(InMemoryStatusStore(_ready_status()))
 
         try:
+            sync_live_graph(endpoint_plan, client)
             for _ in range(2):
                 promote_graph_deltas(
                     "cycle-1",
                     "selection-1",
                     candidate_reader=StaticCandidateReader(deltas),
                     entity_reader=StaticEntityReader(
-                        {f"{prefix}-entity-source", f"{prefix}-entity-target"},
+                        {source_node_id},
                     ),
                     canonical_writer=writer,
                     client=client,
                     status_manager=status_manager,
                 )
 
-            counts = _live_graph_counts(client, node_ids, edge_id, assertion_id)
+            counts = _live_graph_counts(client, node_ids, edge_id)
             serialized_payloads = _live_graph_serialized_payloads(
                 client,
                 source_node_id,
                 edge_id,
-                assertion_id,
             )
         finally:
             client.execute_write(
@@ -127,21 +120,26 @@ def test_repeated_promotion_sync_is_idempotent_in_live_graph() -> None:
     assert counts == {
         "business_nodes": 2,
         "business_edges": 1,
-        "assertion_nodes": 1,
-        "assertion_links": 2,
     }
     assert serialized_payloads == {
         "node_properties_json": _json_payload(_node_properties(source_node_id)),
         "node_integration_prefix": source_node_id,
         "node_metadata": None,
         "node_mixed_aliases": None,
-        "edge_properties_json": _json_payload(_edge_properties(edge_id)),
+        "edge_properties_json": _json_payload(
+            {
+                **_edge_properties(edge_id),
+                "contract_delta_id": "delta-1",
+                "contract_delta_type": "upsert_relation",
+                "evidence_refs": ["fact-1"],
+                "subsystem_id": "subsystem-news",
+                "weight": 0.7,
+            },
+        ),
         "edge_integration_prefix": edge_id,
         "edge_metadata": None,
         "edge_mixed_aliases": None,
         "edge_properties": None,
-        "assertion_evidence_json": _json_payload(_assertion_evidence()),
-        "assertion_evidence": None,
     }
 
 
@@ -209,7 +207,6 @@ def _live_graph_counts(
     client: Neo4jClient,
     node_ids: list[str],
     edge_id: str,
-    assertion_id: str,
 ) -> dict[str, int]:
     rows = client.execute_read(
         """
@@ -217,24 +214,17 @@ MATCH (business_node)
 WHERE business_node.node_id IN $business_node_ids
 WITH count(business_node) AS business_nodes
 MATCH ()-[business_edge:SUPPLY_CHAIN {edge_id: $edge_id}]->()
-WITH business_nodes, count(business_edge) AS business_edges
-MATCH (assertion:Assertion {node_id: $assertion_id})
-WITH business_nodes, business_edges, count(assertion) AS assertion_nodes
-MATCH ()-[assertion_link:ASSERTION_LINK {assertion_id: $assertion_id}]-()
-RETURN business_nodes, business_edges, assertion_nodes, count(assertion_link) AS assertion_links
+RETURN business_nodes, count(business_edge) AS business_edges
 """,
         {
-            "business_node_ids": node_ids[:2],
+            "business_node_ids": node_ids,
             "edge_id": edge_id,
-            "assertion_id": assertion_id,
         },
     )
     row = rows[0]
     return {
         "business_nodes": row["business_nodes"],
         "business_edges": row["business_edges"],
-        "assertion_nodes": row["assertion_nodes"],
-        "assertion_links": row["assertion_links"],
     }
 
 
@@ -242,13 +232,11 @@ def _live_graph_serialized_payloads(
     client: Neo4jClient,
     source_node_id: str,
     edge_id: str,
-    assertion_id: str,
 ) -> dict[str, object]:
     rows = client.execute_read(
         """
 MATCH (node {node_id: $source_node_id})
 MATCH ()-[edge:SUPPLY_CHAIN {edge_id: $edge_id}]->()
-MATCH (assertion:Assertion {node_id: $assertion_id})
 RETURN node.properties_json AS node_properties_json,
        node.integration_prefix AS node_integration_prefix,
        node.metadata AS node_metadata,
@@ -257,14 +245,11 @@ RETURN node.properties_json AS node_properties_json,
        edge.integration_prefix AS edge_integration_prefix,
        edge.metadata AS edge_metadata,
        edge.mixed_aliases AS edge_mixed_aliases,
-       edge.properties AS edge_properties,
-       assertion.evidence_json AS assertion_evidence_json,
-       assertion.evidence AS assertion_evidence
+       edge.properties AS edge_properties
 """,
         {
             "source_node_id": source_node_id,
             "edge_id": edge_id,
-            "assertion_id": assertion_id,
         },
     )
     return rows[0]
@@ -303,6 +288,38 @@ RETURN node.score AS node_score,
         },
     )
     return rows[0]
+
+
+def _direct_node_sync_plan(
+    source_node_id: str,
+    target_node_id: str,
+) -> PromotionPlan:
+    return PromotionPlan(
+        cycle_id="cycle-1",
+        selection_ref="selection-1",
+        delta_ids=["endpoint-nodes"],
+        node_records=[
+            GraphNodeRecord(
+                node_id=source_node_id,
+                canonical_entity_id=f"{source_node_id}-entity",
+                label=NodeLabel.ENTITY.value,
+                properties=_node_properties(source_node_id),
+                created_at=NOW,
+                updated_at=NOW,
+            ),
+            GraphNodeRecord(
+                node_id=target_node_id,
+                canonical_entity_id=f"{target_node_id}-entity",
+                label=NodeLabel.ENTITY.value,
+                properties={},
+                created_at=NOW,
+                updated_at=NOW,
+            ),
+        ],
+        edge_records=[],
+        assertion_records=[],
+        created_at=NOW,
+    )
 
 
 def _direct_sync_plan(
@@ -352,82 +369,21 @@ def _direct_sync_plan(
     )
 
 
-def _node_delta(
+def _contract_delta(
     delta_id: str,
-    node_id: str,
-    canonical_entity_id: str,
-) -> FrozenGraphDelta:
-    return FrozenGraphDelta(
-        delta_id=delta_id,
-        cycle_id="cycle-1",
-        delta_type="node_add",
-        source_entity_ids=[canonical_entity_id],
-        payload={
-            "node": {
-                "node_id": node_id,
-                "canonical_entity_id": canonical_entity_id,
-                "label": NodeLabel.ENTITY.value,
-                "properties": _node_properties(node_id),
-                "created_at": NOW,
-                "updated_at": NOW,
-            }
-        },
-        validation_status="frozen",
-    )
-
-
-def _edge_delta(
-    delta_id: str,
-    edge_id: str,
     source_node_id: str,
     target_node_id: str,
-    source_entity_ids: list[str],
-) -> FrozenGraphDelta:
-    return FrozenGraphDelta(
+    properties: dict[str, object],
+) -> CandidateGraphDelta:
+    return CandidateGraphDelta(
         delta_id=delta_id,
-        cycle_id="cycle-1",
-        delta_type="edge_add",
-        source_entity_ids=source_entity_ids,
-        payload={
-            "edge": {
-                "edge_id": edge_id,
-                "source_node_id": source_node_id,
-                "target_node_id": target_node_id,
-                "relationship_type": RelationshipType.SUPPLY_CHAIN.value,
-                "properties": _edge_properties(edge_id),
-                "weight": 0.7,
-                "created_at": NOW,
-                "updated_at": NOW,
-            }
-        },
-        validation_status="frozen",
-    )
-
-
-def _assertion_delta(
-    delta_id: str,
-    assertion_id: str,
-    source_node_id: str,
-    target_node_id: str,
-    source_entity_ids: list[str],
-) -> FrozenGraphDelta:
-    return FrozenGraphDelta(
-        delta_id=delta_id,
-        cycle_id="cycle-1",
-        delta_type="assertion_add",
-        source_entity_ids=source_entity_ids,
-        payload={
-            "assertion": {
-                "assertion_id": assertion_id,
-                "source_node_id": source_node_id,
-                "target_node_id": target_node_id,
-                "assertion_type": "integration",
-                "evidence": _assertion_evidence(),
-                "confidence": 0.9,
-                "created_at": NOW,
-            }
-        },
-        validation_status="frozen",
+        delta_type="upsert_relation",
+        source_node=source_node_id,
+        target_node=target_node_id,
+        relation_type=RelationshipType.SUPPLY_CHAIN.value,
+        properties=properties,
+        evidence=["fact-1"],
+        subsystem_id="subsystem-news",
     )
 
 
@@ -444,13 +400,6 @@ def _edge_properties(edge_id: str) -> dict[str, object]:
         "integration_prefix": edge_id,
         "mixed_aliases": ["SUPPLY_CHAIN", 1],
         "metadata": {"source_system": "fixture"},
-    }
-
-
-def _assertion_evidence() -> dict[str, object]:
-    return {
-        "source": "test",
-        "documents": [{"document_id": "doc-1"}],
     }
 
 

--- a/tests/unit/test_promotion.py
+++ b/tests/unit/test_promotion.py
@@ -132,7 +132,7 @@ def test_contract_candidate_graph_delta_adapts_to_internal_edge_record() -> None
     promotion_delta = adapt_candidate_graph_delta(contract_delta, "cycle-1")
     plan = build_promotion_plan("cycle-1", "selection-1", [promotion_delta])
 
-    assert promotion_delta.source_entity_ids == ["node-1"]
+    assert promotion_delta.source_entity_ids == ["node-1", "node-2"]
     assert plan.delta_ids == ["delta-1"]
     assert len(plan.edge_records) == 1
     edge_record = plan.edge_records[0]
@@ -242,7 +242,7 @@ def test_promote_graph_deltas_writes_canonical_before_live_graph(
         candidate_reader=FakeCandidateReader([
             _contract_delta("delta-1"),
         ]),
-        entity_reader=FakeEntityReader({"node-1"}),
+        entity_reader=FakeEntityReader({"node-1", "node-2"}),
         canonical_writer=writer,
         client=mock_client,
         status_manager=_status_manager_from_store(store),
@@ -261,6 +261,27 @@ def test_promote_graph_deltas_writes_canonical_before_live_graph(
     assert store.status == _status()
 
 
+def test_promote_graph_deltas_rejects_missing_target_anchor_before_canonical_write() -> None:
+    writer = FakeCanonicalWriter()
+    entity_reader = FakeEntityReader({"node-1"})
+
+    with pytest.raises(ValueError, match="node-2"):
+        promote_graph_deltas(
+            "cycle-1",
+            "selection-1",
+            candidate_reader=FakeCandidateReader([
+                _contract_delta("delta-1"),
+            ]),
+            entity_reader=entity_reader,
+            canonical_writer=writer,
+            sync_to_live_graph=False,
+        )
+
+    assert entity_reader.calls == [{"node-1", "node-2"}]
+    assert writer.calls == []
+    assert writer.plans == []
+
+
 def test_promote_graph_deltas_does_not_sync_when_canonical_write_fails(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -274,7 +295,7 @@ def test_promote_graph_deltas_does_not_sync_when_canonical_write_fails(
             candidate_reader=FakeCandidateReader([
                 _contract_delta("delta-1"),
             ]),
-            entity_reader=FakeEntityReader({"node-1"}),
+            entity_reader=FakeEntityReader({"node-1", "node-2"}),
             canonical_writer=FakeCanonicalWriter(fail=True),
             client=MagicMock(spec=Neo4jClient),
             status_manager=_status_manager(),
@@ -294,7 +315,7 @@ def test_promote_graph_deltas_requires_status_manager_for_live_sync() -> None:
             "cycle-1",
             "selection-1",
             candidate_reader=reader,
-            entity_reader=FakeEntityReader({"node-1"}),
+            entity_reader=FakeEntityReader({"node-1", "node-2"}),
             canonical_writer=writer,
             client=MagicMock(spec=Neo4jClient),
         )
@@ -317,7 +338,7 @@ def test_promote_graph_deltas_blocks_live_sync_when_graph_is_not_ready(
             candidate_reader=FakeCandidateReader([
                 _contract_delta("delta-1"),
             ]),
-            entity_reader=FakeEntityReader({"node-1"}),
+            entity_reader=FakeEntityReader({"node-1", "node-2"}),
             canonical_writer=writer,
             client=MagicMock(spec=Neo4jClient),
             status_manager=_status_manager(graph_status="rebuilding"),
@@ -342,7 +363,7 @@ def test_promote_graph_deltas_rejects_stale_status_before_live_sync(
             candidate_reader=FakeCandidateReader([
                 _contract_delta("delta-1"),
             ]),
-            entity_reader=FakeEntityReader({"node-1"}),
+            entity_reader=FakeEntityReader({"node-1", "node-2"}),
             canonical_writer=writer,
             client=MagicMock(spec=Neo4jClient),
             status_manager=status_manager,
@@ -366,7 +387,7 @@ def test_promote_graph_deltas_does_not_sync_if_rebuild_starts_after_barrier(
             candidate_reader=FakeCandidateReader([
                 _contract_delta("delta-1"),
             ]),
-            entity_reader=FakeEntityReader({"node-1"}),
+            entity_reader=FakeEntityReader({"node-1", "node-2"}),
             canonical_writer=FakeCanonicalWriter(),
             client=MagicMock(spec=Neo4jClient),
             status_manager=_status_manager_from_store(store),
@@ -397,7 +418,7 @@ def test_promote_graph_deltas_detects_status_change_during_live_sync(
             candidate_reader=FakeCandidateReader([
                 _contract_delta("delta-1"),
             ]),
-            entity_reader=FakeEntityReader({"node-1"}),
+            entity_reader=FakeEntityReader({"node-1", "node-2"}),
             canonical_writer=writer,
             client=MagicMock(spec=Neo4jClient),
             status_manager=_status_manager_from_store(store),
@@ -424,7 +445,7 @@ def test_promote_graph_deltas_marks_status_failed_when_live_sync_fails(
             candidate_reader=FakeCandidateReader([
                 _contract_delta("delta-1"),
             ]),
-            entity_reader=FakeEntityReader({"node-1"}),
+            entity_reader=FakeEntityReader({"node-1", "node-2"}),
             canonical_writer=FakeCanonicalWriter(),
             client=MagicMock(spec=Neo4jClient),
             status_manager=_status_manager_from_store(store),
@@ -443,7 +464,7 @@ def test_promote_graph_deltas_can_skip_live_graph_sync() -> None:
         candidate_reader=FakeCandidateReader([
             _contract_delta("delta-1"),
         ]),
-        entity_reader=FakeEntityReader({"node-1"}),
+        entity_reader=FakeEntityReader({"node-1", "node-2"}),
         canonical_writer=writer,
         sync_to_live_graph=False,
     )

--- a/tests/unit/test_promotion.py
+++ b/tests/unit/test_promotion.py
@@ -52,6 +52,20 @@ class FakeEntityReader:
         return self.existing_ids
 
 
+class FakeGraphEndpointResolver:
+    def __init__(self, entity_ids_by_node_id: dict[str, str]) -> None:
+        self.entity_ids_by_node_id = entity_ids_by_node_id
+        self.calls: list[set[str]] = []
+
+    def canonical_entity_ids_for_node_ids(self, node_ids: set[str]) -> dict[str, str]:
+        self.calls.append(node_ids)
+        return {
+            node_id: entity_id
+            for node_id, entity_id in self.entity_ids_by_node_id.items()
+            if node_id in node_ids
+        }
+
+
 class FakeCanonicalWriter:
     def __init__(self, calls: list[str] | None = None, fail: bool = False) -> None:
         self.calls = calls if calls is not None else []
@@ -129,10 +143,14 @@ def test_contract_candidate_graph_delta_adapts_to_internal_edge_record() -> None
         properties={"weight": 0.4},
     )
 
-    promotion_delta = adapt_candidate_graph_delta(contract_delta, "cycle-1")
+    promotion_delta = adapt_candidate_graph_delta(
+        contract_delta,
+        "cycle-1",
+        {"node-1": "entity-1", "node-2": "entity-2"},
+    )
     plan = build_promotion_plan("cycle-1", "selection-1", [promotion_delta])
 
-    assert promotion_delta.source_entity_ids == ["node-1", "node-2"]
+    assert promotion_delta.source_entity_ids == ["entity-1", "entity-2"]
     assert plan.delta_ids == ["delta-1"]
     assert len(plan.edge_records) == 1
     edge_record = plan.edge_records[0]
@@ -242,7 +260,8 @@ def test_promote_graph_deltas_writes_canonical_before_live_graph(
         candidate_reader=FakeCandidateReader([
             _contract_delta("delta-1"),
         ]),
-        entity_reader=FakeEntityReader({"node-1", "node-2"}),
+        entity_reader=FakeEntityReader({"entity-1", "entity-2"}),
+        endpoint_resolver=_endpoint_resolver(),
         canonical_writer=writer,
         client=mock_client,
         status_manager=_status_manager_from_store(store),
@@ -263,9 +282,10 @@ def test_promote_graph_deltas_writes_canonical_before_live_graph(
 
 def test_promote_graph_deltas_rejects_missing_target_anchor_before_canonical_write() -> None:
     writer = FakeCanonicalWriter()
-    entity_reader = FakeEntityReader({"node-1"})
+    entity_reader = FakeEntityReader({"entity-1"})
+    endpoint_resolver = _endpoint_resolver()
 
-    with pytest.raises(ValueError, match="node-2"):
+    with pytest.raises(ValueError, match="entity-2"):
         promote_graph_deltas(
             "cycle-1",
             "selection-1",
@@ -273,11 +293,44 @@ def test_promote_graph_deltas_rejects_missing_target_anchor_before_canonical_wri
                 _contract_delta("delta-1"),
             ]),
             entity_reader=entity_reader,
+            endpoint_resolver=endpoint_resolver,
             canonical_writer=writer,
             sync_to_live_graph=False,
         )
 
-    assert entity_reader.calls == [{"node-1", "node-2"}]
+    assert endpoint_resolver.calls == [{"node-1", "node-2"}]
+    assert entity_reader.calls == [{"entity-1", "entity-2"}]
+    assert writer.calls == []
+    assert writer.plans == []
+
+
+def test_promote_graph_deltas_rejects_bad_contract_endpoint_node_before_canonical_write() -> None:
+    writer = FakeCanonicalWriter()
+    entity_reader = FakeEntityReader({"entity-a", "entity-b"})
+    endpoint_resolver = FakeGraphEndpointResolver({
+        "node-a": "entity-a",
+        "node-b": "entity-b",
+    })
+
+    with pytest.raises(ValueError, match="missing graph endpoint nodes: entity-b"):
+        promote_graph_deltas(
+            "cycle-1",
+            "selection-1",
+            candidate_reader=FakeCandidateReader([
+                _contract_delta(
+                    "delta-1",
+                    source_node="node-a",
+                    target_node="entity-b",
+                ),
+            ]),
+            entity_reader=entity_reader,
+            endpoint_resolver=endpoint_resolver,
+            canonical_writer=writer,
+            sync_to_live_graph=False,
+        )
+
+    assert endpoint_resolver.calls == [{"entity-b", "node-a"}]
+    assert entity_reader.calls == []
     assert writer.calls == []
     assert writer.plans == []
 
@@ -295,7 +348,8 @@ def test_promote_graph_deltas_does_not_sync_when_canonical_write_fails(
             candidate_reader=FakeCandidateReader([
                 _contract_delta("delta-1"),
             ]),
-            entity_reader=FakeEntityReader({"node-1", "node-2"}),
+            entity_reader=FakeEntityReader({"entity-1", "entity-2"}),
+            endpoint_resolver=_endpoint_resolver(),
             canonical_writer=FakeCanonicalWriter(fail=True),
             client=MagicMock(spec=Neo4jClient),
             status_manager=_status_manager(),
@@ -315,7 +369,8 @@ def test_promote_graph_deltas_requires_status_manager_for_live_sync() -> None:
             "cycle-1",
             "selection-1",
             candidate_reader=reader,
-            entity_reader=FakeEntityReader({"node-1", "node-2"}),
+            entity_reader=FakeEntityReader({"entity-1", "entity-2"}),
+            endpoint_resolver=_endpoint_resolver(),
             canonical_writer=writer,
             client=MagicMock(spec=Neo4jClient),
         )
@@ -338,7 +393,8 @@ def test_promote_graph_deltas_blocks_live_sync_when_graph_is_not_ready(
             candidate_reader=FakeCandidateReader([
                 _contract_delta("delta-1"),
             ]),
-            entity_reader=FakeEntityReader({"node-1", "node-2"}),
+            entity_reader=FakeEntityReader({"entity-1", "entity-2"}),
+            endpoint_resolver=_endpoint_resolver(),
             canonical_writer=writer,
             client=MagicMock(spec=Neo4jClient),
             status_manager=_status_manager(graph_status="rebuilding"),
@@ -363,7 +419,8 @@ def test_promote_graph_deltas_rejects_stale_status_before_live_sync(
             candidate_reader=FakeCandidateReader([
                 _contract_delta("delta-1"),
             ]),
-            entity_reader=FakeEntityReader({"node-1", "node-2"}),
+            entity_reader=FakeEntityReader({"entity-1", "entity-2"}),
+            endpoint_resolver=_endpoint_resolver(),
             canonical_writer=writer,
             client=MagicMock(spec=Neo4jClient),
             status_manager=status_manager,
@@ -387,7 +444,8 @@ def test_promote_graph_deltas_does_not_sync_if_rebuild_starts_after_barrier(
             candidate_reader=FakeCandidateReader([
                 _contract_delta("delta-1"),
             ]),
-            entity_reader=FakeEntityReader({"node-1", "node-2"}),
+            entity_reader=FakeEntityReader({"entity-1", "entity-2"}),
+            endpoint_resolver=_endpoint_resolver(),
             canonical_writer=FakeCanonicalWriter(),
             client=MagicMock(spec=Neo4jClient),
             status_manager=_status_manager_from_store(store),
@@ -418,7 +476,8 @@ def test_promote_graph_deltas_detects_status_change_during_live_sync(
             candidate_reader=FakeCandidateReader([
                 _contract_delta("delta-1"),
             ]),
-            entity_reader=FakeEntityReader({"node-1", "node-2"}),
+            entity_reader=FakeEntityReader({"entity-1", "entity-2"}),
+            endpoint_resolver=_endpoint_resolver(),
             canonical_writer=writer,
             client=MagicMock(spec=Neo4jClient),
             status_manager=_status_manager_from_store(store),
@@ -445,7 +504,8 @@ def test_promote_graph_deltas_marks_status_failed_when_live_sync_fails(
             candidate_reader=FakeCandidateReader([
                 _contract_delta("delta-1"),
             ]),
-            entity_reader=FakeEntityReader({"node-1", "node-2"}),
+            entity_reader=FakeEntityReader({"entity-1", "entity-2"}),
+            endpoint_resolver=_endpoint_resolver(),
             canonical_writer=FakeCanonicalWriter(),
             client=MagicMock(spec=Neo4jClient),
             status_manager=_status_manager_from_store(store),
@@ -464,7 +524,8 @@ def test_promote_graph_deltas_can_skip_live_graph_sync() -> None:
         candidate_reader=FakeCandidateReader([
             _contract_delta("delta-1"),
         ]),
-        entity_reader=FakeEntityReader({"node-1", "node-2"}),
+        entity_reader=FakeEntityReader({"entity-1", "entity-2"}),
+        endpoint_resolver=_endpoint_resolver(),
         canonical_writer=writer,
         sync_to_live_graph=False,
     )
@@ -516,6 +577,14 @@ def _contract_delta(
         properties=properties or {"weight": 0.7},
         evidence=evidence or ["fact-1"],
         subsystem_id="subsystem-news",
+    )
+
+
+def _endpoint_resolver(
+    entity_ids_by_node_id: dict[str, str] | None = None,
+) -> FakeGraphEndpointResolver:
+    return FakeGraphEndpointResolver(
+        entity_ids_by_node_id or {"node-1": "entity-1", "node-2": "entity-2"},
     )
 
 

--- a/tests/unit/test_promotion.py
+++ b/tests/unit/test_promotion.py
@@ -2,16 +2,25 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from datetime import datetime, timezone
-from typing import Any
+from typing import Any, get_type_hints
 from unittest.mock import MagicMock
 
 import pytest
 
 import graph_engine.promotion.service as service_module
 from graph_engine.client import Neo4jClient
-from graph_engine.models import FrozenGraphDelta, Neo4jGraphStatus, PromotionPlan
+from graph_engine.models import (
+    CandidateGraphDelta,
+    FrozenGraphDelta,
+    Neo4jGraphStatus,
+    PromotionPlan,
+)
 from graph_engine.promotion import build_promotion_plan, promote_graph_deltas
-from graph_engine.promotion.planner import validate_entity_anchors
+from graph_engine.promotion.interfaces import CandidateDeltaReader
+from graph_engine.promotion.planner import (
+    adapt_candidate_graph_delta,
+    validate_entity_anchors,
+)
 from graph_engine.schema.definitions import NodeLabel, RelationshipType
 from graph_engine.status import GraphStatusManager
 from tests.fakes import InMemoryStatusStore
@@ -20,7 +29,7 @@ NOW = datetime(2026, 4, 17, 1, 2, 3, tzinfo=timezone.utc)
 
 
 class FakeCandidateReader:
-    def __init__(self, deltas: list[FrozenGraphDelta]) -> None:
+    def __init__(self, deltas: list[CandidateGraphDelta]) -> None:
         self.deltas = deltas
         self.calls: list[tuple[str, str]] = []
 
@@ -28,7 +37,7 @@ class FakeCandidateReader:
         self,
         cycle_id: str,
         selection_ref: str,
-    ) -> list[FrozenGraphDelta]:
+    ) -> list[CandidateGraphDelta]:
         self.calls.append((cycle_id, selection_ref))
         return self.deltas
 
@@ -106,6 +115,32 @@ def test_validate_entity_anchors_checks_all_source_entities_once() -> None:
         validate_entity_anchors(deltas, entity_reader)
 
     assert entity_reader.calls == [{"entity-1", "entity-2"}]
+
+
+def test_candidate_delta_reader_exposes_contract_delta_shape() -> None:
+    hints = get_type_hints(CandidateDeltaReader.read_candidate_graph_deltas)
+
+    assert hints["return"] == list[CandidateGraphDelta]
+
+
+def test_contract_candidate_graph_delta_adapts_to_internal_edge_record() -> None:
+    contract_delta = _contract_delta(
+        relation_type="belongs_to_sector",
+        properties={"weight": 0.4},
+    )
+
+    promotion_delta = adapt_candidate_graph_delta(contract_delta, "cycle-1")
+    plan = build_promotion_plan("cycle-1", "selection-1", [promotion_delta])
+
+    assert promotion_delta.source_entity_ids == ["node-1"]
+    assert plan.delta_ids == ["delta-1"]
+    assert len(plan.edge_records) == 1
+    edge_record = plan.edge_records[0]
+    assert edge_record.edge_id == "node-1|SECTOR_MEMBERSHIP|node-2"
+    assert edge_record.relationship_type == RelationshipType.SECTOR_MEMBERSHIP.value
+    assert edge_record.weight == 0.4
+    assert edge_record.properties["evidence_refs"] == ["fact-1"]
+    assert edge_record.properties["subsystem_id"] == "subsystem-news"
 
 
 def test_build_promotion_plan_parses_frozen_deltas_in_stable_order() -> None:
@@ -205,9 +240,9 @@ def test_promote_graph_deltas_writes_canonical_before_live_graph(
         "cycle-1",
         "selection-1",
         candidate_reader=FakeCandidateReader([
-            _delta("delta-1", "node_add", {"node": _node_payload()}),
+            _contract_delta("delta-1"),
         ]),
-        entity_reader=FakeEntityReader({"entity-1"}),
+        entity_reader=FakeEntityReader({"node-1"}),
         canonical_writer=writer,
         client=mock_client,
         status_manager=_status_manager_from_store(store),
@@ -237,9 +272,9 @@ def test_promote_graph_deltas_does_not_sync_when_canonical_write_fails(
             "cycle-1",
             "selection-1",
             candidate_reader=FakeCandidateReader([
-                _delta("delta-1", "node_add", {"node": _node_payload()}),
+                _contract_delta("delta-1"),
             ]),
-            entity_reader=FakeEntityReader({"entity-1"}),
+            entity_reader=FakeEntityReader({"node-1"}),
             canonical_writer=FakeCanonicalWriter(fail=True),
             client=MagicMock(spec=Neo4jClient),
             status_manager=_status_manager(),
@@ -251,7 +286,7 @@ def test_promote_graph_deltas_does_not_sync_when_canonical_write_fails(
 def test_promote_graph_deltas_requires_status_manager_for_live_sync() -> None:
     writer = FakeCanonicalWriter()
     reader = FakeCandidateReader([
-        _delta("delta-1", "node_add", {"node": _node_payload()}),
+        _contract_delta("delta-1"),
     ])
 
     with pytest.raises(ValueError, match="status_manager"):
@@ -259,7 +294,7 @@ def test_promote_graph_deltas_requires_status_manager_for_live_sync() -> None:
             "cycle-1",
             "selection-1",
             candidate_reader=reader,
-            entity_reader=FakeEntityReader({"entity-1"}),
+            entity_reader=FakeEntityReader({"node-1"}),
             canonical_writer=writer,
             client=MagicMock(spec=Neo4jClient),
         )
@@ -280,9 +315,9 @@ def test_promote_graph_deltas_blocks_live_sync_when_graph_is_not_ready(
             "cycle-1",
             "selection-1",
             candidate_reader=FakeCandidateReader([
-                _delta("delta-1", "node_add", {"node": _node_payload()}),
+                _contract_delta("delta-1"),
             ]),
-            entity_reader=FakeEntityReader({"entity-1"}),
+            entity_reader=FakeEntityReader({"node-1"}),
             canonical_writer=writer,
             client=MagicMock(spec=Neo4jClient),
             status_manager=_status_manager(graph_status="rebuilding"),
@@ -305,9 +340,9 @@ def test_promote_graph_deltas_rejects_stale_status_before_live_sync(
             "cycle-1",
             "selection-1",
             candidate_reader=FakeCandidateReader([
-                _delta("delta-1", "node_add", {"node": _node_payload()}),
+                _contract_delta("delta-1"),
             ]),
-            entity_reader=FakeEntityReader({"entity-1"}),
+            entity_reader=FakeEntityReader({"node-1"}),
             canonical_writer=writer,
             client=MagicMock(spec=Neo4jClient),
             status_manager=status_manager,
@@ -329,9 +364,9 @@ def test_promote_graph_deltas_does_not_sync_if_rebuild_starts_after_barrier(
             "cycle-1",
             "selection-1",
             candidate_reader=FakeCandidateReader([
-                _delta("delta-1", "node_add", {"node": _node_payload()}),
+                _contract_delta("delta-1"),
             ]),
-            entity_reader=FakeEntityReader({"entity-1"}),
+            entity_reader=FakeEntityReader({"node-1"}),
             canonical_writer=FakeCanonicalWriter(),
             client=MagicMock(spec=Neo4jClient),
             status_manager=_status_manager_from_store(store),
@@ -360,9 +395,9 @@ def test_promote_graph_deltas_detects_status_change_during_live_sync(
             "cycle-1",
             "selection-1",
             candidate_reader=FakeCandidateReader([
-                _delta("delta-1", "node_add", {"node": _node_payload()}),
+                _contract_delta("delta-1"),
             ]),
-            entity_reader=FakeEntityReader({"entity-1"}),
+            entity_reader=FakeEntityReader({"node-1"}),
             canonical_writer=writer,
             client=MagicMock(spec=Neo4jClient),
             status_manager=_status_manager_from_store(store),
@@ -387,9 +422,9 @@ def test_promote_graph_deltas_marks_status_failed_when_live_sync_fails(
             "cycle-1",
             "selection-1",
             candidate_reader=FakeCandidateReader([
-                _delta("delta-1", "node_add", {"node": _node_payload()}),
+                _contract_delta("delta-1"),
             ]),
-            entity_reader=FakeEntityReader({"entity-1"}),
+            entity_reader=FakeEntityReader({"node-1"}),
             canonical_writer=FakeCanonicalWriter(),
             client=MagicMock(spec=Neo4jClient),
             status_manager=_status_manager_from_store(store),
@@ -406,9 +441,9 @@ def test_promote_graph_deltas_can_skip_live_graph_sync() -> None:
         "cycle-1",
         "selection-1",
         candidate_reader=FakeCandidateReader([
-            _delta("delta-1", "node_add", {"node": _node_payload()}),
+            _contract_delta("delta-1"),
         ]),
-        entity_reader=FakeEntityReader({"entity-1"}),
+        entity_reader=FakeEntityReader({"node-1"}),
         canonical_writer=writer,
         sync_to_live_graph=False,
     )
@@ -438,6 +473,28 @@ def _status(
         last_verified_at=NOW if graph_status == "ready" else None,
         last_reload_at=None,
         writer_lock_token=writer_lock_token,
+    )
+
+
+def _contract_delta(
+    delta_id: str = "delta-1",
+    *,
+    delta_type: str = "upsert_relation",
+    source_node: str = "node-1",
+    target_node: str = "node-2",
+    relation_type: str = RelationshipType.SUPPLY_CHAIN.value,
+    properties: dict[str, Any] | None = None,
+    evidence: list[str] | None = None,
+) -> CandidateGraphDelta:
+    return CandidateGraphDelta(
+        delta_id=delta_id,
+        delta_type=delta_type,
+        source_node=source_node,
+        target_node=target_node,
+        relation_type=relation_type,
+        properties=properties or {"weight": 0.7},
+        evidence=evidence or ["fact-1"],
+        subsystem_id="subsystem-news",
     )
 
 


### PR DESCRIPTION
Closes #48

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `benchmarks/artifacts/lite_target_100k_800k.json`, `benchmarks/generate_synthetic.py`, `cross-cutting`, `examples/consumer_stream_layer.py`, `graph_engine/__pycache__/__init__.cpython-314.pyc`, `graph_engine/propagation/pipeline.py`, `graph_engine/query/service.py`, `graph_engine/status/consistency.py`, `graph_engine/sync/live_graph.py`, `project_ult_graph_engine.egg-info/SOURCES.txt`


---
## 背景与目标
Milestone review for milestone-5 发现阻塞性问题，必须在进入下一阶段前修复。

## 问题描述
The public `CandidateGraphDelta` name is re-exported from `contracts`, but the promotion reader and planner were changed to consume `FrozenGraphDelta`, which is the old local candidate delta shape under a new name. That means the actual graph delta ingestion path still depends on graph-engine-local fields such as `cycle_id`, `source_entity_ids`, `payload`, and `validation_status`, while the contract `CandidateGraphDelta` is not accepted by the milestone's core promotion flow. This preserves the exact drift risk issue #46 was meant to remove.

## 实现范围
- 修改文件: `graph_engine/promotion/interfaces.py`
- Move the promotion boundary to a contracts-defined delta shape, or add an explicit, tested adapter from `contracts.schemas.CandidateGraphDelta` into an internal promotion record. Do not let `CandidateDeltaReader` expose `FrozenGraphDelta` as the integration contract.

## 验收标准
- [ ] 原始 P0 问题已修复
- [ ] 新增回归测试覆盖该场景
- [ ] 构建通过

## 验证命令
```bash
/Users/fanjie/Desktop/Cowork/project-ult/graph-engine/.venv/bin/python -m pytest
```
