### PR TITLE
[codex] Add holdings-only propagation algorithms

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,22 @@ Implemented interface/type decisions:
 - Represent pledge status as `OWNERSHIP` properties such as `pledge_ratio`;
   do not add a separate `PLEDGE_STATUS` relationship.
 - Issue #56 covers enum, planner, query, and propagation-channel support only.
-  Issue #55 remains the later place for co-holding cluster or
-  northbound-anomaly algorithms.
+- Issue #55 is narrowed to holdings-only algorithms. The current
+  implementation adds explicit entry points for `CO_HOLDING`
+  co-holding crowding and `NORTHBOUND_HOLD` northbound anomaly:
+  `HoldingsAlgorithmConfig`, `run_co_holding_crowding`,
+  `run_northbound_anomaly`, and `run_holdings_algorithms`.
+- The #55 implementation is deliberately **not** wired into
+  `run_full_propagation`; callers must opt in through the explicit
+  holdings entry points so the generic event/reflexive channels do not
+  double-count the same holdings edges.
+- Old #55 references to guarantees, related-party/financial-doc
+  propagation, contracts subtype work, `MAJOR_CUSTOMER`, and
+  `MAJOR_SUPPLIER` are superseded for the current execution scope.
+  This module still does not add `TOP_SHAREHOLDER` or `PLEDGE_STATUS`.
+- This is algorithm-level support over a ready live graph read. It does
+  not claim production rollout to live Neo4j, graph writeback, or new
+  cross-module contracts.
 
 CLAUDE.md §10 domain invariants this module enforces by construction:
 
@@ -130,6 +144,15 @@ Focused #56 holdings evidence:
   tests/unit/test_schema.py tests/unit/test_promotion.py \
   tests/unit/test_query.py tests/unit/test_propagation_channels.py \
   tests/boundary/test_red_lines.py -q
+```
+
+Focused #55 holdings-only algorithm evidence:
+
+```bash
+PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -m pytest -p no:cacheprovider -q \
+  tests/unit/test_propagation_holdings.py tests/unit/test_propagation_merge.py \
+  tests/unit/test_snapshots.py tests/unit/test_propagation_channels.py \
+  tests/unit/test_schema.py tests/boundary/test_red_lines.py
 ```
 
 Refresh global pass/skip counts only after running the full suite in the

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -1,74 +1,61 @@
 # graph-engine 项目进度总览
 
-> **最后更新**: 2026-04-17
+> **最后更新**: 2026-05-07
 > **项目文档**: [graph-engine.project-doc.md](./graph-engine.project-doc.md)
 > **任务拆解**: [TASK_BREAKDOWN.md](./TASK_BREAKDOWN.md)
 
+## 当前状态
+
+graph-engine 已进入 holdings extension 阶段。核心 P3a/P3b 能力不再处于
+原始任务拆解中的“未开始”状态：promotion、status guard、cold reload、
+event/reflexive propagation、readonly query/simulation、snapshot generation
+和 #56 holdings enum/planner/query/channel 基础已经落地。
+
+本轮 #55 范围已被收窄并 supersede 旧 issue 文本：
+
+- 已实现 `CO_HOLDING` co-holding crowding algorithm。
+- 已实现 `NORTHBOUND_HOLD` northbound anomaly algorithm。
+- 第一版只提供显式入口：`run_co_holding_crowding`、
+  `run_northbound_anomaly`、`run_holdings_algorithms`。
+- 未接入默认 `run_full_propagation`，避免与 generic event/reflexive
+  propagation 双计数。
+- 未实现担保链、关联交易、financial-doc、contracts subtype、
+  `MAJOR_CUSTOMER`、`MAJOR_SUPPLIER`、`TOP_SHAREHOLDER` 或
+  `PLEDGE_STATUS`。
+- 未声明 live Neo4j production rollout；算法仅读取 ready live graph，
+  不写 Neo4j。
+
 ## 里程碑进度
 
-| 阶段 | 里程碑 | 目标 | Issue 数量 | 状态 | 退出条件 |
-|------|--------|------|-----------|------|----------|
-| 阶段 0 | milestone-0 | 图谱性能与模型 Spike | 2 | **未开始** | Lite 规模传播 < 1 分钟 |
-| 阶段 1 | milestone-1 | P3a 图谱主干 | 2 | 未开始 | 候选变更进入正式图并完成快照回写 |
-| 阶段 2 | milestone-2 | P3a 运维闭环 | 2 | 未开始 | Neo4j 可清空/重建/校验/ready |
-| 阶段 3 | milestone-3 | P3b 完整传播 | 2 | 未开始 | 正式 impact snapshot 稳定产出 |
-| 阶段 4 | milestone-4 | P3b 只读服务 | 2 | 未开始 | 事件驱动链路可读图谱但不写正式图 |
+| 阶段 | 目标 | 当前状态 |
+|------|------|----------|
+| Phase 0 | 图谱性能与模型 Spike | 基础设施与模型已落地；性能预算仍需单独实测更新 |
+| Phase 1 | P3a 图谱主干 | CandidateGraphDelta promotion + Layer A before live sync 已落地 |
+| Phase 2 | P3a 运维闭环 | Neo4j graph status、consistency guard、Cold Reload 已落地 |
+| Phase 3 | P3b 传播 | fundamental / event / reflexive 已落地；#55 holdings-only 显式算法已落地 |
+| Phase 4 | P3b 只读服务 | subgraph/path query 与 readonly local simulation 已落地 |
 
-## Issue 状态明细
+## Holdings Issue 状态
 
-| Issue | 标题 | 里程碑 | 优先级 | 状态 | 依赖 |
-|-------|------|--------|--------|------|------|
-| ISSUE-001 | 项目基础设施、Neo4j 连接层、Schema 定义与核心领域模型 | milestone-0 | P0 | **未开始** | 无 |
-| ISSUE-002 | GDS 规模压测脚本与传播预算验证 | milestone-0 | P0 | 未开始 | #001 |
-| ISSUE-003 | Graph Promotion — CandidateGraphDelta 到正式图的提升与 Live Graph 同步 | milestone-1 | P0 | 未开始 | #001 |
-| ISSUE-004 | 单通道传播引擎与 Snapshot 生成回写 | milestone-1 | P0 | 未开始 | #003 |
-| ISSUE-005 | Neo4j Graph Status 状态机与一致性校验 | milestone-2 | P0 | 未开始 | #001 |
-| ISSUE-006 | Cold Reload 全量重建与 GDS Projection 恢复 | milestone-2 | P0 | 未开始 | #005 |
-| ISSUE-007 | Event 与 Reflexive 传播通道实现 | milestone-3 | P1 | 未开始 | #004 |
-| ISSUE-008 | 三通道融合、Regime-aware 权重调整与完整 Impact Snapshot | milestone-3 | P1 | 未开始 | #007 |
-| ISSUE-009 | 子图查询与传播路径查询接口 | milestone-4 | P1 | 未开始 | #005 |
-| ISSUE-010 | 只读局部传播模拟与消费方接入样例 | milestone-4 | P1 | 未开始 | #008, #009 |
+| Issue | 当前状态 | 说明 |
+|------|----------|------|
+| #56 | 已完成 | `CO_HOLDING` / `NORTHBOUND_HOLD` enum、planner、query、channel 基础能力 |
+| #55 | holdings-only 实现中/待发布 | 当前仅包含 co-holding crowding 与 northbound anomaly 显式算法 |
 
-## 依赖关系图
+## 验证命令
 
-```
-ISSUE-001 (基础设施 + 模型)
-  ├── ISSUE-002 (GDS 压测)
-  ├── ISSUE-003 (Graph Promotion)
-  │     └── ISSUE-004 (单通道传播 + Snapshot)
-  │           └── ISSUE-007 (Event + Reflexive 通道)
-  │                 └── ISSUE-008 (三通道融合)
-  │                       └── ISSUE-010 (只读模拟)
-  └── ISSUE-005 (Status 状态机)
-        ├── ISSUE-006 (Cold Reload)
-        └── ISSUE-009 (子图查询)
-              └── ISSUE-010 (只读模拟)
+```bash
+PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -m pytest -p no:cacheprovider -q \
+  tests/unit/test_propagation_holdings.py tests/unit/test_propagation_merge.py \
+  tests/unit/test_snapshots.py tests/unit/test_propagation_channels.py \
+  tests/unit/test_schema.py tests/boundary/test_red_lines.py
 ```
 
-## 关键性能预算 (§19.1)
+## 保留边界
 
-| 指标 | 目标值 | 当前状态 |
-|------|--------|----------|
-| Phase 1 单轮传播耗时 | < 60 秒 | 待验证 (ISSUE-002) |
-| Phase 0 一致性校验耗时 | < 5 秒 | 待验证 (ISSUE-002) |
-| Cold Reload 典型耗时 | < 90 秒 | 待验证 (ISSUE-002) |
-| Cold Reload 硬超时 | < 5 分钟 | 待验证 (ISSUE-002) |
-
-## 质量指标 (§19.2)
-
-| 指标 | 目标值 | 当前状态 |
-|------|--------|----------|
-| ready 状态下 Neo4j / Iceberg 计数偏差率 | 0 | 未实现 |
-| 事件驱动局部模拟误写正式图次数 | 0 | 未实现 |
-| graph_snapshot 产出成功率 | 100% | 未实现 |
-| 反向代码依赖事件数 | 0 | 符合 |
-
-## 验收标准检查表 (§23)
-
-- [ ] 1. 冻结后的 CandidateGraphDelta 先写入 Layer A，再同步到 Neo4j live graph
-- [ ] 2. 稳定生成并回写 graph_snapshot 与 graph_impact_snapshot
-- [ ] 3. neo4j_graph_status、consistency check、Cold Reload 闭环可运行
-- [ ] 4. 三类传播都有正式实现，并能使用只读 regime context
-- [ ] 5. graph-engine 不反向 import main-core
-- [ ] 6. Full 模式局部图模拟保持只读
-- [ ] 7. 模块边界与主项目 12 + N 模块边界一致
+- 不改 `contracts`，不新增 holdings-specific subtype。
+- 不新增 relationship enum。
+- 不 import `data_platform`、`subsystem_*`、`main_core`、`assembly` 或
+  `orchestrator`。
+- 不直接写 Neo4j live graph。
+- 不恢复旧 #55 的 financial-doc、担保链或关联交易 scope。

--- a/graph_engine/propagation/__init__.py
+++ b/graph_engine/propagation/__init__.py
@@ -11,6 +11,12 @@ from graph_engine.propagation.reflexive import (
     REFLEXIVE_RELATIONSHIP_TYPES,
     run_reflexive_propagation,
 )
+from graph_engine.propagation.holdings import (
+    HoldingsAlgorithmConfig,
+    run_co_holding_crowding,
+    run_holdings_algorithms,
+    run_northbound_anomaly,
+)
 from graph_engine.propagation.merge import merge_propagation_results
 from graph_engine.propagation.pipeline import run_full_propagation
 from graph_engine.propagation.scoring import build_score_explanation, compute_path_score
@@ -21,12 +27,16 @@ __all__ = [
     "PROPAGATION_CHANNELS",
     "REFLEXIVE_RELATIONSHIP_TYPES",
     "RegimeContextReader",
+    "HoldingsAlgorithmConfig",
     "build_propagation_context",
     "build_score_explanation",
     "compute_path_score",
     "merge_propagation_results",
+    "run_co_holding_crowding",
     "run_event_propagation",
     "run_full_propagation",
     "run_fundamental_propagation",
+    "run_holdings_algorithms",
+    "run_northbound_anomaly",
     "run_reflexive_propagation",
 ]

--- a/graph_engine/propagation/holdings.py
+++ b/graph_engine/propagation/holdings.py
@@ -1,0 +1,689 @@
+"""Holdings-only propagation algorithms for graph-engine #55.
+
+These algorithms are explicit entry points. They intentionally do not plug
+into ``run_full_propagation`` so holdings signals are not double-counted by
+the generic event/reflexive propagation channels.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from graph_engine.client import Neo4jClient
+from graph_engine.evidence import evidence_refs_from_mapping
+from graph_engine.models import PropagationContext, PropagationResult
+from graph_engine.propagation.merge import merge_propagation_results
+from graph_engine.propagation.scoring import build_score_explanation
+from graph_engine.status import GraphStatusManager, hold_ready_read
+
+_CO_HOLDING_CHANNEL = "reflexive"
+_NORTHBOUND_CHANNEL = "event"
+_CO_HOLDING_RELATIONSHIP = "CO_HOLDING"
+_NORTHBOUND_RELATIONSHIP = "NORTHBOUND_HOLD"
+
+
+@dataclass(frozen=True)
+class HoldingsAlgorithmConfig:
+    """Thresholds for holdings-only propagation algorithms."""
+
+    min_holder_count: int = 2
+    normalization_holder_count: int = 5
+    crowding_threshold: float = 0.4
+    northbound_z_threshold: float = 2.0
+
+    def __post_init__(self) -> None:
+        if self.min_holder_count < 1:
+            raise ValueError("min_holder_count must be positive")
+        if self.normalization_holder_count < 1:
+            raise ValueError("normalization_holder_count must be positive")
+        if not _is_finite_non_negative(self.crowding_threshold):
+            raise ValueError("crowding_threshold must be finite and non-negative")
+        if not _is_finite_non_negative(self.northbound_z_threshold):
+            raise ValueError("northbound_z_threshold must be finite and non-negative")
+
+
+def run_co_holding_crowding(
+    context: PropagationContext,
+    client: Neo4jClient,
+    *,
+    status_manager: GraphStatusManager,
+    config: HoldingsAlgorithmConfig | None = None,
+    result_limit: int = 100,
+) -> PropagationResult:
+    """Compute explicit co-holding crowding signals from ``CO_HOLDING`` edges."""
+
+    algorithm_config = config or HoldingsAlgorithmConfig()
+    if _CO_HOLDING_CHANNEL not in context.enabled_channels:
+        raise PermissionError("co-holding crowding requires the reflexive channel")
+    _validate_result_limit(result_limit)
+
+    with hold_ready_read(status_manager, "holdings co-holding crowding") as ready_status:
+        _validate_context_generation(context, ready_status.graph_generation_id)
+        rows = _read_co_holding_rows(client, result_limit=result_limit)
+
+    valid_paths: list[dict[str, Any]] = []
+    diagnostics: dict[str, int] = {}
+    for row in rows:
+        path = _co_holding_path_from_row(context, row, algorithm_config, diagnostics)
+        if path is not None:
+            valid_paths.append(path)
+
+    grouped_paths = _co_holding_paths_above_threshold(
+        valid_paths,
+        algorithm_config,
+        diagnostics,
+        result_limit=result_limit,
+    )
+    impacted_entities = _co_holding_impacted_entities(grouped_paths, result_limit=result_limit)
+
+    return PropagationResult(
+        cycle_id=context.cycle_id,
+        graph_generation_id=context.graph_generation_id,
+        activated_paths=grouped_paths,
+        impacted_entities=impacted_entities,
+        channel_breakdown={
+            _CO_HOLDING_CHANNEL: {
+                "co_holding_crowding": {
+                    "relationship_type": _CO_HOLDING_RELATIONSHIP,
+                    "path_count": len(grouped_paths),
+                    "impacted_entity_count": len(impacted_entities),
+                    "total_path_score": sum(float(path["score"]) for path in grouped_paths),
+                    "min_holder_count": algorithm_config.min_holder_count,
+                    "normalization_holder_count": algorithm_config.normalization_holder_count,
+                    "crowding_threshold": algorithm_config.crowding_threshold,
+                    "scanned_edge_count": len(rows),
+                    "valid_edge_count": len(valid_paths),
+                    "skipped_edge_count": sum(diagnostics.values()),
+                    "diagnostics": dict(sorted(diagnostics.items())),
+                },
+            },
+        },
+    )
+
+
+def run_northbound_anomaly(
+    context: PropagationContext,
+    client: Neo4jClient,
+    *,
+    status_manager: GraphStatusManager,
+    config: HoldingsAlgorithmConfig | None = None,
+    result_limit: int = 100,
+) -> PropagationResult:
+    """Compute explicit northbound anomaly signals from ``NORTHBOUND_HOLD`` edges."""
+
+    algorithm_config = config or HoldingsAlgorithmConfig()
+    if _NORTHBOUND_CHANNEL not in context.enabled_channels:
+        raise PermissionError("northbound anomaly requires the event channel")
+    _validate_result_limit(result_limit)
+
+    with hold_ready_read(status_manager, "holdings northbound anomaly") as ready_status:
+        _validate_context_generation(context, ready_status.graph_generation_id)
+        rows = _read_northbound_rows(client, result_limit=result_limit)
+
+    diagnostics: dict[str, int] = {}
+    activated_paths = [
+        path
+        for row in rows
+        if (
+            path := _northbound_path_from_row(
+                context,
+                row,
+                algorithm_config,
+                diagnostics,
+            )
+        )
+        is not None
+    ]
+    activated_paths.sort(key=_path_sort_key)
+    activated_paths = activated_paths[:result_limit]
+    impacted_entities = _impacted_entities_from_paths(
+        activated_paths,
+        channel=_NORTHBOUND_CHANNEL,
+        result_limit=result_limit,
+    )
+
+    return PropagationResult(
+        cycle_id=context.cycle_id,
+        graph_generation_id=context.graph_generation_id,
+        activated_paths=activated_paths,
+        impacted_entities=impacted_entities,
+        channel_breakdown={
+            _NORTHBOUND_CHANNEL: {
+                "northbound_anomaly": {
+                    "relationship_type": _NORTHBOUND_RELATIONSHIP,
+                    "path_count": len(activated_paths),
+                    "impacted_entity_count": len(impacted_entities),
+                    "total_path_score": sum(float(path["score"]) for path in activated_paths),
+                    "northbound_z_threshold": algorithm_config.northbound_z_threshold,
+                    "scanned_edge_count": len(rows),
+                    "skipped_edge_count": sum(diagnostics.values()),
+                    "diagnostics": dict(sorted(diagnostics.items())),
+                },
+            },
+        },
+    )
+
+
+def run_holdings_algorithms(
+    context: PropagationContext,
+    client: Neo4jClient,
+    *,
+    status_manager: GraphStatusManager,
+    config: HoldingsAlgorithmConfig | None = None,
+    result_limit: int = 100,
+) -> PropagationResult:
+    """Run enabled holdings algorithms and merge their explicit results."""
+
+    if (
+        _CO_HOLDING_CHANNEL not in context.enabled_channels
+        and _NORTHBOUND_CHANNEL not in context.enabled_channels
+    ):
+        raise PermissionError("holdings algorithms require event or reflexive channel")
+
+    results: list[PropagationResult] = []
+    if _CO_HOLDING_CHANNEL in context.enabled_channels:
+        results.append(
+            run_co_holding_crowding(
+                context,
+                client,
+                status_manager=status_manager,
+                config=config,
+                result_limit=result_limit,
+            )
+        )
+    if _NORTHBOUND_CHANNEL in context.enabled_channels:
+        results.append(
+            run_northbound_anomaly(
+                context,
+                client,
+                status_manager=status_manager,
+                config=config,
+                result_limit=result_limit,
+            )
+        )
+
+    if len(results) == 1:
+        return results[0]
+    return merge_propagation_results(results, result_limit=result_limit)
+
+
+def _read_co_holding_rows(
+    client: Neo4jClient,
+    *,
+    result_limit: int,
+) -> list[dict[str, Any]]:
+    return client.execute_read(
+        """
+MATCH (source)-[relationship:CO_HOLDING]->(target)
+RETURN source.node_id AS source_node_id,
+       source.canonical_entity_id AS source_entity_id,
+       labels(source) AS source_labels,
+       target.node_id AS target_node_id,
+       target.canonical_entity_id AS target_entity_id,
+       labels(target) AS target_labels,
+       relationship.edge_id AS edge_id,
+       type(relationship) AS relationship_type,
+       relationship.evidence_refs AS evidence_refs,
+       relationship.evidence_ref AS evidence_ref,
+       relationship.properties_json AS properties_json,
+       relationship.weight AS weight,
+       relationship.evidence_confidence AS evidence_confidence,
+       relationship.recency_decay AS recency_decay,
+       relationship.co_holding_fund_count AS co_holding_fund_count,
+       relationship.security_left_fund_count AS security_left_fund_count,
+       relationship.security_right_fund_count AS security_right_fund_count,
+       relationship.jaccard_score AS jaccard_score,
+       relationship.report_date AS report_date,
+       relationship.latest_announced_date AS latest_announced_date,
+       source.canonical_id_rule_version AS source_canonical_id_rule_version,
+       target.canonical_id_rule_version AS target_canonical_id_rule_version
+ORDER BY target_node_id ASC,
+         coalesce(relationship.co_holding_fund_count, 0) DESC,
+         coalesce(relationship.jaccard_score, relationship.weight, 0.0) DESC,
+         source_node_id ASC,
+         edge_id ASC
+LIMIT $scan_limit
+""",
+        {"scan_limit": _scan_limit(result_limit)},
+    )
+
+
+def _read_northbound_rows(
+    client: Neo4jClient,
+    *,
+    result_limit: int,
+) -> list[dict[str, Any]]:
+    return client.execute_read(
+        """
+MATCH (source)-[relationship:NORTHBOUND_HOLD]->(target)
+RETURN source.node_id AS source_node_id,
+       source.canonical_entity_id AS source_entity_id,
+       labels(source) AS source_labels,
+       target.node_id AS target_node_id,
+       target.canonical_entity_id AS target_entity_id,
+       labels(target) AS target_labels,
+       relationship.edge_id AS edge_id,
+       type(relationship) AS relationship_type,
+       relationship.evidence_refs AS evidence_refs,
+       relationship.evidence_ref AS evidence_ref,
+       relationship.properties_json AS properties_json,
+       relationship.weight AS weight,
+       relationship.evidence_confidence AS evidence_confidence,
+       relationship.recency_decay AS recency_decay,
+       relationship.metric_z_score AS metric_z_score,
+       relationship.northbound_z_score AS northbound_z_score,
+       relationship.z_score AS z_score,
+       relationship.z_score_metric AS z_score_metric,
+       relationship.lookback_observations AS lookback_observations,
+       relationship.window_start_date AS window_start_date,
+       relationship.window_end_date AS window_end_date,
+       relationship.observation_count AS observation_count,
+       relationship.metric_value AS metric_value,
+       relationship.metric_mean AS metric_mean,
+       relationship.metric_stddev AS metric_stddev,
+       relationship.report_date AS report_date,
+       source.canonical_id_rule_version AS source_canonical_id_rule_version,
+       target.canonical_id_rule_version AS target_canonical_id_rule_version
+ORDER BY abs(coalesce(
+             relationship.metric_z_score,
+             relationship.northbound_z_score,
+             relationship.z_score,
+             0.0
+         )) DESC,
+         target_node_id ASC,
+         edge_id ASC
+LIMIT $scan_limit
+""",
+        {"scan_limit": _scan_limit(result_limit)},
+    )
+
+
+def _co_holding_path_from_row(
+    context: PropagationContext,
+    row: Mapping[str, Any],
+    config: HoldingsAlgorithmConfig,
+    diagnostics: dict[str, int],
+) -> dict[str, Any] | None:
+    evidence_refs = _evidence_refs(row, diagnostics)
+    if not evidence_refs:
+        return None
+
+    holder_count = _int_value(row.get("co_holding_fund_count"))
+    if holder_count is None:
+        _increment(diagnostics, "missing_holder_count")
+        return None
+    if holder_count < config.min_holder_count:
+        _increment(diagnostics, "holder_count_below_minimum")
+        return None
+
+    relation_weight = _co_holding_relation_weight(row, diagnostics)
+    evidence_confidence = _bounded_float(row.get("evidence_confidence"), default=1.0)
+    recency_decay = _bounded_float(row.get("recency_decay"), default=1.0)
+    if relation_weight is None or evidence_confidence is None or recency_decay is None:
+        _increment(diagnostics, "invalid_scoring_field")
+        return None
+
+    explanation = build_score_explanation(
+        relation_weight=relation_weight,
+        evidence_confidence=evidence_confidence,
+        channel_multiplier=_context_multiplier(context, _CO_HOLDING_CHANNEL),
+        regime_multiplier=_context_regime_multiplier(context, _CO_HOLDING_CHANNEL),
+        recency_decay=recency_decay,
+    )
+
+    return {
+        "channel": _CO_HOLDING_CHANNEL,
+        "algorithm": "co_holding_crowding",
+        "source_node_id": row.get("source_node_id"),
+        "source_entity_id": row.get("source_entity_id"),
+        "source_labels": _string_list(row.get("source_labels")),
+        "target_node_id": row.get("target_node_id"),
+        "target_entity_id": row.get("target_entity_id"),
+        "target_labels": _string_list(row.get("target_labels")),
+        "edge_id": row.get("edge_id"),
+        "relationship_type": row.get("relationship_type") or _CO_HOLDING_RELATIONSHIP,
+        "evidence_refs": evidence_refs,
+        "source_canonical_id_rule_version": row.get("source_canonical_id_rule_version"),
+        "target_canonical_id_rule_version": row.get("target_canonical_id_rule_version"),
+        "co_holding_fund_count": holder_count,
+        "security_left_fund_count": _int_value(row.get("security_left_fund_count")),
+        "security_right_fund_count": _int_value(row.get("security_right_fund_count")),
+        "jaccard_score": _optional_float(row.get("jaccard_score")),
+        "report_date": row.get("report_date"),
+        "latest_announced_date": row.get("latest_announced_date"),
+        "lineage": _lineage_from_row(row),
+        "score": explanation["score"],
+        "explanation": explanation,
+    }
+
+
+def _co_holding_relation_weight(
+    row: Mapping[str, Any],
+    diagnostics: dict[str, int],
+) -> float | None:
+    raw_jaccard = row.get("jaccard_score")
+    if raw_jaccard is not None:
+        jaccard = _optional_float(raw_jaccard)
+        if jaccard is None or jaccard < 0.0:
+            _increment(diagnostics, "invalid_jaccard_score")
+            return None
+        return min(jaccard, 1.0)
+
+    properties = _properties_from_row(row)
+    if properties is None or "weight" not in properties:
+        _increment(diagnostics, "missing_explicit_weight")
+        return None
+
+    weight = _optional_float(properties.get("weight"))
+    if weight is None or weight < 0.0:
+        _increment(diagnostics, "invalid_explicit_weight")
+        return None
+    return min(weight, 1.0)
+
+
+def _co_holding_paths_above_threshold(
+    paths: list[dict[str, Any]],
+    config: HoldingsAlgorithmConfig,
+    diagnostics: dict[str, int],
+    *,
+    result_limit: int,
+) -> list[dict[str, Any]]:
+    grouped: dict[str, list[dict[str, Any]]] = {}
+    for path in paths:
+        target_key = str(path.get("target_node_id") or "")
+        if not target_key:
+            _increment(diagnostics, "missing_target_node")
+            continue
+        grouped.setdefault(target_key, []).append(path)
+
+    activated_paths: list[dict[str, Any]] = []
+    for target_paths in grouped.values():
+        total_strength = sum(float(path["score"]) for path in target_paths)
+        crowding_score = min(1.0, total_strength / config.normalization_holder_count)
+        if crowding_score < config.crowding_threshold:
+            _increment_by(
+                diagnostics,
+                "crowding_score_below_threshold",
+                len(target_paths),
+            )
+            continue
+
+        target_holder_count = sum(
+            int(path.get("co_holding_fund_count") or 0)
+            for path in target_paths
+        )
+        for path in target_paths:
+            activated = dict(path)
+            activated["crowding_score"] = crowding_score
+            activated["target_holder_count"] = target_holder_count
+            activated_paths.append(activated)
+
+    activated_paths.sort(key=_path_sort_key)
+    return activated_paths[:result_limit]
+
+
+def _co_holding_impacted_entities(
+    paths: list[dict[str, Any]],
+    *,
+    result_limit: int,
+) -> list[dict[str, Any]]:
+    impacted = _impacted_entities_from_paths(
+        paths,
+        channel=_CO_HOLDING_CHANNEL,
+        result_limit=result_limit,
+        score_key="crowding_score",
+    )
+    for entity in impacted:
+        entity_paths = [
+            path
+            for path in paths
+            if str(path.get("target_node_id") or "") == str(entity.get("node_id") or "")
+        ]
+        entity["algorithm"] = "co_holding_crowding"
+        entity["holder_count"] = max(
+            (int(path.get("target_holder_count") or 0) for path in entity_paths),
+            default=0,
+        )
+    return impacted
+
+
+def _northbound_path_from_row(
+    context: PropagationContext,
+    row: Mapping[str, Any],
+    config: HoldingsAlgorithmConfig,
+    diagnostics: dict[str, int],
+) -> dict[str, Any] | None:
+    evidence_refs = _evidence_refs(row, diagnostics)
+    if not evidence_refs:
+        return None
+
+    z_score = _first_float(row, ("metric_z_score", "northbound_z_score", "z_score"))
+    if z_score is None:
+        _increment(diagnostics, "missing_z_score")
+        return None
+    if abs(z_score) < config.northbound_z_threshold:
+        _increment(diagnostics, "z_score_below_threshold")
+        return None
+
+    evidence_confidence = _bounded_float(row.get("evidence_confidence"), default=1.0)
+    recency_decay = _bounded_float(row.get("recency_decay"), default=1.0)
+    if evidence_confidence is None or recency_decay is None:
+        _increment(diagnostics, "invalid_scoring_field")
+        return None
+
+    explanation = build_score_explanation(
+        relation_weight=abs(z_score),
+        evidence_confidence=evidence_confidence,
+        channel_multiplier=_context_multiplier(context, _NORTHBOUND_CHANNEL),
+        regime_multiplier=_context_regime_multiplier(context, _NORTHBOUND_CHANNEL),
+        recency_decay=recency_decay,
+    )
+
+    return {
+        "channel": _NORTHBOUND_CHANNEL,
+        "algorithm": "northbound_anomaly",
+        "source_node_id": row.get("source_node_id"),
+        "source_entity_id": row.get("source_entity_id"),
+        "source_labels": _string_list(row.get("source_labels")),
+        "target_node_id": row.get("target_node_id"),
+        "target_entity_id": row.get("target_entity_id"),
+        "target_labels": _string_list(row.get("target_labels")),
+        "edge_id": row.get("edge_id"),
+        "relationship_type": row.get("relationship_type") or _NORTHBOUND_RELATIONSHIP,
+        "evidence_refs": evidence_refs,
+        "source_canonical_id_rule_version": row.get("source_canonical_id_rule_version"),
+        "target_canonical_id_rule_version": row.get("target_canonical_id_rule_version"),
+        "direction": "inflow" if z_score > 0 else "outflow",
+        "z_score": z_score,
+        "z_score_metric": row.get("z_score_metric"),
+        "lookback_observations": _int_value(row.get("lookback_observations")),
+        "window_start_date": row.get("window_start_date"),
+        "window_end_date": row.get("window_end_date"),
+        "observation_count": _int_value(row.get("observation_count")),
+        "metric_value": _optional_float(row.get("metric_value")),
+        "metric_mean": _optional_float(row.get("metric_mean")),
+        "metric_stddev": _optional_float(row.get("metric_stddev")),
+        "report_date": row.get("report_date"),
+        "lineage": _lineage_from_row(row),
+        "score": explanation["score"],
+        "explanation": explanation,
+    }
+
+
+def _impacted_entities_from_paths(
+    paths: list[dict[str, Any]],
+    *,
+    channel: str,
+    result_limit: int,
+    score_key: str = "score",
+) -> list[dict[str, Any]]:
+    impacted_by_node_id: dict[str, dict[str, Any]] = {}
+    for path in paths:
+        target_node_id = path.get("target_node_id")
+        if target_node_id is None:
+            continue
+        node_id = str(target_node_id)
+        impact = impacted_by_node_id.setdefault(
+            node_id,
+            {
+                "channel": channel,
+                "node_id": target_node_id,
+                "canonical_entity_id": path.get("target_entity_id"),
+                "labels": _string_list(path.get("target_labels")),
+                "score": 0.0,
+                "stable_node_id": node_id,
+                "path_count": 0,
+            },
+        )
+        impact["score"] = max(
+            float(impact["score"]),
+            _optional_float(path.get(score_key)) or 0.0,
+        )
+        impact["path_count"] = int(impact["path_count"]) + 1
+
+    impacted_entities = list(impacted_by_node_id.values())
+    impacted_entities.sort(
+        key=lambda entity: (
+            -float(entity["score"]),
+            str(entity["stable_node_id"]),
+        ),
+    )
+    return impacted_entities[:result_limit]
+
+
+def _lineage_from_row(row: Mapping[str, Any]) -> dict[str, Any]:
+    properties = _properties_from_row(row)
+    if properties is None:
+        return {}
+    lineage = properties.get("lineage")
+    if isinstance(lineage, Mapping):
+        return dict(lineage)
+    return {}
+
+
+def _properties_from_row(row: Mapping[str, Any]) -> Mapping[str, Any] | None:
+    properties_json = row.get("properties_json")
+    if not isinstance(properties_json, str) or not properties_json:
+        return None
+    try:
+        properties = json.loads(properties_json)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(properties, Mapping):
+        return None
+    return properties
+
+
+def _evidence_refs(row: Mapping[str, Any], diagnostics: dict[str, int]) -> list[str]:
+    try:
+        refs = evidence_refs_from_mapping(row)
+    except ValueError:
+        _increment(diagnostics, "invalid_evidence_refs")
+        return []
+    if not refs:
+        _increment(diagnostics, "missing_evidence_refs")
+        return []
+    return refs
+
+
+def _first_float(
+    row: Mapping[str, Any],
+    keys: tuple[str, ...],
+    *,
+    default: float | None = None,
+) -> float | None:
+    for key in keys:
+        value = row.get(key)
+        if value is None:
+            continue
+        return _optional_float(value)
+    return default
+
+
+def _optional_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(number):
+        return None
+    return number
+
+
+def _bounded_float(value: Any, *, default: float) -> float | None:
+    number = _optional_float(value)
+    if number is None:
+        number = default
+    if number < 0.0:
+        return None
+    return number
+
+
+def _int_value(value: Any) -> int | None:
+    number = _optional_float(value)
+    if number is None:
+        return None
+    return int(number)
+
+
+def _context_multiplier(context: PropagationContext, channel: str) -> float:
+    return float(context.channel_multipliers.get(channel, 1.0))
+
+
+def _context_regime_multiplier(context: PropagationContext, channel: str) -> float:
+    return float(context.regime_multipliers.get(channel, 1.0))
+
+
+def _path_sort_key(path: Mapping[str, Any]) -> tuple[float, str, str, str, str, str]:
+    return (
+        -float(path.get("score") or 0.0),
+        str(path.get("channel") or ""),
+        str(path.get("source_node_id") or ""),
+        str(path.get("relationship_type") or ""),
+        str(path.get("target_node_id") or ""),
+        str(path.get("edge_id") or ""),
+    )
+
+
+def _string_list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return sorted(str(item) for item in value)
+
+
+def _scan_limit(result_limit: int) -> int:
+    return max(result_limit * 20, 100)
+
+
+def _validate_result_limit(result_limit: int) -> None:
+    if result_limit < 1:
+        raise ValueError("result_limit must be greater than zero")
+
+
+def _validate_context_generation(
+    context: PropagationContext,
+    graph_generation_id: int,
+) -> None:
+    if graph_generation_id != context.graph_generation_id:
+        raise ValueError(
+            "PropagationContext graph_generation_id disagrees with Neo4jGraphStatus: "
+            f"context={context.graph_generation_id}, status={graph_generation_id}",
+        )
+
+
+def _increment(diagnostics: dict[str, int], key: str) -> None:
+    diagnostics[key] = diagnostics.get(key, 0) + 1
+
+
+def _increment_by(diagnostics: dict[str, int], key: str, amount: int) -> None:
+    diagnostics[key] = diagnostics.get(key, 0) + amount
+
+
+def _is_finite_non_negative(value: float) -> bool:
+    return math.isfinite(value) and value >= 0.0

--- a/tests/unit/test_propagation_holdings.py
+++ b/tests/unit/test_propagation_holdings.py
@@ -1,0 +1,631 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+
+from graph_engine.models import Neo4jGraphStatus, PropagationContext
+from graph_engine.propagation import (
+    HoldingsAlgorithmConfig,
+    run_co_holding_crowding,
+    run_holdings_algorithms,
+    run_northbound_anomaly,
+)
+from graph_engine.status import GraphStatusManager
+from tests.fakes import InMemoryStatusStore
+
+NOW = datetime(2026, 5, 7, 1, 2, 3, tzinfo=timezone.utc)
+
+
+class FakeHoldingsClient:
+    def __init__(
+        self,
+        *,
+        co_holding_rows: list[dict[str, Any]] | None = None,
+        northbound_rows: list[dict[str, Any]] | None = None,
+    ) -> None:
+        self.co_holding_rows = co_holding_rows or []
+        self.northbound_rows = northbound_rows or []
+        self.read_calls: list[tuple[str, dict[str, Any]]] = []
+        self.write_calls: list[tuple[str, dict[str, Any]]] = []
+
+    def execute_read(
+        self,
+        query: str,
+        parameters: dict[str, Any] | None = None,
+    ) -> list[dict[str, Any]]:
+        params = parameters or {}
+        self.read_calls.append((query, params))
+        if "CO_HOLDING" in query:
+            return self.co_holding_rows[: int(params.get("scan_limit", len(self.co_holding_rows)))]
+        if "NORTHBOUND_HOLD" in query:
+            return self.northbound_rows[: int(params.get("scan_limit", len(self.northbound_rows)))]
+        return []
+
+    def execute_write(
+        self,
+        query: str,
+        parameters: dict[str, Any] | None = None,
+    ) -> list[dict[str, Any]]:
+        self.write_calls.append((query, parameters or {}))
+        raise AssertionError("holdings algorithms must not execute writes")
+
+
+@pytest.mark.parametrize("graph_status", ["rebuilding", "failed"])
+def test_co_holding_crowding_blocks_non_ready_before_neo4j_reads(
+    graph_status: str,
+) -> None:
+    client = FakeHoldingsClient(co_holding_rows=[_co_row()])
+
+    with pytest.raises(PermissionError, match="ready"):
+        run_co_holding_crowding(
+            _context(enabled_channels=["reflexive"]),
+            client,  # type: ignore[arg-type]
+            status_manager=_status_manager(graph_status=graph_status),
+        )
+
+    assert client.read_calls == []
+    assert client.write_calls == []
+
+
+def test_co_holding_crowding_blocks_active_writer_lock_before_neo4j_reads() -> None:
+    client = FakeHoldingsClient(co_holding_rows=[_co_row()])
+
+    with pytest.raises(PermissionError, match="writer lock"):
+        run_co_holding_crowding(
+            _context(enabled_channels=["reflexive"]),
+            client,  # type: ignore[arg-type]
+            status_manager=_status_manager(writer_lock_token="incremental-sync"),
+        )
+
+    assert client.read_calls == []
+    assert client.write_calls == []
+
+
+def test_co_holding_crowding_blocks_generation_mismatch_before_neo4j_reads() -> None:
+    client = FakeHoldingsClient(co_holding_rows=[_co_row()])
+
+    with pytest.raises(ValueError, match="graph_generation_id"):
+        run_co_holding_crowding(
+            _context(enabled_channels=["reflexive"]),
+            client,  # type: ignore[arg-type]
+            status_manager=_status_manager(graph_generation_id=2),
+        )
+
+    assert client.read_calls == []
+    assert client.write_calls == []
+
+
+def test_co_holding_crowding_requires_reflexive_channel_before_neo4j_reads() -> None:
+    client = FakeHoldingsClient(co_holding_rows=[_co_row()])
+
+    with pytest.raises(PermissionError, match="reflexive channel"):
+        run_co_holding_crowding(
+            _context(enabled_channels=["event"]),
+            client,  # type: ignore[arg-type]
+            status_manager=_status_manager(),
+        )
+
+    assert client.read_calls == []
+    assert client.write_calls == []
+
+
+def test_co_holding_crowding_scores_thresholds_and_records_diagnostics() -> None:
+    client = FakeHoldingsClient(
+        co_holding_rows=[
+            _co_row(
+                edge_id="edge-a",
+                source_node_id="security-a",
+                target_node_id="security-crowded",
+                co_holding_fund_count=4,
+                jaccard_score=1.0,
+                evidence_refs=["mart-co-a"],
+            ),
+            _co_row(
+                edge_id="edge-b",
+                source_node_id="security-b",
+                target_node_id="security-crowded",
+                co_holding_fund_count=3,
+                jaccard_score=1.0,
+                evidence_refs=["mart-co-b"],
+            ),
+            _co_row(
+                edge_id="edge-low-holder",
+                target_node_id="security-skipped",
+                co_holding_fund_count=1,
+                evidence_refs=["mart-low-holder"],
+            ),
+            _co_row(
+                edge_id="edge-no-evidence",
+                target_node_id="security-skipped",
+                evidence_refs=[],
+            ),
+            _co_row(
+                edge_id="edge-below-score",
+                target_node_id="security-below-score",
+                co_holding_fund_count=3,
+                jaccard_score=0.1,
+                evidence_refs=["mart-below-score"],
+            ),
+        ]
+    )
+
+    result = run_co_holding_crowding(
+        _context(enabled_channels=["reflexive"]),
+        client,  # type: ignore[arg-type]
+        status_manager=_status_manager(),
+        config=HoldingsAlgorithmConfig(crowding_threshold=0.4),
+        result_limit=10,
+    )
+
+    assert [path["edge_id"] for path in result.activated_paths] == ["edge-a", "edge-b"]
+    assert all(path["channel"] == "reflexive" for path in result.activated_paths)
+    assert result.activated_paths[0]["algorithm"] == "co_holding_crowding"
+    assert result.activated_paths[0]["crowding_score"] == pytest.approx(0.4)
+    assert result.activated_paths[0]["target_holder_count"] == 7
+    assert result.activated_paths[0]["evidence_refs"] == ["mart-co-a"]
+    assert result.activated_paths[0]["lineage"] == {
+        "source_mart": "mart_deriv_fund_co_holding"
+    }
+
+    assert len(result.impacted_entities) == 1
+    assert result.impacted_entities[0]["node_id"] == "security-crowded"
+    assert result.impacted_entities[0]["score"] == pytest.approx(0.4)
+    assert result.impacted_entities[0]["holder_count"] == 7
+
+    breakdown = result.channel_breakdown["reflexive"]["co_holding_crowding"]
+    assert breakdown["scanned_edge_count"] == 5
+    assert breakdown["valid_edge_count"] == 3
+    assert breakdown["diagnostics"] == {
+        "crowding_score_below_threshold": 1,
+        "holder_count_below_minimum": 1,
+        "missing_evidence_refs": 1,
+    }
+
+    assert client.write_calls == []
+    assert _all_queries_read_only(client.read_calls)
+    assert "CREATE" not in client.read_calls[0][0]
+    assert "MERGE" not in client.read_calls[0][0]
+
+
+def test_co_holding_crowding_prefers_jaccard_over_default_weight() -> None:
+    client = FakeHoldingsClient(
+        co_holding_rows=[
+            _co_row(
+                edge_id="edge-low-jaccard",
+                weight=1.0,
+                jaccard_score=0.2,
+                evidence_refs=["mart-low-jaccard"],
+            ),
+        ]
+    )
+
+    result = run_co_holding_crowding(
+        _context(enabled_channels=["reflexive"]),
+        client,  # type: ignore[arg-type]
+        status_manager=_status_manager(),
+        config=HoldingsAlgorithmConfig(crowding_threshold=0.0),
+    )
+
+    assert len(result.activated_paths) == 1
+    path = result.activated_paths[0]
+    assert path["edge_id"] == "edge-low-jaccard"
+    assert path["score"] == pytest.approx(0.2)
+    assert path["explanation"]["relation_weight"] == pytest.approx(0.2)
+    assert path["crowding_score"] == pytest.approx(0.04)
+
+
+def test_co_holding_crowding_skips_default_weight_when_jaccard_missing() -> None:
+    client = FakeHoldingsClient(
+        co_holding_rows=[
+            _co_row(
+                edge_id="edge-default-weight",
+                weight=1.0,
+                jaccard_score=None,
+                evidence_refs=["mart-default-weight"],
+            ),
+        ]
+    )
+
+    result = run_co_holding_crowding(
+        _context(enabled_channels=["reflexive"]),
+        client,  # type: ignore[arg-type]
+        status_manager=_status_manager(),
+        config=HoldingsAlgorithmConfig(crowding_threshold=0.0),
+    )
+
+    assert result.activated_paths == []
+    breakdown = result.channel_breakdown["reflexive"]["co_holding_crowding"]
+    assert breakdown["diagnostics"] == {
+        "invalid_scoring_field": 1,
+        "missing_explicit_weight": 1,
+    }
+
+
+def test_co_holding_crowding_falls_back_to_explicit_properties_weight() -> None:
+    client = FakeHoldingsClient(
+        co_holding_rows=[
+            _co_row(
+                edge_id="edge-weight-only",
+                weight=1.0,
+                jaccard_score=None,
+                properties_weight=0.7,
+                include_properties_weight=True,
+                evidence_refs=["mart-weight-only"],
+            ),
+        ]
+    )
+
+    result = run_co_holding_crowding(
+        _context(enabled_channels=["reflexive"]),
+        client,  # type: ignore[arg-type]
+        status_manager=_status_manager(),
+        config=HoldingsAlgorithmConfig(crowding_threshold=0.0),
+    )
+
+    assert len(result.activated_paths) == 1
+    path = result.activated_paths[0]
+    assert path["edge_id"] == "edge-weight-only"
+    assert path["score"] == pytest.approx(0.7)
+    assert path["explanation"]["relation_weight"] == pytest.approx(0.7)
+
+
+def test_co_holding_crowding_skips_invalid_explicit_properties_weight() -> None:
+    client = FakeHoldingsClient(
+        co_holding_rows=[
+            _co_row(
+                edge_id="edge-invalid-explicit-weight",
+                weight=1.0,
+                jaccard_score=None,
+                properties_weight="not-a-number",
+                include_properties_weight=True,
+                evidence_refs=["mart-invalid-explicit-weight"],
+            ),
+        ]
+    )
+
+    result = run_co_holding_crowding(
+        _context(enabled_channels=["reflexive"]),
+        client,  # type: ignore[arg-type]
+        status_manager=_status_manager(),
+        config=HoldingsAlgorithmConfig(crowding_threshold=0.0),
+    )
+
+    assert result.activated_paths == []
+    breakdown = result.channel_breakdown["reflexive"]["co_holding_crowding"]
+    assert breakdown["diagnostics"] == {
+        "invalid_explicit_weight": 1,
+        "invalid_scoring_field": 1,
+    }
+
+
+def test_co_holding_crowding_skips_invalid_jaccard_without_fallback() -> None:
+    client = FakeHoldingsClient(
+        co_holding_rows=[
+            _co_row(
+                edge_id="edge-invalid-jaccard",
+                weight=1.0,
+                jaccard_score="not-a-number",
+                evidence_refs=["mart-invalid-jaccard"],
+            ),
+        ]
+    )
+
+    result = run_co_holding_crowding(
+        _context(enabled_channels=["reflexive"]),
+        client,  # type: ignore[arg-type]
+        status_manager=_status_manager(),
+        config=HoldingsAlgorithmConfig(crowding_threshold=0.0),
+    )
+
+    assert result.activated_paths == []
+    breakdown = result.channel_breakdown["reflexive"]["co_holding_crowding"]
+    assert breakdown["diagnostics"] == {
+        "invalid_jaccard_score": 1,
+        "invalid_scoring_field": 1,
+    }
+
+
+def test_northbound_anomaly_blocks_generation_mismatch_before_neo4j_reads() -> None:
+    client = FakeHoldingsClient(northbound_rows=[_northbound_row()])
+
+    with pytest.raises(ValueError, match="graph_generation_id"):
+        run_northbound_anomaly(
+            _context(enabled_channels=["event"]),
+            client,  # type: ignore[arg-type]
+            status_manager=_status_manager(graph_generation_id=2),
+        )
+
+    assert client.read_calls == []
+    assert client.write_calls == []
+
+
+def test_northbound_anomaly_scores_direction_and_skips_invalid_rows() -> None:
+    client = FakeHoldingsClient(
+        northbound_rows=[
+            _northbound_row(
+                edge_id="edge-inflow",
+                target_node_id="security-a",
+                metric_z_score=2.4,
+                evidence_refs=["mart-nb-inflow"],
+            ),
+            _northbound_row(
+                edge_id="edge-outflow",
+                target_node_id="security-b",
+                metric_z_score=-2.1,
+                evidence_refs=["mart-nb-outflow"],
+            ),
+            _northbound_row(
+                edge_id="edge-low",
+                metric_z_score=1.9,
+                evidence_refs=["mart-nb-low"],
+            ),
+            _northbound_row(
+                edge_id="edge-missing-z",
+                metric_z_score=None,
+                northbound_z_score=None,
+                z_score=None,
+                evidence_refs=["mart-nb-missing-z"],
+            ),
+            _northbound_row(edge_id="edge-no-evidence", evidence_refs=[]),
+        ]
+    )
+
+    result = run_northbound_anomaly(
+        _context(enabled_channels=["event"]),
+        client,  # type: ignore[arg-type]
+        status_manager=_status_manager(),
+        result_limit=10,
+    )
+
+    assert [path["edge_id"] for path in result.activated_paths] == [
+        "edge-inflow",
+        "edge-outflow",
+    ]
+    assert result.activated_paths[0]["channel"] == "event"
+    assert result.activated_paths[0]["algorithm"] == "northbound_anomaly"
+    assert result.activated_paths[0]["direction"] == "inflow"
+    assert result.activated_paths[1]["direction"] == "outflow"
+    assert result.activated_paths[0]["score"] == pytest.approx(2.4)
+    assert result.activated_paths[0]["lookback_observations"] == 8
+    assert result.activated_paths[0]["lineage"] == {
+        "source_mart": "mart_deriv_northbound_holding_z_score"
+    }
+    assert [entity["node_id"] for entity in result.impacted_entities] == [
+        "security-a",
+        "security-b",
+    ]
+
+    breakdown = result.channel_breakdown["event"]["northbound_anomaly"]
+    assert breakdown["diagnostics"] == {
+        "missing_evidence_refs": 1,
+        "missing_z_score": 1,
+        "z_score_below_threshold": 1,
+    }
+    assert breakdown["northbound_z_threshold"] == pytest.approx(2.0)
+    assert client.write_calls == []
+    assert _all_queries_read_only(client.read_calls)
+
+
+def test_northbound_anomaly_accepts_fallback_z_score_fields() -> None:
+    client = FakeHoldingsClient(
+        northbound_rows=[
+            _northbound_row(
+                edge_id="edge-northbound-z",
+                metric_z_score=None,
+                northbound_z_score=2.2,
+                z_score=None,
+                evidence_refs=["mart-nb-fallback-1"],
+            ),
+            _northbound_row(
+                edge_id="edge-z-score",
+                metric_z_score=None,
+                northbound_z_score=None,
+                z_score=-2.3,
+                evidence_refs=["mart-nb-fallback-2"],
+            ),
+        ]
+    )
+
+    result = run_northbound_anomaly(
+        _context(enabled_channels=["event"]),
+        client,  # type: ignore[arg-type]
+        status_manager=_status_manager(),
+        result_limit=10,
+    )
+
+    assert [path["z_score"] for path in result.activated_paths] == [-2.3, 2.2]
+    assert [path["direction"] for path in result.activated_paths] == ["outflow", "inflow"]
+
+
+def test_run_holdings_algorithms_merges_explicit_event_and_reflexive_results() -> None:
+    client = FakeHoldingsClient(
+        co_holding_rows=[
+            _co_row(
+                edge_id="edge-co-a",
+                target_node_id="security-shared",
+                jaccard_score=1.0,
+                evidence_refs=["mart-co-a"],
+            ),
+            _co_row(
+                edge_id="edge-co-b",
+                source_node_id="security-b",
+                target_node_id="security-shared",
+                jaccard_score=1.0,
+                evidence_refs=["mart-co-b"],
+            ),
+        ],
+        northbound_rows=[
+            _northbound_row(
+                edge_id="edge-nb",
+                target_node_id="security-nb",
+                metric_z_score=2.5,
+                evidence_refs=["mart-nb"],
+            ),
+        ],
+    )
+
+    result = run_holdings_algorithms(
+        _context(enabled_channels=["event", "reflexive"]),
+        client,  # type: ignore[arg-type]
+        status_manager=_status_manager(),
+        result_limit=10,
+    )
+
+    assert result.channel_breakdown["merged"]["enabled_channels"] == ["event", "reflexive"]
+    assert {path["algorithm"] for path in result.activated_paths} == {
+        "co_holding_crowding",
+        "northbound_anomaly",
+    }
+    assert {path["relationship_type"] for path in result.activated_paths} == {
+        "CO_HOLDING",
+        "NORTHBOUND_HOLD",
+    }
+    assert client.write_calls == []
+
+
+def test_run_holdings_algorithms_is_not_wired_into_full_propagation() -> None:
+    import graph_engine.propagation.pipeline as propagation_pipeline
+
+    assert "run_holdings_algorithms" not in propagation_pipeline.__dict__
+
+
+def _context(*, enabled_channels: list[str]) -> PropagationContext:
+    return PropagationContext(
+        cycle_id="cycle-1",
+        world_state_ref="world-state-1",
+        graph_generation_id=1,
+        enabled_channels=enabled_channels,  # type: ignore[arg-type]
+        channel_multipliers={channel: 1.0 for channel in enabled_channels},
+        regime_multipliers={channel: 1.0 for channel in enabled_channels},
+        decay_policy={},
+        regime_context={},
+    )
+
+
+def _status_manager(
+    *,
+    graph_status: str = "ready",
+    graph_generation_id: int = 1,
+    writer_lock_token: str | None = None,
+) -> GraphStatusManager:
+    return GraphStatusManager(
+        InMemoryStatusStore(
+            Neo4jGraphStatus(
+                graph_status=graph_status,  # type: ignore[arg-type]
+                graph_generation_id=graph_generation_id,
+                node_count=3,
+                edge_count=2,
+                key_label_counts={"Entity": 3},
+                checksum="abc123" if graph_status == "ready" else graph_status,
+                last_verified_at=NOW if graph_status == "ready" else None,
+                last_reload_at=None,
+                writer_lock_token=writer_lock_token,
+            ),
+        ),
+    )
+
+
+def _co_row(
+    *,
+    edge_id: str = "edge-co",
+    source_node_id: str = "security-a",
+    source_entity_id: str = "entity-security-a",
+    target_node_id: str = "security-b",
+    target_entity_id: str = "entity-security-b",
+    co_holding_fund_count: int | None = 3,
+    security_left_fund_count: int = 10,
+    security_right_fund_count: int = 9,
+    weight: float | None = None,
+    jaccard_score: Any = 1.0,
+    properties_weight: Any = None,
+    include_properties_weight: bool = False,
+    evidence_refs: list[str] | None = None,
+) -> dict[str, Any]:
+    properties: dict[str, Any] = {
+        "lineage": {"source_mart": "mart_deriv_fund_co_holding"},
+    }
+    if include_properties_weight:
+        properties["weight"] = properties_weight
+
+    return {
+        "source_node_id": source_node_id,
+        "source_entity_id": source_entity_id,
+        "source_labels": ["Entity"],
+        "target_node_id": target_node_id,
+        "target_entity_id": target_entity_id,
+        "target_labels": ["Entity"],
+        "edge_id": edge_id,
+        "relationship_type": "CO_HOLDING",
+        "evidence_refs": [f"fact-{edge_id}"] if evidence_refs is None else evidence_refs,
+        "evidence_ref": None,
+        "properties_json": json.dumps(properties, sort_keys=True),
+        "weight": weight,
+        "evidence_confidence": 1.0,
+        "recency_decay": 1.0,
+        "co_holding_fund_count": co_holding_fund_count,
+        "security_left_fund_count": security_left_fund_count,
+        "security_right_fund_count": security_right_fund_count,
+        "jaccard_score": jaccard_score,
+        "report_date": "2026-03-31",
+        "latest_announced_date": "2026-04-30",
+        "source_canonical_id_rule_version": "entity-registry/v1",
+        "target_canonical_id_rule_version": "entity-registry/v1",
+    }
+
+
+def _northbound_row(
+    *,
+    edge_id: str = "edge-nb",
+    source_node_id: str = "northbound-holder",
+    source_entity_id: str = "entity-northbound-holder",
+    target_node_id: str = "security-a",
+    target_entity_id: str = "entity-security-a",
+    metric_z_score: float | None = 2.4,
+    northbound_z_score: float | None = None,
+    z_score: float | None = None,
+    evidence_refs: list[str] | None = None,
+) -> dict[str, Any]:
+    return {
+        "source_node_id": source_node_id,
+        "source_entity_id": source_entity_id,
+        "source_labels": ["Entity"],
+        "target_node_id": target_node_id,
+        "target_entity_id": target_entity_id,
+        "target_labels": ["Entity"],
+        "edge_id": edge_id,
+        "relationship_type": "NORTHBOUND_HOLD",
+        "evidence_refs": [f"fact-{edge_id}"] if evidence_refs is None else evidence_refs,
+        "evidence_ref": None,
+        "properties_json": json.dumps(
+            {"lineage": {"source_mart": "mart_deriv_northbound_holding_z_score"}},
+            sort_keys=True,
+        ),
+        "weight": None,
+        "evidence_confidence": 1.0,
+        "recency_decay": 1.0,
+        "metric_z_score": metric_z_score,
+        "northbound_z_score": northbound_z_score,
+        "z_score": z_score,
+        "z_score_metric": "holding_ratio",
+        "lookback_observations": 8,
+        "window_start_date": "2025-12-31",
+        "window_end_date": "2026-03-31",
+        "observation_count": 63,
+        "metric_value": 0.018,
+        "metric_mean": 0.011,
+        "metric_stddev": 0.0029,
+        "report_date": "2026-03-31",
+        "source_canonical_id_rule_version": "entity-registry/v1",
+        "target_canonical_id_rule_version": "entity-registry/v1",
+    }
+
+
+def _all_queries_read_only(read_calls: list[tuple[str, dict[str, Any]]]) -> bool:
+    forbidden_tokens = ("CREATE", "MERGE", " SET ", "DELETE")
+    return all(
+        not any(token in query for token in forbidden_tokens)
+        for query, _ in read_calls
+    )


### PR DESCRIPTION
## Summary
- Add explicit holdings-only propagation algorithms for graph-engine #55.
- Implement `CO_HOLDING` co-holding crowding on the `reflexive` channel.
- Implement `NORTHBOUND_HOLD` northbound anomaly detection on the `event` channel.
- Update README and PROGRESS docs to mark the old #55 four-algorithm scope as superseded.

Closes #55

## Superseded Scope / Boundaries
This PR intentionally narrows #55 to the currently validated holdings scope only.

Included:
- `CO_HOLDING` co-holding crowding
- `NORTHBOUND_HOLD` northbound anomaly
- explicit algorithm entrypoints only
- read-only graph access through `execute_read`

Not included:
- no guarantees algorithm
- no related-party / financial-doc algorithm
- no contracts subtype or contracts changes
- no `MAJOR_CUSTOMER` / `MAJOR_SUPPLIER`
- no default `run_full_propagation` integration
- no live graph writeback or production rollout claim

## Tests
- Holdings readiness: `78 passed`
- Promotion/contracts regression: `56 passed`
- Ruff: passed
- `git diff --check`: passed

## Notes
The implementation fail-closes on non-ready graph state, writer lock, generation mismatch, missing evidence, missing or invalid co-holding score inputs, and missing or low northbound z-score inputs. It keeps the first version as an explicit API so default propagation behavior does not double-count holdings signals.