### PR TITLE
[codex] Support holdings edge_upsert promotion proof

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,12 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+      - name: Authenticate private git dependencies
+        env:
+          GH_TOKEN: ${{ secrets.PROJECT_ULT_CI_READ_TOKEN || github.token }}
+        run: |
+          auth_header="$(printf 'x-access-token:%s' "${GH_TOKEN}" | base64 -w 0)"
+          git config --global http.https://github.com/.extraheader "AUTHORIZATION: basic ${auth_header}"
       - name: Step 1 — Install contracts@v0.1.3
         run: pip install "git+https://github.com/shenfanjie5-bit/project-ult-contracts.git@v0.1.3"
       - name: Step 2 — Install (full(ci) lane — all extras)
@@ -48,6 +54,12 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+      - name: Authenticate private git dependencies
+        env:
+          GH_TOKEN: ${{ secrets.PROJECT_ULT_CI_READ_TOKEN || github.token }}
+        run: |
+          auth_header="$(printf 'x-access-token:%s' "${GH_TOKEN}" | base64 -w 0)"
+          git config --global http.https://github.com/.extraheader "AUTHORIZATION: basic ${auth_header}"
       - name: Step 1 — Install contracts@v0.1.3
         run: pip install "git+https://github.com/shenfanjie5-bit/project-ult-contracts.git@v0.1.3"
       - name: Step 2 — Install (offline-first dev only)
@@ -62,6 +74,12 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+      - name: Authenticate private git dependencies
+        env:
+          GH_TOKEN: ${{ secrets.PROJECT_ULT_CI_READ_TOKEN || github.token }}
+        run: |
+          auth_header="$(printf 'x-access-token:%s' "${GH_TOKEN}" | base64 -w 0)"
+          git config --global http.https://github.com/.extraheader "AUTHORIZATION: basic ${auth_header}"
       - name: Step 1 — Install contracts@v0.1.3
         run: pip install "git+https://github.com/shenfanjie5-bit/project-ult-contracts.git@v0.1.3"
       - name: Step 2 — Install (offline-first dev only)
@@ -76,6 +94,12 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+      - name: Authenticate private git dependencies
+        env:
+          GH_TOKEN: ${{ secrets.PROJECT_ULT_CI_READ_TOKEN || github.token }}
+        run: |
+          auth_header="$(printf 'x-access-token:%s' "${GH_TOKEN}" | base64 -w 0)"
+          git config --global http.https://github.com/.extraheader "AUTHORIZATION: basic ${auth_header}"
       - name: Step 1 — Install contracts@v0.1.3
         run: pip install "git+https://github.com/shenfanjie5-bit/project-ult-contracts.git@v0.1.3"
       - name: Step 2 — Install (with cross-repo contracts-schemas extra)
@@ -90,6 +114,12 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+      - name: Authenticate private git dependencies
+        env:
+          GH_TOKEN: ${{ secrets.PROJECT_ULT_CI_READ_TOKEN || github.token }}
+        run: |
+          auth_header="$(printf 'x-access-token:%s' "${GH_TOKEN}" | base64 -w 0)"
+          git config --global http.https://github.com/.extraheader "AUTHORIZATION: basic ${auth_header}"
       - name: Step 1 — Install contracts@v0.1.3
         run: pip install "git+https://github.com/shenfanjie5-bit/project-ult-contracts.git@v0.1.3"
       - name: Step 2 — Install (with shared-fixtures git extra @v0.2.2)

--- a/graph_engine/promotion/planner.py
+++ b/graph_engine/promotion/planner.py
@@ -38,6 +38,7 @@ _InternalContractDeltaType = Literal["edge_add"]
 _CONTRACT_DELTA_TYPE_TO_INTERNAL: Mapping[str, _InternalContractDeltaType] = {
     "add": "edge_add",
     "add_edge": "edge_add",
+    "edge_upsert": "edge_add",
     "upsert_edge": "edge_add",
     "upsert_relation": "edge_add",
 }

--- a/tests/contract/test_contracts_alignment.py
+++ b/tests/contract/test_contracts_alignment.py
@@ -160,9 +160,11 @@ class TestConsumerSideRoundTripsThroughRealContracts:
         assert consumer_validated.target_node == wire_payload["target_node"]
         assert consumer_validated.relation_type == wire_payload["relation_type"]
 
+    @pytest.mark.parametrize("delta_type", ["upsert_edge", "edge_upsert"])
     @pytest.mark.parametrize("relation_type", ["CO_HOLDING", "NORTHBOUND_HOLD"])
     def test_holdings_relationship_terms_stay_inside_generic_ex3_contract(
         self,
+        delta_type: str,
         relation_type: str,
     ) -> None:
         from contracts.schemas import CandidateGraphDelta
@@ -175,7 +177,7 @@ class TestConsumerSideRoundTripsThroughRealContracts:
         payload = {
             "subsystem_id": "subsystem-holdings",
             "delta_id": f"{relation_type.lower()}-alignment-001",
-            "delta_type": "upsert_edge",
+            "delta_type": delta_type,
             "source_node": "ENT_HOLDING_SRC",
             "target_node": "ENT_HOLDING_DST",
             "relation_type": relation_type,

--- a/tests/unit/test_promotion.py
+++ b/tests/unit/test_promotion.py
@@ -291,6 +291,22 @@ def test_contract_delta_upsert_relation_maps_to_edge_promotion() -> None:
     assert plan.edge_records[0].relationship_type == contract_delta.relation_type
 
 
+def test_contract_delta_edge_upsert_maps_to_edge_promotion() -> None:
+    contract_delta = _contract_delta(delta_type="edge_upsert")
+
+    plan = promote_graph_deltas(
+        "cycle-1",
+        "selection-1",
+        candidate_reader=FakeCandidateReader([contract_delta]),
+        entity_reader=_contract_entity_reader(),
+        canonical_writer=FakeCanonicalWriter(),
+        sync_to_live_graph=False,
+    )
+
+    assert [edge.edge_id for edge in plan.edge_records] == [contract_delta.delta_id]
+    assert plan.edge_records[0].relationship_type == contract_delta.relation_type
+
+
 @pytest.mark.parametrize(
     "relationship_type",
     [
@@ -317,6 +333,84 @@ def test_contract_delta_promotes_holdings_relationship_types(
 
     assert plan.edge_records[0].relationship_type == relationship_type
     assert plan.edge_records[0].edge_id.startswith(f"{relationship_type.lower()}:")
+
+
+@pytest.mark.parametrize(
+    "relationship_type",
+    [
+        RelationshipType.CO_HOLDING.value,
+        RelationshipType.NORTHBOUND_HOLD.value,
+    ],
+)
+def test_frozen_holdings_edge_upsert_promotes_to_layer_a_without_live_sync(
+    monkeypatch: pytest.MonkeyPatch,
+    relationship_type: str,
+) -> None:
+    sync_live_graph = MagicMock()
+    monkeypatch.setattr(service_module, "sync_live_graph", sync_live_graph)
+    source_node = f"node-holder-{relationship_type.lower()}"
+    target_node = f"node-security-{relationship_type.lower()}"
+    source_entity = f"entity-holder-{relationship_type.lower()}"
+    target_entity = f"entity-security-{relationship_type.lower()}"
+    contract_delta = _contract_delta(
+        delta_id=f"{relationship_type.lower()}-live-proof-1",
+        delta_type="edge_upsert",
+        source_node=source_node,
+        target_node=target_node,
+        relation_type=relationship_type,
+        subsystem_id="subsystem-holdings",
+    )
+    contract_delta.properties = {
+        "weight": 0.7,
+        "edge_key": f"{relationship_type}|holder|security",
+        "source_mart": "mart_deriv_holdings_proof",
+    }
+    contract_delta.producer_context = {
+        "graph_node_upserts": [
+            _node_payload(source_node, canonical_entity_id=source_entity),
+            _node_payload(target_node, canonical_entity_id=target_entity),
+        ],
+    }
+    writer = FakeCanonicalWriter()
+
+    plan = promote_graph_deltas(
+        "cycle-1",
+        "selection-1",
+        candidate_reader=FakeCandidateReader([contract_delta]),
+        entity_reader=_contract_entity_reader(
+            existing_ids={source_entity, target_entity},
+            node_entity_ids={},
+        ),
+        canonical_writer=writer,
+        sync_to_live_graph=False,
+    )
+
+    edge = plan.edge_records[0]
+    assert writer.calls == ["canonical"]
+    assert writer.plans == [plan]
+    sync_live_graph.assert_not_called()
+    assert sorted(node.node_id for node in plan.node_records) == [
+        source_node,
+        target_node,
+    ]
+    assert edge.relationship_type == relationship_type
+    assert edge.source_node_id == source_node
+    assert edge.target_node_id == target_node
+    assert edge.edge_id.startswith(f"{relationship_type.lower()}:")
+    assert edge.edge_id != contract_delta.delta_id
+
+    replay_plan = promote_graph_deltas(
+        "cycle-1",
+        "selection-1",
+        candidate_reader=FakeCandidateReader([contract_delta]),
+        entity_reader=_contract_entity_reader(
+            existing_ids={source_entity, target_entity},
+            node_entity_ids={},
+        ),
+        canonical_writer=FakeCanonicalWriter(),
+        sync_to_live_graph=False,
+    )
+    assert replay_plan.edge_records[0].edge_id == edge.edge_id
 
 
 def test_holdings_contract_delta_can_upsert_endpoint_nodes_before_edge() -> None:
@@ -1207,6 +1301,7 @@ def _contract_delta(
     source_node: str = "node-1",
     target_node: str = "node-2",
     relation_type: str = RelationshipType.SUPPLY_CHAIN.value,
+    subsystem_id: str = "subsystem-news",
 ) -> CandidateGraphDelta:
     return CandidateGraphDelta(
         delta_id=delta_id,
@@ -1216,7 +1311,7 @@ def _contract_delta(
         relation_type=relation_type,
         properties={"weight": 0.7},
         evidence=[f"fact-{delta_id}"],
-        subsystem_id="subsystem-news",
+        subsystem_id=subsystem_id,
     )
 
 

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -528,6 +528,51 @@ def test_query_propagation_paths_can_filter_northbound_hold_as_reflexive() -> No
     assert any('"NORTHBOUND_HOLD"' in query for query, _ in client.read_calls)
 
 
+def test_query_propagation_paths_can_filter_co_holding_as_reflexive() -> None:
+    client = FakeQueryClient(
+        edges=[
+            {
+                "edge_id": "edge-co-holding",
+                "source_node_id": "node-a",
+                "target_node_id": "node-b",
+                "relationship_type": "CO_HOLDING",
+                "properties": {},
+                "weight": 0.8,
+            }
+        ]
+    )
+
+    result = query_propagation_paths(
+        ["entity-a"],
+        1,
+        client=client,  # type: ignore[arg-type]
+        status_manager=_status_manager(),
+        channels=["reflexive"],
+        result_limit=5,
+    )
+
+    assert result.paths == [
+        {
+            "channel": "reflexive",
+            "edge_id": "edge-co-holding",
+            "source_node_id": "node-a",
+            "target_node_id": "node-b",
+            "relationship_type": "CO_HOLDING",
+            "score": 0.8,
+            "path_length": 1,
+            "properties": {},
+        }
+    ]
+    assert any(
+        '"CO_HOLDING" THEN ["reflexive"]' in query
+        for query, _ in client.read_calls
+    )
+    assert any(
+        read_parameters.get("channel_filter") == ["reflexive"]
+        for _, read_parameters in client.read_calls
+    )
+
+
 def test_query_propagation_paths_depth_zero_returns_empty_path_summary() -> None:
     client = FakeQueryClient()
 


### PR DESCRIPTION
## Scope

- Adds #56-compatible `edge_upsert` promotion mapping for holdings Ex-3 candidates.
- Adds frozen holdings offline promotion/query/channel proof for `CO_HOLDING` and `NORTHBOUND_HOLD`.
- Verifies canonical writer is called and live graph sync is not invoked in the frozen holdings proof.

## Non-goals

- Does not implement graph-engine #55 algorithms.
- No co-holding crowding, no northbound anomaly, and no GDS/community detection.
- No financial-doc scope, no `MAJOR_CUSTOMER`, and no `MAJOR_SUPPLIER`.

## Tests

- `PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -m pytest -p no:cacheprovider -q tests/unit/test_promotion.py tests/unit/test_phase1_from_env.py tests/unit/test_phase1_provider.py tests/contract/test_contracts_alignment.py tests/unit/test_query.py tests/unit/test_propagation_channels.py`
- Result: 106 passed, 1 skipped.
- `git diff --check` passed.

## Boundaries

- `contracts` unchanged.
- No holdings-specific contracts subtype.
- No live graph sync or graph-engine #55 algorithm closure claimed.
