### PR TITLE
feat(#48): [milestone-5 review] P0: Promotion still uses a local graph delta schema

### DIFF
--- a/graph_engine/promotion/interfaces.py
+++ b/graph_engine/promotion/interfaces.py
@@ -21,7 +21,10 @@ class CandidateDeltaReader(Protocol):
 
 
 class EntityAnchorReader(Protocol):
-    """Read canonical entity anchors owned by entity-registry."""
+    """Read endpoint entity mappings and canonical entity anchors."""
+
+    def canonical_entity_ids_for_node_ids(self, node_ids: set[str]) -> dict[str, str]:
+        """Return canonical entity ids for graph node ids referenced by contract deltas."""
 
     def existing_entity_ids(self, entity_ids: set[str]) -> set[str]:
         """Return the subset of entity ids that already exist as canonical anchors."""

--- a/graph_engine/promotion/interfaces.py
+++ b/graph_engine/promotion/interfaces.py
@@ -4,18 +4,20 @@ from __future__ import annotations
 
 from typing import Protocol
 
-from graph_engine.models import FrozenGraphDelta, PromotionPlan
+from contracts.schemas import CandidateGraphDelta
+
+from graph_engine.models import PromotionPlan
 
 
 class CandidateDeltaReader(Protocol):
-    """Read frozen candidate deltas from the upstream canonical input surface."""
+    """Read contract candidate deltas from the upstream canonical input surface."""
 
     def read_candidate_graph_deltas(
         self,
         cycle_id: str,
         selection_ref: str,
-    ) -> list[FrozenGraphDelta]:
-        """Return candidate graph deltas selected for promotion."""
+    ) -> list[CandidateGraphDelta]:
+        """Return contract graph deltas selected for promotion."""
 
 
 class EntityAnchorReader(Protocol):

--- a/graph_engine/promotion/planner.py
+++ b/graph_engine/promotion/planner.py
@@ -1,4 +1,4 @@
-"""Build canonical graph promotion plans from frozen candidate deltas."""
+"""Build canonical graph promotion plans from internal promotion deltas."""
 
 from __future__ import annotations
 
@@ -7,8 +7,9 @@ from collections.abc import Mapping, Sequence
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
+from contracts.schemas import CandidateGraphDelta
+
 from graph_engine.models import (
-    CandidateGraphDelta,
     FrozenGraphDelta,
     GraphAssertionRecord,
     GraphEdgeRecord,
@@ -28,6 +29,25 @@ _VALID_NODE_LABELS = {label.value for label in NodeLabel}
 _VALID_RELATIONSHIP_TYPES = {relationship.value for relationship in RelationshipType}
 _STABLE_CONTRACT_EDGE_TIMESTAMP_BASE = datetime(2000, 1, 1, tzinfo=timezone.utc)
 _STABLE_CONTRACT_EDGE_TIMESTAMP_SPAN_SECONDS = 10 * 365 * 24 * 60 * 60
+
+
+def freeze_contract_delta(
+    cycle_id: str,
+    contract_delta: CandidateGraphDelta,
+) -> FrozenGraphDelta:
+    """Adapt a contract graph delta into the internal promotion planner record."""
+
+    return FrozenGraphDelta(
+        delta_id=contract_delta.delta_id,
+        cycle_id=cycle_id,
+        delta_type="edge_add",
+        source_entity_ids=[
+            contract_delta.source_node,
+            contract_delta.target_node,
+        ],
+        payload=contract_delta.model_dump(),
+        validation_status="frozen",
+    )
 
 
 def validate_entity_anchors(

--- a/graph_engine/promotion/planner.py
+++ b/graph_engine/promotion/planner.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import hashlib
 from collections.abc import Mapping, Sequence
 from datetime import datetime, timedelta, timezone
-from typing import Any
+from typing import Any, Literal
 
 from contracts.schemas import CandidateGraphDelta
 
@@ -29,6 +29,10 @@ _VALID_NODE_LABELS = {label.value for label in NodeLabel}
 _VALID_RELATIONSHIP_TYPES = {relationship.value for relationship in RelationshipType}
 _STABLE_CONTRACT_EDGE_TIMESTAMP_BASE = datetime(2000, 1, 1, tzinfo=timezone.utc)
 _STABLE_CONTRACT_EDGE_TIMESTAMP_SPAN_SECONDS = 10 * 365 * 24 * 60 * 60
+_InternalContractDeltaType = Literal["edge_add"]
+_CONTRACT_DELTA_TYPE_TO_INTERNAL: Mapping[str, _InternalContractDeltaType] = {
+    "upsert_edge": "edge_add",
+}
 
 
 def freeze_contract_delta(
@@ -37,10 +41,11 @@ def freeze_contract_delta(
 ) -> FrozenGraphDelta:
     """Adapt a contract graph delta into the internal promotion planner record."""
 
+    delta_type = _internal_delta_type_for_contract_delta(contract_delta)
     return FrozenGraphDelta(
         delta_id=contract_delta.delta_id,
         cycle_id=cycle_id,
-        delta_type="edge_add",
+        delta_type=delta_type,
         source_entity_ids=[
             contract_delta.source_node,
             contract_delta.target_node,
@@ -48,6 +53,18 @@ def freeze_contract_delta(
         payload=contract_delta.model_dump(),
         validation_status="frozen",
     )
+
+
+def _internal_delta_type_for_contract_delta(
+    contract_delta: CandidateGraphDelta,
+) -> _InternalContractDeltaType:
+    delta_type = _CONTRACT_DELTA_TYPE_TO_INTERNAL.get(contract_delta.delta_type)
+    if delta_type is None:
+        raise ValueError(
+            "unsupported contract delta_type "
+            f"{contract_delta.delta_type!r} for delta {contract_delta.delta_id}",
+        )
+    return delta_type
 
 
 def validate_entity_anchors(

--- a/graph_engine/promotion/planner.py
+++ b/graph_engine/promotion/planner.py
@@ -38,21 +38,45 @@ _CONTRACT_DELTA_TYPE_TO_INTERNAL: Mapping[str, _InternalContractDeltaType] = {
 def freeze_contract_delta(
     cycle_id: str,
     contract_delta: CandidateGraphDelta,
+    *,
+    node_entity_ids: Mapping[str, str],
 ) -> FrozenGraphDelta:
     """Adapt a contract graph delta into the internal promotion planner record."""
 
     delta_type = _internal_delta_type_for_contract_delta(contract_delta)
+    source_entity_ids = _resolved_endpoint_entity_ids(contract_delta, node_entity_ids)
     return FrozenGraphDelta(
         delta_id=contract_delta.delta_id,
         cycle_id=cycle_id,
         delta_type=delta_type,
-        source_entity_ids=[
-            contract_delta.source_node,
-            contract_delta.target_node,
-        ],
+        source_entity_ids=source_entity_ids,
         payload=contract_delta.model_dump(),
         validation_status="frozen",
     )
+
+
+def freeze_contract_deltas(
+    cycle_id: str,
+    contract_deltas: Sequence[CandidateGraphDelta],
+    entity_reader: EntityAnchorReader,
+) -> list[FrozenGraphDelta]:
+    """Adapt contract graph deltas after resolving endpoint nodes to entity anchors."""
+
+    endpoint_node_ids = _supported_contract_endpoint_node_ids(contract_deltas)
+    node_entity_ids = (
+        entity_reader.canonical_entity_ids_for_node_ids(endpoint_node_ids)
+        if endpoint_node_ids
+        else {}
+    )
+    _validate_endpoint_entity_resolution(endpoint_node_ids, node_entity_ids)
+    return [
+        freeze_contract_delta(
+            cycle_id,
+            contract_delta,
+            node_entity_ids=node_entity_ids,
+        )
+        for contract_delta in contract_deltas
+    ]
 
 
 def _internal_delta_type_for_contract_delta(
@@ -65,6 +89,43 @@ def _internal_delta_type_for_contract_delta(
             f"{contract_delta.delta_type!r} for delta {contract_delta.delta_id}",
         )
     return delta_type
+
+
+def _supported_contract_endpoint_node_ids(
+    contract_deltas: Sequence[CandidateGraphDelta],
+) -> set[str]:
+    node_ids: set[str] = set()
+    for contract_delta in contract_deltas:
+        _internal_delta_type_for_contract_delta(contract_delta)
+        node_ids.add(contract_delta.source_node)
+        node_ids.add(contract_delta.target_node)
+    return node_ids
+
+
+def _validate_endpoint_entity_resolution(
+    endpoint_node_ids: set[str],
+    node_entity_ids: Mapping[str, str],
+) -> None:
+    missing_node_ids = sorted(
+        node_id
+        for node_id in endpoint_node_ids
+        if not node_entity_ids.get(node_id)
+    )
+    if missing_node_ids:
+        raise ValueError(
+            "missing canonical entity ids for graph nodes: "
+            + ", ".join(missing_node_ids),
+        )
+
+
+def _resolved_endpoint_entity_ids(
+    contract_delta: CandidateGraphDelta,
+    node_entity_ids: Mapping[str, str],
+) -> list[str]:
+    return [
+        node_entity_ids[contract_delta.source_node],
+        node_entity_ids[contract_delta.target_node],
+    ]
 
 
 def validate_entity_anchors(

--- a/graph_engine/promotion/service.py
+++ b/graph_engine/promotion/service.py
@@ -59,10 +59,13 @@ def promote_graph_deltas(
 
 def _internal_promotion_delta(
     cycle_id: str,
-    delta: CandidateGraphDelta | FrozenGraphDelta,
+    delta: CandidateGraphDelta,
 ) -> FrozenGraphDelta:
-    if isinstance(delta, FrozenGraphDelta):
-        return delta
+    if not isinstance(delta, CandidateGraphDelta):
+        raise TypeError(
+            "CandidateDeltaReader must return contracts.schemas.CandidateGraphDelta "
+            f"values, got {type(delta).__name__}",
+        )
     return freeze_contract_delta(cycle_id, delta)
 
 

--- a/graph_engine/promotion/service.py
+++ b/graph_engine/promotion/service.py
@@ -2,14 +2,20 @@
 
 from __future__ import annotations
 
+from contracts.schemas import CandidateGraphDelta
+
 from graph_engine.client import Neo4jClient
-from graph_engine.models import Neo4jGraphStatus, PromotionPlan
+from graph_engine.models import FrozenGraphDelta, Neo4jGraphStatus, PromotionPlan
 from graph_engine.promotion.interfaces import (
     CandidateDeltaReader,
     CanonicalWriter,
     EntityAnchorReader,
 )
-from graph_engine.promotion.planner import build_promotion_plan, validate_entity_anchors
+from graph_engine.promotion.planner import (
+    build_promotion_plan,
+    freeze_contract_delta,
+    validate_entity_anchors,
+)
 from graph_engine.status import GraphStatusManager
 from graph_engine.sync import sync_live_graph
 
@@ -32,7 +38,10 @@ def promote_graph_deltas(
     if sync_to_live_graph and status_manager is None:
         raise ValueError("status_manager is required when sync_to_live_graph is True")
 
-    deltas = candidate_reader.read_candidate_graph_deltas(cycle_id, selection_ref)
+    deltas = [
+        _internal_promotion_delta(cycle_id, delta)
+        for delta in candidate_reader.read_candidate_graph_deltas(cycle_id, selection_ref)
+    ]
     validate_entity_anchors(deltas, entity_reader)
     plan = build_promotion_plan(cycle_id, selection_ref, deltas)
 
@@ -46,6 +55,15 @@ def promote_graph_deltas(
         _sync_live_graph_with_status_barrier(plan, client, status_manager)
 
     return plan
+
+
+def _internal_promotion_delta(
+    cycle_id: str,
+    delta: CandidateGraphDelta | FrozenGraphDelta,
+) -> FrozenGraphDelta:
+    if isinstance(delta, FrozenGraphDelta):
+        return delta
+    return freeze_contract_delta(cycle_id, delta)
 
 
 def _sync_live_graph_with_status_barrier(

--- a/graph_engine/promotion/service.py
+++ b/graph_engine/promotion/service.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from contracts.schemas import CandidateGraphDelta
 
 from graph_engine.client import Neo4jClient
-from graph_engine.models import FrozenGraphDelta, Neo4jGraphStatus, PromotionPlan
+from graph_engine.models import Neo4jGraphStatus, PromotionPlan
 from graph_engine.promotion.interfaces import (
     CandidateDeltaReader,
     CanonicalWriter,
@@ -13,7 +13,7 @@ from graph_engine.promotion.interfaces import (
 )
 from graph_engine.promotion.planner import (
     build_promotion_plan,
-    freeze_contract_delta,
+    freeze_contract_deltas,
     validate_entity_anchors,
 )
 from graph_engine.status import GraphStatusManager
@@ -31,17 +31,18 @@ def promote_graph_deltas(
     status_manager: GraphStatusManager | None = None,
     sync_to_live_graph: bool = True,
 ) -> PromotionPlan:
-    """Promote selected frozen graph deltas, then optionally mirror them to Neo4j."""
+    """Promote selected contract graph deltas, then optionally mirror them to Neo4j."""
 
     if sync_to_live_graph and client is None:
         raise ValueError("client is required when sync_to_live_graph is True")
     if sync_to_live_graph and status_manager is None:
         raise ValueError("status_manager is required when sync_to_live_graph is True")
 
-    deltas = [
-        _internal_promotion_delta(cycle_id, delta)
+    contract_deltas = [
+        _require_contract_delta(delta)
         for delta in candidate_reader.read_candidate_graph_deltas(cycle_id, selection_ref)
     ]
+    deltas = freeze_contract_deltas(cycle_id, contract_deltas, entity_reader)
     validate_entity_anchors(deltas, entity_reader)
     plan = build_promotion_plan(cycle_id, selection_ref, deltas)
 
@@ -57,16 +58,13 @@ def promote_graph_deltas(
     return plan
 
 
-def _internal_promotion_delta(
-    cycle_id: str,
-    delta: CandidateGraphDelta,
-) -> FrozenGraphDelta:
+def _require_contract_delta(delta: object) -> CandidateGraphDelta:
     if not isinstance(delta, CandidateGraphDelta):
         raise TypeError(
             "CandidateDeltaReader must return contracts.schemas.CandidateGraphDelta "
             f"values, got {type(delta).__name__}",
         )
-    return freeze_contract_delta(cycle_id, delta)
+    return delta
 
 
 def _sync_live_graph_with_status_barrier(

--- a/tests/unit/test_contract_schemas.py
+++ b/tests/unit/test_contract_schemas.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+from typing import get_args, get_origin, get_type_hints
+
 import contracts.schemas as contract_schemas
 
 import graph_engine
 from graph_engine import models
+from graph_engine.promotion import CandidateDeltaReader
 
 
 def test_public_graph_contracts_are_reexported_from_contracts() -> None:
@@ -60,6 +63,14 @@ def test_public_graph_contract_field_sets_are_pinned() -> None:
         "impact_score",
         "evidence_refs",
     }
+
+
+def test_candidate_delta_reader_exposes_contract_delta_shape() -> None:
+    hints = get_type_hints(CandidateDeltaReader.read_candidate_graph_deltas)
+    return_type = hints["return"]
+
+    assert get_origin(return_type) is list
+    assert get_args(return_type) == (contract_schemas.CandidateGraphDelta,)
 
 
 def test_internal_metric_and_frozen_delta_models_are_not_public_contracts() -> None:

--- a/tests/unit/test_promotion.py
+++ b/tests/unit/test_promotion.py
@@ -40,6 +40,20 @@ class FakeCandidateReader:
         return self.deltas
 
 
+class FakeLegacyCandidateReader:
+    def __init__(self, deltas: list[FrozenGraphDelta]) -> None:
+        self.deltas = deltas
+        self.calls: list[tuple[str, str]] = []
+
+    def read_candidate_graph_deltas(
+        self,
+        cycle_id: str,
+        selection_ref: str,
+    ) -> list[FrozenGraphDelta]:
+        self.calls.append((cycle_id, selection_ref))
+        return self.deltas
+
+
 class FakeEntityReader:
     def __init__(self, existing_ids: set[str]) -> None:
         self.existing_ids = existing_ids
@@ -309,6 +323,46 @@ def test_contract_delta_evidence_flows_through_promotion_to_impact_snapshot() ->
     )
 
     assert impact_snapshot.evidence_refs == ["fact-contract-1"]
+
+
+def test_promote_graph_deltas_rejects_unsupported_contract_delta_type() -> None:
+    writer = FakeCanonicalWriter()
+    entity_reader = FakeEntityReader({"node-1", "node-2"})
+
+    with pytest.raises(ValueError, match="unsupported contract delta_type 'delete_edge'"):
+        promote_graph_deltas(
+            "cycle-1",
+            "selection-1",
+            candidate_reader=FakeCandidateReader(
+                [_contract_delta("delta-1", delta_type="delete_edge")],
+            ),
+            entity_reader=entity_reader,
+            canonical_writer=writer,
+            sync_to_live_graph=False,
+        )
+
+    assert entity_reader.calls == []
+    assert writer.plans == []
+
+
+def test_promote_graph_deltas_rejects_legacy_frozen_delta_reader() -> None:
+    writer = FakeCanonicalWriter()
+    entity_reader = FakeEntityReader({"entity-1"})
+
+    with pytest.raises(TypeError, match="CandidateDeltaReader must return"):
+        promote_graph_deltas(
+            "cycle-1",
+            "selection-1",
+            candidate_reader=FakeLegacyCandidateReader(
+                [_delta("delta-1", "edge_add", {"edge": _edge_payload()})],
+            ),
+            entity_reader=entity_reader,
+            canonical_writer=writer,
+            sync_to_live_graph=False,
+        )
+
+    assert entity_reader.calls == []
+    assert writer.plans == []
 
 
 @pytest.mark.parametrize(
@@ -626,10 +680,14 @@ def _delta(
     )
 
 
-def _contract_delta(delta_id: str = "delta-1") -> CandidateGraphDelta:
+def _contract_delta(
+    delta_id: str = "delta-1",
+    *,
+    delta_type: str = "upsert_edge",
+) -> CandidateGraphDelta:
     return CandidateGraphDelta(
         delta_id=delta_id,
-        delta_type="upsert_edge",
+        delta_type=delta_type,
         source_node="node-1",
         target_node="node-2",
         relation_type=RelationshipType.SUPPLY_CHAIN.value,

--- a/tests/unit/test_promotion.py
+++ b/tests/unit/test_promotion.py
@@ -27,7 +27,7 @@ NOW = datetime(2026, 4, 17, 1, 2, 3, tzinfo=timezone.utc)
 
 
 class FakeCandidateReader:
-    def __init__(self, deltas: list[FrozenGraphDelta]) -> None:
+    def __init__(self, deltas: list[CandidateGraphDelta]) -> None:
         self.deltas = deltas
         self.calls: list[tuple[str, str]] = []
 
@@ -35,7 +35,7 @@ class FakeCandidateReader:
         self,
         cycle_id: str,
         selection_ref: str,
-    ) -> list[FrozenGraphDelta]:
+    ) -> list[CandidateGraphDelta]:
         self.calls.append((cycle_id, selection_ref))
         return self.deltas
 
@@ -263,25 +263,20 @@ def test_contract_delta_evidence_flows_through_promotion_to_impact_snapshot() ->
         subsystem_id="subsystem-news",
     )
     writer = FakeCanonicalWriter()
+    entity_reader = FakeEntityReader({"node-1", "node-2"})
 
     plan = promote_graph_deltas(
         "cycle-1",
         "selection-1",
-        candidate_reader=FakeCandidateReader([
-            _delta(
-                "delta-1",
-                "edge_add",
-                contract_delta.model_dump(),
-                source_entity_ids=["entity-1", "entity-2"],
-            ),
-        ]),
-        entity_reader=FakeEntityReader({"entity-1", "entity-2"}),
+        candidate_reader=FakeCandidateReader([contract_delta]),
+        entity_reader=entity_reader,
         canonical_writer=writer,
         sync_to_live_graph=False,
     )
 
     edge_record = plan.edge_records[0]
     assert writer.plans == [plan]
+    assert entity_reader.calls == [{"node-1", "node-2"}]
     assert edge_record.edge_id == contract_delta.delta_id
     assert edge_record.source_node_id == contract_delta.source_node
     assert edge_record.target_node_id == contract_delta.target_node
@@ -393,10 +388,8 @@ def test_promote_graph_deltas_writes_canonical_before_live_graph(
     plan = promote_graph_deltas(
         "cycle-1",
         "selection-1",
-        candidate_reader=FakeCandidateReader([
-            _delta("delta-1", "node_add", {"node": _node_payload()}),
-        ]),
-        entity_reader=FakeEntityReader({"entity-1"}),
+        candidate_reader=FakeCandidateReader([_contract_delta("delta-1")]),
+        entity_reader=FakeEntityReader({"node-1", "node-2"}),
         canonical_writer=writer,
         client=mock_client,
         status_manager=_status_manager_from_store(store),
@@ -425,10 +418,8 @@ def test_promote_graph_deltas_does_not_sync_when_canonical_write_fails(
         promote_graph_deltas(
             "cycle-1",
             "selection-1",
-            candidate_reader=FakeCandidateReader([
-                _delta("delta-1", "node_add", {"node": _node_payload()}),
-            ]),
-            entity_reader=FakeEntityReader({"entity-1"}),
+            candidate_reader=FakeCandidateReader([_contract_delta("delta-1")]),
+            entity_reader=FakeEntityReader({"node-1", "node-2"}),
             canonical_writer=FakeCanonicalWriter(fail=True),
             client=MagicMock(spec=Neo4jClient),
             status_manager=_status_manager(),
@@ -439,16 +430,14 @@ def test_promote_graph_deltas_does_not_sync_when_canonical_write_fails(
 
 def test_promote_graph_deltas_requires_status_manager_for_live_sync() -> None:
     writer = FakeCanonicalWriter()
-    reader = FakeCandidateReader([
-        _delta("delta-1", "node_add", {"node": _node_payload()}),
-    ])
+    reader = FakeCandidateReader([_contract_delta("delta-1")])
 
     with pytest.raises(ValueError, match="status_manager"):
         promote_graph_deltas(
             "cycle-1",
             "selection-1",
             candidate_reader=reader,
-            entity_reader=FakeEntityReader({"entity-1"}),
+            entity_reader=FakeEntityReader({"node-1", "node-2"}),
             canonical_writer=writer,
             client=MagicMock(spec=Neo4jClient),
         )
@@ -468,10 +457,8 @@ def test_promote_graph_deltas_blocks_live_sync_when_graph_is_not_ready(
         promote_graph_deltas(
             "cycle-1",
             "selection-1",
-            candidate_reader=FakeCandidateReader([
-                _delta("delta-1", "node_add", {"node": _node_payload()}),
-            ]),
-            entity_reader=FakeEntityReader({"entity-1"}),
+            candidate_reader=FakeCandidateReader([_contract_delta("delta-1")]),
+            entity_reader=FakeEntityReader({"node-1", "node-2"}),
             canonical_writer=writer,
             client=MagicMock(spec=Neo4jClient),
             status_manager=_status_manager(graph_status="rebuilding"),
@@ -493,10 +480,8 @@ def test_promote_graph_deltas_rejects_stale_status_before_live_sync(
         promote_graph_deltas(
             "cycle-1",
             "selection-1",
-            candidate_reader=FakeCandidateReader([
-                _delta("delta-1", "node_add", {"node": _node_payload()}),
-            ]),
-            entity_reader=FakeEntityReader({"entity-1"}),
+            candidate_reader=FakeCandidateReader([_contract_delta("delta-1")]),
+            entity_reader=FakeEntityReader({"node-1", "node-2"}),
             canonical_writer=writer,
             client=MagicMock(spec=Neo4jClient),
             status_manager=status_manager,
@@ -517,10 +502,8 @@ def test_promote_graph_deltas_does_not_sync_if_rebuild_starts_after_barrier(
         promote_graph_deltas(
             "cycle-1",
             "selection-1",
-            candidate_reader=FakeCandidateReader([
-                _delta("delta-1", "node_add", {"node": _node_payload()}),
-            ]),
-            entity_reader=FakeEntityReader({"entity-1"}),
+            candidate_reader=FakeCandidateReader([_contract_delta("delta-1")]),
+            entity_reader=FakeEntityReader({"node-1", "node-2"}),
             canonical_writer=FakeCanonicalWriter(),
             client=MagicMock(spec=Neo4jClient),
             status_manager=_status_manager_from_store(store),
@@ -548,10 +531,8 @@ def test_promote_graph_deltas_detects_status_change_during_live_sync(
         promote_graph_deltas(
             "cycle-1",
             "selection-1",
-            candidate_reader=FakeCandidateReader([
-                _delta("delta-1", "node_add", {"node": _node_payload()}),
-            ]),
-            entity_reader=FakeEntityReader({"entity-1"}),
+            candidate_reader=FakeCandidateReader([_contract_delta("delta-1")]),
+            entity_reader=FakeEntityReader({"node-1", "node-2"}),
             canonical_writer=writer,
             client=MagicMock(spec=Neo4jClient),
             status_manager=_status_manager_from_store(store),
@@ -575,10 +556,8 @@ def test_promote_graph_deltas_marks_status_failed_when_live_sync_fails(
         promote_graph_deltas(
             "cycle-1",
             "selection-1",
-            candidate_reader=FakeCandidateReader([
-                _delta("delta-1", "node_add", {"node": _node_payload()}),
-            ]),
-            entity_reader=FakeEntityReader({"entity-1"}),
+            candidate_reader=FakeCandidateReader([_contract_delta("delta-1")]),
+            entity_reader=FakeEntityReader({"node-1", "node-2"}),
             canonical_writer=FakeCanonicalWriter(),
             client=MagicMock(spec=Neo4jClient),
             status_manager=_status_manager_from_store(store),
@@ -594,10 +573,8 @@ def test_promote_graph_deltas_can_skip_live_graph_sync() -> None:
     plan = promote_graph_deltas(
         "cycle-1",
         "selection-1",
-        candidate_reader=FakeCandidateReader([
-            _delta("delta-1", "node_add", {"node": _node_payload()}),
-        ]),
-        entity_reader=FakeEntityReader({"entity-1"}),
+        candidate_reader=FakeCandidateReader([_contract_delta("delta-1")]),
+        entity_reader=FakeEntityReader({"node-1", "node-2"}),
         canonical_writer=writer,
         sync_to_live_graph=False,
     )
@@ -646,6 +623,19 @@ def _delta(
         source_entity_ids=source_entity_ids or ["entity-1"],
         payload=payload,
         validation_status=validation_status,
+    )
+
+
+def _contract_delta(delta_id: str = "delta-1") -> CandidateGraphDelta:
+    return CandidateGraphDelta(
+        delta_id=delta_id,
+        delta_type="upsert_edge",
+        source_node="node-1",
+        target_node="node-2",
+        relation_type=RelationshipType.SUPPLY_CHAIN.value,
+        properties={"weight": 0.7},
+        evidence=[f"fact-{delta_id}"],
+        subsystem_id="subsystem-news",
     )
 
 

--- a/tests/unit/test_promotion.py
+++ b/tests/unit/test_promotion.py
@@ -55,9 +55,23 @@ class FakeLegacyCandidateReader:
 
 
 class FakeEntityReader:
-    def __init__(self, existing_ids: set[str]) -> None:
+    def __init__(
+        self,
+        existing_ids: set[str],
+        node_entity_ids: dict[str, str] | None = None,
+    ) -> None:
         self.existing_ids = existing_ids
+        self.node_entity_ids = node_entity_ids or {}
+        self.node_calls: list[set[str]] = []
         self.calls: list[set[str]] = []
+
+    def canonical_entity_ids_for_node_ids(self, node_ids: set[str]) -> dict[str, str]:
+        self.node_calls.append(node_ids)
+        return {
+            node_id: self.node_entity_ids[node_id]
+            for node_id in node_ids
+            if node_id in self.node_entity_ids
+        }
 
     def existing_entity_ids(self, entity_ids: set[str]) -> set[str]:
         self.calls.append(entity_ids)
@@ -277,7 +291,7 @@ def test_contract_delta_evidence_flows_through_promotion_to_impact_snapshot() ->
         subsystem_id="subsystem-news",
     )
     writer = FakeCanonicalWriter()
-    entity_reader = FakeEntityReader({"node-1", "node-2"})
+    entity_reader = _contract_entity_reader()
 
     plan = promote_graph_deltas(
         "cycle-1",
@@ -290,7 +304,8 @@ def test_contract_delta_evidence_flows_through_promotion_to_impact_snapshot() ->
 
     edge_record = plan.edge_records[0]
     assert writer.plans == [plan]
-    assert entity_reader.calls == [{"node-1", "node-2"}]
+    assert entity_reader.node_calls == [{"node-1", "node-2"}]
+    assert entity_reader.calls == [{"entity-1", "entity-2"}]
     assert edge_record.edge_id == contract_delta.delta_id
     assert edge_record.source_node_id == contract_delta.source_node
     assert edge_record.target_node_id == contract_delta.target_node
@@ -325,9 +340,65 @@ def test_contract_delta_evidence_flows_through_promotion_to_impact_snapshot() ->
     assert impact_snapshot.evidence_refs == ["fact-contract-1"]
 
 
+def test_promote_graph_deltas_validates_resolved_entities_not_endpoint_nodes() -> None:
+    contract_delta = _contract_delta(
+        "delta-1",
+        source_node="node-source",
+        target_node="node-target",
+    )
+    writer = FakeCanonicalWriter()
+    entity_reader = _contract_entity_reader(
+        existing_ids={"entity-source", "entity-target"},
+        node_entity_ids={
+            "node-source": "entity-source",
+            "node-target": "entity-target",
+        },
+    )
+
+    plan = promote_graph_deltas(
+        "cycle-1",
+        "selection-1",
+        candidate_reader=FakeCandidateReader([contract_delta]),
+        entity_reader=entity_reader,
+        canonical_writer=writer,
+        sync_to_live_graph=False,
+    )
+
+    assert entity_reader.node_calls == [{"node-source", "node-target"}]
+    assert entity_reader.calls == [{"entity-source", "entity-target"}]
+    assert writer.plans == [plan]
+    assert plan.edge_records[0].source_node_id == "node-source"
+    assert plan.edge_records[0].target_node_id == "node-target"
+
+
+def test_promote_graph_deltas_rejects_contract_delta_with_unresolved_endpoint_node() -> None:
+    writer = FakeCanonicalWriter()
+    entity_reader = _contract_entity_reader(
+        existing_ids={"entity-1"},
+        node_entity_ids={"node-1": "entity-1"},
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="missing canonical entity ids for graph nodes: node-2",
+    ):
+        promote_graph_deltas(
+            "cycle-1",
+            "selection-1",
+            candidate_reader=FakeCandidateReader([_contract_delta("delta-1")]),
+            entity_reader=entity_reader,
+            canonical_writer=writer,
+            sync_to_live_graph=False,
+        )
+
+    assert entity_reader.node_calls == [{"node-1", "node-2"}]
+    assert entity_reader.calls == []
+    assert writer.plans == []
+
+
 def test_promote_graph_deltas_rejects_unsupported_contract_delta_type() -> None:
     writer = FakeCanonicalWriter()
-    entity_reader = FakeEntityReader({"node-1", "node-2"})
+    entity_reader = _contract_entity_reader()
 
     with pytest.raises(ValueError, match="unsupported contract delta_type 'delete_edge'"):
         promote_graph_deltas(
@@ -342,6 +413,7 @@ def test_promote_graph_deltas_rejects_unsupported_contract_delta_type() -> None:
         )
 
     assert entity_reader.calls == []
+    assert entity_reader.node_calls == []
     assert writer.plans == []
 
 
@@ -443,7 +515,7 @@ def test_promote_graph_deltas_writes_canonical_before_live_graph(
         "cycle-1",
         "selection-1",
         candidate_reader=FakeCandidateReader([_contract_delta("delta-1")]),
-        entity_reader=FakeEntityReader({"node-1", "node-2"}),
+        entity_reader=_contract_entity_reader(),
         canonical_writer=writer,
         client=mock_client,
         status_manager=_status_manager_from_store(store),
@@ -473,7 +545,7 @@ def test_promote_graph_deltas_does_not_sync_when_canonical_write_fails(
             "cycle-1",
             "selection-1",
             candidate_reader=FakeCandidateReader([_contract_delta("delta-1")]),
-            entity_reader=FakeEntityReader({"node-1", "node-2"}),
+            entity_reader=_contract_entity_reader(),
             canonical_writer=FakeCanonicalWriter(fail=True),
             client=MagicMock(spec=Neo4jClient),
             status_manager=_status_manager(),
@@ -491,7 +563,7 @@ def test_promote_graph_deltas_requires_status_manager_for_live_sync() -> None:
             "cycle-1",
             "selection-1",
             candidate_reader=reader,
-            entity_reader=FakeEntityReader({"node-1", "node-2"}),
+            entity_reader=_contract_entity_reader(),
             canonical_writer=writer,
             client=MagicMock(spec=Neo4jClient),
         )
@@ -512,7 +584,7 @@ def test_promote_graph_deltas_blocks_live_sync_when_graph_is_not_ready(
             "cycle-1",
             "selection-1",
             candidate_reader=FakeCandidateReader([_contract_delta("delta-1")]),
-            entity_reader=FakeEntityReader({"node-1", "node-2"}),
+            entity_reader=_contract_entity_reader(),
             canonical_writer=writer,
             client=MagicMock(spec=Neo4jClient),
             status_manager=_status_manager(graph_status="rebuilding"),
@@ -535,7 +607,7 @@ def test_promote_graph_deltas_rejects_stale_status_before_live_sync(
             "cycle-1",
             "selection-1",
             candidate_reader=FakeCandidateReader([_contract_delta("delta-1")]),
-            entity_reader=FakeEntityReader({"node-1", "node-2"}),
+            entity_reader=_contract_entity_reader(),
             canonical_writer=writer,
             client=MagicMock(spec=Neo4jClient),
             status_manager=status_manager,
@@ -557,7 +629,7 @@ def test_promote_graph_deltas_does_not_sync_if_rebuild_starts_after_barrier(
             "cycle-1",
             "selection-1",
             candidate_reader=FakeCandidateReader([_contract_delta("delta-1")]),
-            entity_reader=FakeEntityReader({"node-1", "node-2"}),
+            entity_reader=_contract_entity_reader(),
             canonical_writer=FakeCanonicalWriter(),
             client=MagicMock(spec=Neo4jClient),
             status_manager=_status_manager_from_store(store),
@@ -586,7 +658,7 @@ def test_promote_graph_deltas_detects_status_change_during_live_sync(
             "cycle-1",
             "selection-1",
             candidate_reader=FakeCandidateReader([_contract_delta("delta-1")]),
-            entity_reader=FakeEntityReader({"node-1", "node-2"}),
+            entity_reader=_contract_entity_reader(),
             canonical_writer=writer,
             client=MagicMock(spec=Neo4jClient),
             status_manager=_status_manager_from_store(store),
@@ -611,7 +683,7 @@ def test_promote_graph_deltas_marks_status_failed_when_live_sync_fails(
             "cycle-1",
             "selection-1",
             candidate_reader=FakeCandidateReader([_contract_delta("delta-1")]),
-            entity_reader=FakeEntityReader({"node-1", "node-2"}),
+            entity_reader=_contract_entity_reader(),
             canonical_writer=FakeCanonicalWriter(),
             client=MagicMock(spec=Neo4jClient),
             status_manager=_status_manager_from_store(store),
@@ -628,7 +700,7 @@ def test_promote_graph_deltas_can_skip_live_graph_sync() -> None:
         "cycle-1",
         "selection-1",
         candidate_reader=FakeCandidateReader([_contract_delta("delta-1")]),
-        entity_reader=FakeEntityReader({"node-1", "node-2"}),
+        entity_reader=_contract_entity_reader(),
         canonical_writer=writer,
         sync_to_live_graph=False,
     )
@@ -641,6 +713,20 @@ def _status_manager(
     graph_status: str = "ready",
 ) -> GraphStatusManager:
     return GraphStatusManager(InMemoryStatusStore(_status(graph_status=graph_status)))
+
+
+def _contract_entity_reader(
+    existing_ids: set[str] | None = None,
+    node_entity_ids: dict[str, str] | None = None,
+) -> FakeEntityReader:
+    resolved_node_entity_ids = node_entity_ids or {
+        "node-1": "entity-1",
+        "node-2": "entity-2",
+    }
+    return FakeEntityReader(
+        existing_ids or set(resolved_node_entity_ids.values()),
+        resolved_node_entity_ids,
+    )
 
 
 def _status(
@@ -684,12 +770,14 @@ def _contract_delta(
     delta_id: str = "delta-1",
     *,
     delta_type: str = "upsert_edge",
+    source_node: str = "node-1",
+    target_node: str = "node-2",
 ) -> CandidateGraphDelta:
     return CandidateGraphDelta(
         delta_id=delta_id,
         delta_type=delta_type,
-        source_node="node-1",
-        target_node="node-2",
+        source_node=source_node,
+        target_node=target_node,
         relation_type=RelationshipType.SUPPLY_CHAIN.value,
         properties={"weight": 0.7},
         evidence=[f"fact-{delta_id}"],


### PR DESCRIPTION
Closes #48

Implemented by Codex.

### Opportunistic P1 Fixes
This PR also addresses accumulated P1 warnings in files being modified.
P1 backlog files: `benchmarks/artifacts/lite_target_100k_800k.json`, `benchmarks/generate_synthetic.py`, `cross-cutting`, `examples/consumer_stream_layer.py`, `graph_engine/__pycache__/__init__.cpython-314.pyc`, `graph_engine/propagation/pipeline.py`, `graph_engine/query/service.py`, `graph_engine/status/consistency.py`, `graph_engine/sync/live_graph.py`, `project_ult_graph_engine.egg-info/SOURCES.txt`


---
## 背景与目标
Milestone review for milestone-5 发现阻塞性问题，必须在进入下一阶段前修复。

## 问题描述
The public `CandidateGraphDelta` name is re-exported from `contracts`, but the promotion reader and planner were changed to consume `FrozenGraphDelta`, which is the old local candidate delta shape under a new name. That means the actual graph delta ingestion path still depends on graph-engine-local fields such as `cycle_id`, `source_entity_ids`, `payload`, and `validation_status`, while the contract `CandidateGraphDelta` is not accepted by the milestone's core promotion flow. This preserves the exact drift risk issue #46 was meant to remove.

## 实现范围
- 修改文件: `graph_engine/promotion/interfaces.py`
- Move the promotion boundary to a contracts-defined delta shape, or add an explicit, tested adapter from `contracts.schemas.CandidateGraphDelta` into an internal promotion record. Do not let `CandidateDeltaReader` expose `FrozenGraphDelta` as the integration contract.

## 验收标准
- [ ] 原始 P0 问题已修复
- [ ] 新增回归测试覆盖该场景
- [ ] 构建通过

## 验证命令
```bash
/Users/fanjie/Desktop/Cowork/project-ult/graph-engine/.venv/bin/python -m pytest
```
