### PR TITLE
[codex] Add holdings live graph proof harness

### DIFF
--- a/graph_engine/proofs/__init__.py
+++ b/graph_engine/proofs/__init__.py
@@ -1,0 +1,39 @@
+"""Proof utilities for guarded graph-engine validation flows."""
+
+from graph_engine.proofs.holdings_live_graph import (
+    HoldingsAlgorithmProofSummary,
+    HoldingsLiveGraphProofConfig,
+    HoldingsLiveGraphProofSummary,
+    LayerAArtifactCanonicalWriter,
+    LayerAArtifactSummary,
+    LoadedCandidateDeltaReader,
+    Neo4jEdgeVerificationSummary,
+    ReadOnlyGraphClient,
+    build_holdings_proof_context,
+    run_holdings_live_graph_proof,
+    run_holdings_algorithm_proof,
+    validate_holdings_candidate_deltas,
+    validate_holdings_live_graph_proof_env,
+    validate_holdings_promotion_plan,
+    verify_holdings_edges,
+    write_layer_a_artifact,
+)
+
+__all__ = [
+    "HoldingsAlgorithmProofSummary",
+    "HoldingsLiveGraphProofConfig",
+    "HoldingsLiveGraphProofSummary",
+    "LayerAArtifactCanonicalWriter",
+    "LayerAArtifactSummary",
+    "LoadedCandidateDeltaReader",
+    "Neo4jEdgeVerificationSummary",
+    "ReadOnlyGraphClient",
+    "build_holdings_proof_context",
+    "run_holdings_live_graph_proof",
+    "run_holdings_algorithm_proof",
+    "validate_holdings_candidate_deltas",
+    "validate_holdings_live_graph_proof_env",
+    "validate_holdings_promotion_plan",
+    "verify_holdings_edges",
+    "write_layer_a_artifact",
+]

--- a/graph_engine/proofs/holdings_live_graph.py
+++ b/graph_engine/proofs/holdings_live_graph.py
@@ -1,0 +1,569 @@
+"""Guarded utilities for the holdings live graph proof.
+
+The module is intentionally a library surface for the assembly cross-repo
+runner. It does not load environment variables, open network connections, or
+run the production propagation pipeline by itself.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Protocol
+
+from contracts.schemas import CandidateGraphDelta
+
+from graph_engine.models import PropagationContext, PropagationResult, PromotionPlan
+from graph_engine.promotion.interfaces import EntityAnchorReader
+from graph_engine.promotion.service import promote_graph_deltas
+from graph_engine.propagation import (
+    HoldingsAlgorithmConfig,
+    run_co_holding_crowding,
+    run_northbound_anomaly,
+)
+from graph_engine.status import GraphStatusManager
+
+_CONFIRM_ENV = "GRAPH_ENGINE_LIVE_PROOF_CONFIRM"
+_NAMESPACE_ENV = "GRAPH_ENGINE_LIVE_PROOF_NAMESPACE"
+_NEO4J_DATABASE_ENV = "NEO4J_DATABASE"
+_CONFIRM_VALUE = "1"
+_DEFAULT_NEO4J_DATABASE = "neo4j"
+_SAFE_NAMESPACE_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]{2,95}$")
+_SAFE_FILE_COMPONENT_PATTERN = re.compile(r"[^A-Za-z0-9_.-]+")
+_PROOF_PATH_MARKER_PATTERN = re.compile(r"(^|[.-])(proof|smoke|test)([.-]|$)")
+_ALLOWED_HOLDINGS_RELATIONSHIPS = frozenset({"CO_HOLDING", "NORTHBOUND_HOLD"})
+
+
+class ReadOnlyGraphClient(Protocol):
+    """Graph client surface needed by proof readback and algorithms."""
+
+    def execute_read(
+        self,
+        query: str,
+        parameters: dict[str, Any] | None = None,
+    ) -> list[dict[str, Any]]:
+        """Run a read query and return rows."""
+
+
+@dataclass(frozen=True)
+class HoldingsLiveGraphProofConfig:
+    """Validated live graph proof gates."""
+
+    namespace: str
+    neo4j_database: str
+    artifact_root: Path
+
+
+@dataclass(frozen=True)
+class LayerAArtifactSummary:
+    """Summary of the Layer A canonical artifact written for a proof."""
+
+    manifest_path: Path
+    records_path: Path
+    cycle_id: str
+    selection_ref: str
+    delta_count: int
+    node_count: int
+    edge_count: int
+    assertion_count: int
+    relation_counts: dict[str, int]
+
+
+@dataclass(frozen=True)
+class Neo4jEdgeVerificationSummary:
+    """Read-only verification result for synced holdings edges."""
+
+    expected_edge_count: int
+    edge_count: int
+    relation_counts: dict[str, int]
+    missing_edge_ids: list[str]
+    disallowed_relation_types: list[str]
+
+
+@dataclass(frozen=True)
+class HoldingsAlgorithmProofSummary:
+    """Summary of explicit #55 holdings algorithm output."""
+
+    cycle_id: str
+    graph_generation_id: int
+    co_holding_path_count: int
+    northbound_path_count: int
+    total_path_count: int
+    impacted_entity_count: int
+    co_holding_diagnostics: dict[str, int]
+    northbound_diagnostics: dict[str, int]
+
+
+@dataclass(frozen=True)
+class HoldingsLiveGraphProofSummary:
+    """End-to-end holdings proof summary for assembly evidence."""
+
+    namespace: str
+    neo4j_database: str
+    cycle_id: str
+    selection_ref: str
+    layer_a_artifact: LayerAArtifactSummary
+    edge_verification: Neo4jEdgeVerificationSummary
+    algorithm_proof: HoldingsAlgorithmProofSummary
+
+
+@dataclass(frozen=True)
+class LoadedCandidateDeltaReader:
+    """CandidateDeltaReader for already-loaded frozen holdings candidates."""
+
+    deltas: Sequence[CandidateGraphDelta]
+
+    def read_candidate_graph_deltas(
+        self,
+        cycle_id: str,
+        selection_ref: str,
+    ) -> list[CandidateGraphDelta]:
+        """Return validated in-memory candidate deltas."""
+
+        del cycle_id, selection_ref
+        validate_holdings_candidate_deltas(self.deltas)
+        return list(self.deltas)
+
+
+class LayerAArtifactCanonicalWriter:
+    """CanonicalWriter implementation that persists a PromotionPlan as artifacts."""
+
+    def __init__(self, artifact_root: str | Path, *, namespace: str) -> None:
+        config = _validate_artifact_destination(artifact_root, namespace=namespace)
+        self.artifact_root = config.artifact_root
+        self.namespace = config.namespace
+        self.last_summary: LayerAArtifactSummary | None = None
+
+    def write_canonical_records(self, plan: PromotionPlan) -> None:
+        """Write a promotion plan in a curated Layer A artifact shape."""
+
+        self.last_summary = write_layer_a_artifact(
+            plan,
+            artifact_root=self.artifact_root,
+            namespace=self.namespace,
+        )
+
+
+def validate_holdings_live_graph_proof_env(
+    env: Mapping[str, str | None],
+    *,
+    artifact_root: str | Path,
+) -> HoldingsLiveGraphProofConfig:
+    """Validate gates before any live proof can write artifacts or Neo4j."""
+
+    if env.get(_CONFIRM_ENV) != _CONFIRM_VALUE:
+        raise PermissionError(f"{_CONFIRM_ENV}=1 is required for holdings live graph proof")
+
+    namespace = _require_namespace(env.get(_NAMESPACE_ENV))
+    neo4j_database = str(env.get(_NEO4J_DATABASE_ENV) or "").strip()
+    if not neo4j_database:
+        raise PermissionError(f"{_NEO4J_DATABASE_ENV} is required for holdings live graph proof")
+    if neo4j_database.lower() == _DEFAULT_NEO4J_DATABASE:
+        raise PermissionError("default Neo4j database 'neo4j' is not allowed for this proof")
+
+    artifact_config = _validate_artifact_destination(artifact_root, namespace=namespace)
+    return HoldingsLiveGraphProofConfig(
+        namespace=namespace,
+        neo4j_database=neo4j_database,
+        artifact_root=artifact_config.artifact_root,
+    )
+
+
+def validate_holdings_candidate_deltas(
+    deltas: Sequence[CandidateGraphDelta],
+) -> None:
+    """Fail closed unless every candidate delta is a supported holdings edge."""
+
+    relation_types = sorted({delta.relation_type for delta in deltas})
+    disallowed = [
+        relation_type
+        for relation_type in relation_types
+        if relation_type not in _ALLOWED_HOLDINGS_RELATIONSHIPS
+    ]
+    if disallowed:
+        raise ValueError(f"unsupported holdings proof relation types: {disallowed}")
+    if not deltas:
+        raise ValueError("holdings proof requires at least one candidate delta")
+
+
+def validate_holdings_promotion_plan(plan: PromotionPlan) -> None:
+    """Fail closed unless the promotion plan only contains holdings edges."""
+
+    relation_types = sorted({edge.relationship_type for edge in plan.edge_records})
+    disallowed = [
+        relation_type
+        for relation_type in relation_types
+        if relation_type not in _ALLOWED_HOLDINGS_RELATIONSHIPS
+    ]
+    if disallowed:
+        raise ValueError(f"unsupported holdings proof relation types: {disallowed}")
+    if not plan.edge_records:
+        raise ValueError("holdings proof requires at least one promoted edge")
+
+
+def write_layer_a_artifact(
+    plan: PromotionPlan,
+    *,
+    artifact_root: str | Path,
+    namespace: str,
+) -> LayerAArtifactSummary:
+    """Write canonical records as sanitized JSON + JSONL Layer A artifacts."""
+
+    artifact_config = _validate_artifact_destination(artifact_root, namespace=namespace)
+    validate_holdings_promotion_plan(plan)
+
+    artifact_dir = (
+        artifact_config.artifact_root
+        / artifact_config.namespace
+        / "layer_a"
+        / _safe_file_component(plan.cycle_id)
+        / _safe_file_component(plan.selection_ref)
+    )
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    records_path = artifact_dir / "canonical_records.jsonl"
+    manifest_path = artifact_dir / "manifest.json"
+
+    records = list(_canonical_record_lines(plan))
+    _atomic_write_text(records_path, "\n".join(records) + "\n")
+
+    relation_counts = dict(
+        sorted(Counter(edge.relationship_type for edge in plan.edge_records).items())
+    )
+    manifest = {
+        "artifact_type": "holdings_live_graph_layer_a",
+        "layer": "Layer A",
+        "namespace": artifact_config.namespace,
+        "cycle_id": plan.cycle_id,
+        "selection_ref": plan.selection_ref,
+        "records_ref": "canonical_records.jsonl",
+        "delta_count": len(plan.delta_ids),
+        "node_count": len(plan.node_records),
+        "edge_count": len(plan.edge_records),
+        "assertion_count": len(plan.assertion_records),
+        "relation_counts": relation_counts,
+        "relation_types": sorted(relation_counts),
+        "delta_ids": sorted(plan.delta_ids),
+        "created_at": plan.created_at.isoformat(),
+    }
+    _atomic_write_json(manifest_path, manifest)
+
+    return LayerAArtifactSummary(
+        manifest_path=manifest_path,
+        records_path=records_path,
+        cycle_id=plan.cycle_id,
+        selection_ref=plan.selection_ref,
+        delta_count=len(plan.delta_ids),
+        node_count=len(plan.node_records),
+        edge_count=len(plan.edge_records),
+        assertion_count=len(plan.assertion_records),
+        relation_counts=relation_counts,
+    )
+
+
+def verify_holdings_edges(
+    client: ReadOnlyGraphClient,
+    *,
+    edge_ids: Sequence[str],
+    strict: bool = True,
+) -> Neo4jEdgeVerificationSummary:
+    """Verify synced holdings edges with a read-only query scoped by edge id."""
+
+    expected_edge_ids = sorted({str(edge_id) for edge_id in edge_ids if str(edge_id).strip()})
+    if not expected_edge_ids:
+        raise ValueError("edge_ids must not be empty")
+
+    rows = client.execute_read(
+        """
+MATCH ()-[relationship]->()
+WHERE relationship.edge_id IN $edge_ids
+RETURN relationship.edge_id AS edge_id,
+       type(relationship) AS relationship_type
+ORDER BY edge_id ASC
+""",
+        {"edge_ids": expected_edge_ids},
+    )
+    seen_edge_ids = sorted(
+        str(row.get("edge_id"))
+        for row in rows
+        if row.get("edge_id") is not None
+    )
+    relation_counts = dict(
+        sorted(Counter(str(row.get("relationship_type")) for row in rows).items())
+    )
+    missing_edge_ids = sorted(set(expected_edge_ids) - set(seen_edge_ids))
+    disallowed_relation_types = sorted(
+        relation_type
+        for relation_type in relation_counts
+        if relation_type not in _ALLOWED_HOLDINGS_RELATIONSHIPS
+    )
+
+    summary = Neo4jEdgeVerificationSummary(
+        expected_edge_count=len(expected_edge_ids),
+        edge_count=len(seen_edge_ids),
+        relation_counts=relation_counts,
+        missing_edge_ids=missing_edge_ids,
+        disallowed_relation_types=disallowed_relation_types,
+    )
+    if strict:
+        if missing_edge_ids:
+            raise ValueError(f"missing synced holdings edges: {missing_edge_ids}")
+        if disallowed_relation_types:
+            raise ValueError(
+                "unexpected holdings proof relation types: "
+                f"{disallowed_relation_types}"
+            )
+    return summary
+
+
+def build_holdings_proof_context(
+    *,
+    cycle_id: str,
+    graph_generation_id: int,
+    namespace: str,
+    world_state_ref: str | None = None,
+) -> PropagationContext:
+    """Create the explicit #55 read-only algorithm context for a proof run."""
+
+    safe_namespace = _require_namespace(namespace)
+    return PropagationContext(
+        cycle_id=cycle_id,
+        world_state_ref=world_state_ref or f"holdings-live-graph-proof:{safe_namespace}",
+        graph_generation_id=graph_generation_id,
+        enabled_channels=["event", "reflexive"],
+        channel_multipliers={"event": 1.0, "reflexive": 1.0},
+        regime_multipliers={"event": 1.0, "reflexive": 1.0},
+        decay_policy={},
+        regime_context={"proof_namespace": safe_namespace},
+    )
+
+
+def run_holdings_algorithm_proof(
+    context: PropagationContext,
+    client: ReadOnlyGraphClient,
+    *,
+    status_manager: GraphStatusManager,
+    config: HoldingsAlgorithmConfig | None = None,
+    result_limit: int = 100,
+) -> HoldingsAlgorithmProofSummary:
+    """Run explicit holdings-only #55 algorithms and summarize their output."""
+
+    if "event" not in context.enabled_channels or "reflexive" not in context.enabled_channels:
+        raise PermissionError("holdings live graph proof requires event and reflexive channels")
+
+    co_holding = run_co_holding_crowding(
+        context,
+        client,  # type: ignore[arg-type]
+        status_manager=status_manager,
+        config=config,
+        result_limit=result_limit,
+    )
+    northbound = run_northbound_anomaly(
+        context,
+        client,  # type: ignore[arg-type]
+        status_manager=status_manager,
+        config=config,
+        result_limit=result_limit,
+    )
+    return HoldingsAlgorithmProofSummary(
+        cycle_id=context.cycle_id,
+        graph_generation_id=context.graph_generation_id,
+        co_holding_path_count=len(co_holding.activated_paths),
+        northbound_path_count=len(northbound.activated_paths),
+        total_path_count=len(co_holding.activated_paths) + len(northbound.activated_paths),
+        impacted_entity_count=_merged_impacted_entity_count(co_holding, northbound),
+        co_holding_diagnostics=_co_holding_diagnostics(co_holding),
+        northbound_diagnostics=_northbound_diagnostics(northbound),
+    )
+
+
+def run_holdings_live_graph_proof(
+    *,
+    cycle_id: str,
+    selection_ref: str,
+    candidate_deltas: Sequence[CandidateGraphDelta],
+    entity_reader: EntityAnchorReader,
+    client: Any,
+    status_manager: GraphStatusManager,
+    env: Mapping[str, str | None],
+    artifact_root: str | Path,
+    config: HoldingsAlgorithmConfig | None = None,
+    result_limit: int = 100,
+) -> HoldingsLiveGraphProofSummary:
+    """Run the guarded holdings proof with injected services.
+
+    The only Neo4j write path is the existing promotion live-sync barrier.
+    This function must be called by a runner that already provisioned a
+    disposable Neo4j database and one-time upstream queue/freeze state.
+    """
+
+    proof_config = validate_holdings_live_graph_proof_env(env, artifact_root=artifact_root)
+    validate_holdings_candidate_deltas(candidate_deltas)
+
+    canonical_writer = LayerAArtifactCanonicalWriter(
+        proof_config.artifact_root,
+        namespace=proof_config.namespace,
+    )
+    plan = promote_graph_deltas(
+        cycle_id,
+        selection_ref,
+        candidate_reader=LoadedCandidateDeltaReader(candidate_deltas),
+        entity_reader=entity_reader,
+        canonical_writer=canonical_writer,
+        client=client,
+        status_manager=status_manager,
+        sync_to_live_graph=True,
+    )
+    validate_holdings_promotion_plan(plan)
+    if canonical_writer.last_summary is None:
+        raise RuntimeError("Layer A artifact writer did not record a summary")
+
+    edge_verification = verify_holdings_edges(
+        client,
+        edge_ids=[edge.edge_id for edge in plan.edge_records],
+    )
+    ready_status = status_manager.require_ready()
+    proof_context = build_holdings_proof_context(
+        cycle_id=cycle_id,
+        graph_generation_id=ready_status.graph_generation_id,
+        namespace=proof_config.namespace,
+    )
+    algorithm_proof = run_holdings_algorithm_proof(
+        proof_context,
+        client,
+        status_manager=status_manager,
+        config=config,
+        result_limit=result_limit,
+    )
+
+    return HoldingsLiveGraphProofSummary(
+        namespace=proof_config.namespace,
+        neo4j_database=proof_config.neo4j_database,
+        cycle_id=cycle_id,
+        selection_ref=selection_ref,
+        layer_a_artifact=canonical_writer.last_summary,
+        edge_verification=edge_verification,
+        algorithm_proof=algorithm_proof,
+    )
+
+
+def _validate_artifact_destination(
+    artifact_root: str | Path,
+    *,
+    namespace: str,
+) -> HoldingsLiveGraphProofConfig:
+    safe_namespace = _require_namespace(namespace)
+    resolved_root = Path(artifact_root).expanduser().resolve(strict=False)
+    if resolved_root.exists() and not resolved_root.is_dir():
+        raise ValueError("artifact_root must be a directory")
+    if not _path_has_proof_marker(resolved_root):
+        raise ValueError("artifact_root must be under a proof/smoke/test workspace")
+    return HoldingsLiveGraphProofConfig(
+        namespace=safe_namespace,
+        neo4j_database="<not-validated>",
+        artifact_root=resolved_root,
+    )
+
+
+def _require_namespace(namespace: str | None) -> str:
+    value = str(namespace or "").strip()
+    if not value:
+        raise PermissionError(f"{_NAMESPACE_ENV} is required for holdings live graph proof")
+    if not _SAFE_NAMESPACE_PATTERN.fullmatch(value):
+        raise ValueError(
+            f"{_NAMESPACE_ENV} must match {_SAFE_NAMESPACE_PATTERN.pattern}",
+        )
+    if value.lower() in {"default", "live", "prod", "production", "neo4j"}:
+        raise ValueError(f"{_NAMESPACE_ENV} must be unique, not {value!r}")
+    return value
+
+
+def _path_has_proof_marker(path: Path) -> bool:
+    return any(_PROOF_PATH_MARKER_PATTERN.search(part.lower()) for part in path.parts)
+
+
+def _canonical_record_lines(plan: PromotionPlan) -> list[str]:
+    lines: list[str] = []
+    for node_record in plan.node_records:
+        lines.append(
+            _json_dumps(
+                {
+                    "record_type": "node",
+                    "record": node_record.model_dump(mode="json"),
+                }
+            )
+        )
+    for edge_record in plan.edge_records:
+        lines.append(
+            _json_dumps(
+                {
+                    "record_type": "edge",
+                    "record": edge_record.model_dump(mode="json"),
+                }
+            )
+        )
+    for assertion_record in plan.assertion_records:
+        lines.append(
+            _json_dumps(
+                {
+                    "record_type": "assertion",
+                    "record": assertion_record.model_dump(mode="json"),
+                }
+            )
+        )
+    return lines
+
+
+def _safe_file_component(value: str) -> str:
+    sanitized = _SAFE_FILE_COMPONENT_PATTERN.sub("-", value.strip()).strip(".-")
+    if not sanitized:
+        raise ValueError("file component must not be empty after sanitization")
+    return sanitized[:120]
+
+
+def _atomic_write_json(path: Path, payload: Mapping[str, Any]) -> None:
+    _atomic_write_text(path, _json_dumps(payload) + "\n")
+
+
+def _atomic_write_text(path: Path, text: str) -> None:
+    tmp_path = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    tmp_path.write_text(text, encoding="utf-8")
+    tmp_path.replace(path)
+
+
+def _json_dumps(payload: Mapping[str, Any]) -> str:
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"))
+
+
+def _co_holding_diagnostics(result: PropagationResult) -> dict[str, int]:
+    breakdown = result.channel_breakdown.get("reflexive", {}).get("co_holding_crowding", {})
+    return _int_diagnostics(breakdown.get("diagnostics"))
+
+
+def _northbound_diagnostics(result: PropagationResult) -> dict[str, int]:
+    breakdown = result.channel_breakdown.get("event", {}).get("northbound_anomaly", {})
+    return _int_diagnostics(breakdown.get("diagnostics"))
+
+
+def _int_diagnostics(value: Any) -> dict[str, int]:
+    if not isinstance(value, Mapping):
+        return {}
+    return {
+        str(key): int(count)
+        for key, count in value.items()
+        if isinstance(count, int | float)
+    }
+
+
+def _merged_impacted_entity_count(*results: PropagationResult) -> int:
+    entity_ids: set[str] = set()
+    for result in results:
+        for entity in result.impacted_entities:
+            node_id = entity.get("node_id")
+            if node_id is not None:
+                entity_ids.add(str(node_id))
+    return len(entity_ids)

--- a/graph_engine/proofs/holdings_live_graph.py
+++ b/graph_engine/proofs/holdings_live_graph.py
@@ -36,7 +36,34 @@ _DEFAULT_NEO4J_DATABASE = "neo4j"
 _SAFE_NAMESPACE_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]{2,95}$")
 _SAFE_FILE_COMPONENT_PATTERN = re.compile(r"[^A-Za-z0-9_.-]+")
 _PROOF_PATH_MARKER_PATTERN = re.compile(r"(^|[.-])(proof|smoke|test)([.-]|$)")
+_PROOF_NAME_MARKER_PATTERN = re.compile(r"(proof|smoke|test)", re.IGNORECASE)
+_SAFE_NEO4J_DATABASE_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]{2,95}$")
 _ALLOWED_HOLDINGS_RELATIONSHIPS = frozenset({"CO_HOLDING", "NORTHBOUND_HOLD"})
+_UNSAFE_NEO4J_DATABASE_NAMES = frozenset(
+    {
+        "default",
+        "live",
+        "main",
+        "neo4j",
+        "prod",
+        "production",
+        "system",
+    }
+)
+_SENSITIVE_KEY_PATTERN = re.compile(
+    r"(token|secret|password|passwd|pwd|dsn|database_url|private_key|"
+    r"raw[_-]?(payload|response|provider)?|provider[_-]?payload|"
+    r"local[_-]?path|runtime[_-]?path)",
+    re.IGNORECASE,
+)
+_SENSITIVE_VALUE_PATTERNS = (
+    re.compile(r"\b(?:postgres(?:ql)?|mysql|redis|mongodb)://\S+", re.IGNORECASE),
+    re.compile(r"\b(?:ghp|gho|github_pat)_[A-Za-z0-9_]+\b"),
+    re.compile(r"\b[A-Za-z0-9_]*token[A-Za-z0-9_]*=[^\s,;]+", re.IGNORECASE),
+    re.compile(r"/Users/[^,\s\"']+"),
+    re.compile(r"/tmp/[^,\s\"']*project-ult[^,\s\"']*", re.IGNORECASE),
+)
+_REDACTED_VALUE = "<redacted>"
 
 
 class ReadOnlyGraphClient(Protocol):
@@ -163,8 +190,7 @@ def validate_holdings_live_graph_proof_env(
     neo4j_database = str(env.get(_NEO4J_DATABASE_ENV) or "").strip()
     if not neo4j_database:
         raise PermissionError(f"{_NEO4J_DATABASE_ENV} is required for holdings live graph proof")
-    if neo4j_database.lower() == _DEFAULT_NEO4J_DATABASE:
-        raise PermissionError("default Neo4j database 'neo4j' is not allowed for this proof")
+    _validate_neo4j_database_name(neo4j_database)
 
     artifact_config = _validate_artifact_destination(artifact_root, namespace=namespace)
     return HoldingsLiveGraphProofConfig(
@@ -402,6 +428,7 @@ def run_holdings_live_graph_proof(
     """
 
     proof_config = validate_holdings_live_graph_proof_env(env, artifact_root=artifact_root)
+    validate_neo4j_client_database(client, proof_config.neo4j_database)
     validate_holdings_candidate_deltas(candidate_deltas)
 
     canonical_writer = LayerAArtifactCanonicalWriter(
@@ -482,6 +509,48 @@ def _require_namespace(namespace: str | None) -> str:
     return value
 
 
+def validate_neo4j_client_database(client: Any, expected_database: str) -> None:
+    """Bind the guarded env database to the actual client before live sync."""
+
+    actual_database = _client_database(client)
+    if actual_database != expected_database:
+        raise PermissionError(
+            "Neo4j client database does not match guarded proof database: "
+            f"expected {expected_database!r}",
+        )
+    _validate_neo4j_database_name(actual_database)
+
+
+def _validate_neo4j_database_name(database: str) -> str:
+    value = str(database or "").strip()
+    if not value:
+        raise PermissionError(f"{_NEO4J_DATABASE_ENV} is required for holdings live graph proof")
+    if not _SAFE_NEO4J_DATABASE_PATTERN.fullmatch(value):
+        raise ValueError("Neo4j proof database name must be a safe identifier")
+    if value.lower() == _DEFAULT_NEO4J_DATABASE:
+        raise PermissionError("default Neo4j database 'neo4j' is not allowed for this proof")
+    if value.lower() in _UNSAFE_NEO4J_DATABASE_NAMES:
+        raise PermissionError(
+            f"Neo4j database {value!r} is not allowed for holdings live graph proof",
+        )
+    if not _PROOF_NAME_MARKER_PATTERN.search(value):
+        raise PermissionError(
+            "Neo4j proof database name must contain proof, smoke, or test",
+        )
+    return value
+
+
+def _client_database(client: Any) -> str:
+    config = getattr(client, "config", None)
+    database = getattr(config, "database", None)
+    if database is None:
+        raise PermissionError("Neo4j client database could not be verified")
+    value = str(database).strip()
+    if not value:
+        raise PermissionError("Neo4j client database could not be verified")
+    return value
+
+
 def _path_has_proof_marker(path: Path) -> bool:
     return any(_PROOF_PATH_MARKER_PATTERN.search(part.lower()) for part in path.parts)
 
@@ -493,7 +562,7 @@ def _canonical_record_lines(plan: PromotionPlan) -> list[str]:
             _json_dumps(
                 {
                     "record_type": "node",
-                    "record": node_record.model_dump(mode="json"),
+                    "record": _curated_node_record(node_record),
                 }
             )
         )
@@ -502,7 +571,7 @@ def _canonical_record_lines(plan: PromotionPlan) -> list[str]:
             _json_dumps(
                 {
                     "record_type": "edge",
-                    "record": edge_record.model_dump(mode="json"),
+                    "record": _curated_edge_record(edge_record),
                 }
             )
         )
@@ -511,11 +580,94 @@ def _canonical_record_lines(plan: PromotionPlan) -> list[str]:
             _json_dumps(
                 {
                     "record_type": "assertion",
-                    "record": assertion_record.model_dump(mode="json"),
+                    "record": _curated_assertion_record(assertion_record),
                 }
             )
         )
     return lines
+
+
+def _curated_node_record(node_record: Any) -> dict[str, Any]:
+    return {
+        "node_id": node_record.node_id,
+        "canonical_entity_id": node_record.canonical_entity_id,
+        "label": node_record.label,
+        "properties": _redact_sensitive_payload(node_record.properties),
+        "created_at": node_record.created_at.isoformat(),
+        "updated_at": node_record.updated_at.isoformat(),
+    }
+
+
+def _curated_edge_record(edge_record: Any) -> dict[str, Any]:
+    return {
+        "edge_id": edge_record.edge_id,
+        "source_node_id": edge_record.source_node_id,
+        "target_node_id": edge_record.target_node_id,
+        "relationship_type": edge_record.relationship_type,
+        "properties": _redact_sensitive_payload(edge_record.properties),
+        "weight": edge_record.weight,
+        "created_at": edge_record.created_at.isoformat(),
+        "updated_at": edge_record.updated_at.isoformat(),
+    }
+
+
+def _curated_assertion_record(assertion_record: Any) -> dict[str, Any]:
+    return {
+        "assertion_id": assertion_record.assertion_id,
+        "source_node_id": assertion_record.source_node_id,
+        "target_node_id": assertion_record.target_node_id,
+        "assertion_type": assertion_record.assertion_type,
+        "evidence": _redact_sensitive_payload(assertion_record.evidence),
+        "confidence": assertion_record.confidence,
+        "created_at": assertion_record.created_at.isoformat(),
+    }
+
+
+def _redact_sensitive_payload(value: Any, *, key: str | None = None) -> Any:
+    if key is not None and _SENSITIVE_KEY_PATTERN.search(key):
+        return _REDACTED_VALUE
+    if isinstance(value, Mapping):
+        return {
+            str(item_key): _redact_sensitive_payload(item_value, key=str(item_key))
+            for item_key, item_value in value.items()
+        }
+    if isinstance(value, list):
+        return [_redact_sensitive_payload(item) for item in value]
+    if isinstance(value, tuple):
+        return [_redact_sensitive_payload(item) for item in value]
+    if isinstance(value, str):
+        return _redact_sensitive_string(value)
+    return value
+
+
+def _redact_sensitive_string(value: str) -> str:
+    redacted = value
+    for pattern in _SENSITIVE_VALUE_PATTERNS:
+        redacted = pattern.sub(_REDACTED_VALUE, redacted)
+    if _looks_like_raw_payload_string(redacted):
+        return _REDACTED_VALUE
+    return redacted
+
+
+def _looks_like_raw_payload_string(value: str) -> bool:
+    stripped = value.strip()
+    if not (
+        (stripped.startswith("{") and stripped.endswith("}"))
+        or (stripped.startswith("[") and stripped.endswith("]"))
+    ):
+        return False
+    lowered = stripped.lower()
+    return any(
+        marker in lowered
+        for marker in (
+            '"password"',
+            '"private_key"',
+            '"raw_payload"',
+            '"raw_response"',
+            '"secret"',
+            '"token"',
+        )
+    )
 
 
 def _safe_file_component(value: str) -> str:

--- a/tests/unit/test_holdings_live_graph_proof.py
+++ b/tests/unit/test_holdings_live_graph_proof.py
@@ -1,0 +1,505 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+from contracts.schemas import CandidateGraphDelta
+
+import graph_engine.proofs.holdings_live_graph as proof_module
+from graph_engine.models import (
+    GraphEdgeRecord,
+    GraphNodeRecord,
+    Neo4jGraphStatus,
+    PropagationResult,
+    PromotionPlan,
+)
+from graph_engine.proofs import (
+    HoldingsAlgorithmProofSummary,
+    LayerAArtifactCanonicalWriter,
+    LoadedCandidateDeltaReader,
+    build_holdings_proof_context,
+    run_holdings_live_graph_proof,
+    run_holdings_algorithm_proof,
+    validate_holdings_candidate_deltas,
+    validate_holdings_live_graph_proof_env,
+    verify_holdings_edges,
+    write_layer_a_artifact,
+)
+from graph_engine.status import GraphStatusManager
+from tests.fakes import InMemoryStatusStore
+
+NOW = datetime(2026, 5, 7, 12, 0, tzinfo=timezone.utc)
+
+
+class FakeReadOnlyClient:
+    def __init__(self, rows: list[dict[str, Any]] | None = None) -> None:
+        self.rows = rows or []
+        self.read_calls: list[tuple[str, dict[str, Any]]] = []
+        self.write_calls: list[tuple[str, dict[str, Any]]] = []
+
+    def execute_read(
+        self,
+        query: str,
+        parameters: dict[str, Any] | None = None,
+    ) -> list[dict[str, Any]]:
+        self.read_calls.append((query, parameters or {}))
+        return list(self.rows)
+
+    def execute_write(
+        self,
+        query: str,
+        parameters: dict[str, Any] | None = None,
+    ) -> list[dict[str, Any]]:
+        self.write_calls.append((query, parameters or {}))
+        raise AssertionError("proof readback must not write")
+
+
+def test_live_graph_proof_guard_requires_confirm(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    env = {
+        "GRAPH_ENGINE_LIVE_PROOF_NAMESPACE": "proof-20260507-a",
+        "NEO4J_DATABASE": "projectultproof20260507",
+    }
+
+    with pytest.raises(PermissionError, match="GRAPH_ENGINE_LIVE_PROOF_CONFIRM"):
+        validate_holdings_live_graph_proof_env(env, artifact_root=tmp_path / "proof-artifacts")
+
+
+def test_live_graph_proof_guard_rejects_default_neo4j(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    env = {
+        "GRAPH_ENGINE_LIVE_PROOF_CONFIRM": "1",
+        "GRAPH_ENGINE_LIVE_PROOF_NAMESPACE": "proof-20260507-a",
+        "NEO4J_DATABASE": "neo4j",
+    }
+
+    with pytest.raises(PermissionError, match="default Neo4j database"):
+        validate_holdings_live_graph_proof_env(env, artifact_root=tmp_path / "proof-artifacts")
+
+
+def test_live_graph_proof_guard_requires_namespace(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    env = {
+        "GRAPH_ENGINE_LIVE_PROOF_CONFIRM": "1",
+        "NEO4J_DATABASE": "projectultproof20260507",
+    }
+
+    with pytest.raises(PermissionError, match="GRAPH_ENGINE_LIVE_PROOF_NAMESPACE"):
+        validate_holdings_live_graph_proof_env(env, artifact_root=tmp_path / "proof-artifacts")
+
+
+def test_live_graph_proof_guard_rejects_non_proof_artifact_root(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    env = {
+        "GRAPH_ENGINE_LIVE_PROOF_CONFIRM": "1",
+        "GRAPH_ENGINE_LIVE_PROOF_NAMESPACE": "proof-20260507-a",
+        "NEO4J_DATABASE": "projectultproof20260507",
+    }
+
+    with pytest.raises(ValueError, match="proof/smoke/test workspace"):
+        validate_holdings_live_graph_proof_env(env, artifact_root=tmp_path / "artifacts")
+
+
+def test_layer_a_artifact_writer_sanitizes_manifest_and_records(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    plan = _promotion_plan()
+    summary = write_layer_a_artifact(
+        plan,
+        artifact_root=tmp_path / "proof-workspace",
+        namespace="proof-20260507-a",
+    )
+
+    manifest = json.loads(summary.manifest_path.read_text(encoding="utf-8"))
+    assert manifest == {
+        "artifact_type": "holdings_live_graph_layer_a",
+        "assertion_count": 0,
+        "created_at": NOW.isoformat(),
+        "cycle_id": "cycle-1",
+        "delta_count": 2,
+        "delta_ids": ["delta-co", "delta-nb"],
+        "edge_count": 2,
+        "layer": "Layer A",
+        "namespace": "proof-20260507-a",
+        "node_count": 2,
+        "records_ref": "canonical_records.jsonl",
+        "relation_counts": {"CO_HOLDING": 1, "NORTHBOUND_HOLD": 1},
+        "relation_types": ["CO_HOLDING", "NORTHBOUND_HOLD"],
+        "selection_ref": "selection-1",
+    }
+    assert str(tmp_path) not in summary.manifest_path.read_text(encoding="utf-8")
+
+    records = [
+        json.loads(line)
+        for line in summary.records_path.read_text(encoding="utf-8").splitlines()
+    ]
+    assert [record["record_type"] for record in records] == ["node", "node", "edge", "edge"]
+    assert {record["record"]["relationship_type"] for record in records if record["record_type"] == "edge"} == {
+        "CO_HOLDING",
+        "NORTHBOUND_HOLD",
+    }
+
+
+def test_layer_a_canonical_writer_records_last_summary(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    writer = LayerAArtifactCanonicalWriter(
+        tmp_path / "proof-workspace",
+        namespace="proof-20260507-a",
+    )
+
+    writer.write_canonical_records(_promotion_plan())
+
+    assert writer.last_summary is not None
+    assert writer.last_summary.edge_count == 2
+    assert writer.last_summary.relation_counts == {"CO_HOLDING": 1, "NORTHBOUND_HOLD": 1}
+
+
+def test_relation_whitelist_rejects_non_holdings_candidate() -> None:
+    with pytest.raises(ValueError, match="SUPPLY_CHAIN"):
+        validate_holdings_candidate_deltas(
+            [
+                CandidateGraphDelta(
+                    delta_id="delta-supply",
+                    delta_type="edge_upsert",
+                    source_node="node-a",
+                    target_node="node-b",
+                    relation_type="SUPPLY_CHAIN",
+                    properties={"evidence_refs": ["fact-supply"]},
+                    evidence=["fact-supply"],
+                    subsystem_id="subsystem-news",
+                )
+            ]
+        )
+
+
+def test_loaded_candidate_reader_validates_relation_whitelist() -> None:
+    reader = LoadedCandidateDeltaReader([_candidate_delta("delta-co", "CO_HOLDING")])
+
+    assert reader.read_candidate_graph_deltas("cycle-1", "selection-1") == [
+        _candidate_delta("delta-co", "CO_HOLDING")
+    ]
+
+    bad_reader = LoadedCandidateDeltaReader([_candidate_delta("delta-bad", "SUPPLY_CHAIN")])
+    with pytest.raises(ValueError, match="SUPPLY_CHAIN"):
+        bad_reader.read_candidate_graph_deltas("cycle-1", "selection-1")
+
+
+def test_layer_a_artifact_rejects_non_holdings_plan(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    plan = _promotion_plan(relationship_type="SUPPLY_CHAIN")
+
+    with pytest.raises(ValueError, match="SUPPLY_CHAIN"):
+        write_layer_a_artifact(
+            plan,
+            artifact_root=tmp_path / "proof-workspace",
+            namespace="proof-20260507-a",
+        )
+
+
+def test_verify_holdings_edges_rejects_missing_and_disallowed_edges() -> None:
+    client = FakeReadOnlyClient(
+        rows=[
+            {"edge_id": "edge-co", "relationship_type": "CO_HOLDING"},
+            {"edge_id": "edge-bad", "relationship_type": "SUPPLY_CHAIN"},
+        ]
+    )
+
+    with pytest.raises(ValueError, match="missing synced holdings edges"):
+        verify_holdings_edges(client, edge_ids=["edge-co", "edge-nb", "edge-bad"])
+
+    summary = verify_holdings_edges(
+        client,
+        edge_ids=["edge-co", "edge-nb", "edge-bad"],
+        strict=False,
+    )
+    assert summary.edge_count == 2
+    assert summary.missing_edge_ids == ["edge-nb"]
+    assert summary.disallowed_relation_types == ["SUPPLY_CHAIN"]
+    assert summary.relation_counts == {"CO_HOLDING": 1, "SUPPLY_CHAIN": 1}
+    assert client.write_calls == []
+    assert "MATCH" in client.read_calls[0][0]
+    assert "MERGE" not in client.read_calls[0][0]
+
+
+def test_verify_holdings_edges_passes_for_whitelisted_edges() -> None:
+    client = FakeReadOnlyClient(
+        rows=[
+            {"edge_id": "edge-co", "relationship_type": "CO_HOLDING"},
+            {"edge_id": "edge-nb", "relationship_type": "NORTHBOUND_HOLD"},
+        ]
+    )
+
+    summary = verify_holdings_edges(client, edge_ids=["edge-co", "edge-nb"])
+
+    assert summary.expected_edge_count == 2
+    assert summary.edge_count == 2
+    assert summary.relation_counts == {"CO_HOLDING": 1, "NORTHBOUND_HOLD": 1}
+    assert summary.missing_edge_ids == []
+    assert summary.disallowed_relation_types == []
+
+
+def test_holdings_algorithm_proof_calls_explicit_algorithms_only(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    calls: list[str] = []
+
+    def fake_co_holding(*args: Any, **kwargs: Any) -> PropagationResult:
+        calls.append("co")
+        return _propagation_result("co_holding_crowding", "reflexive", "CO_HOLDING")
+
+    def fake_northbound(*args: Any, **kwargs: Any) -> PropagationResult:
+        calls.append("nb")
+        return _propagation_result("northbound_anomaly", "event", "NORTHBOUND_HOLD")
+
+    monkeypatch.setattr(proof_module, "run_co_holding_crowding", fake_co_holding)
+    monkeypatch.setattr(proof_module, "run_northbound_anomaly", fake_northbound)
+
+    summary = run_holdings_algorithm_proof(
+        build_holdings_proof_context(
+            cycle_id="cycle-1",
+            graph_generation_id=4,
+            namespace="proof-20260507-a",
+        ),
+        FakeReadOnlyClient(),
+        status_manager=_status_manager(graph_generation_id=4),
+    )
+
+    assert calls == ["co", "nb"]
+    assert summary.co_holding_path_count == 1
+    assert summary.northbound_path_count == 1
+    assert summary.total_path_count == 2
+    assert summary.impacted_entity_count == 1
+    assert not hasattr(proof_module, "run_full_propagation")
+
+
+def test_holdings_algorithm_proof_requires_event_and_reflexive_channels() -> None:
+    context = build_holdings_proof_context(
+        cycle_id="cycle-1",
+        graph_generation_id=4,
+        namespace="proof-20260507-a",
+    ).model_copy(update={"enabled_channels": ["event"]})
+
+    with pytest.raises(PermissionError, match="event and reflexive"):
+        run_holdings_algorithm_proof(
+            context,
+            FakeReadOnlyClient(),
+            status_manager=_status_manager(graph_generation_id=4),
+        )
+
+
+def test_live_graph_proof_harness_blocks_dangerous_db_before_promotion(
+    monkeypatch,
+    tmp_path,
+) -> None:  # type: ignore[no-untyped-def]
+    called = False
+
+    def fail_if_called(*args: Any, **kwargs: Any) -> PromotionPlan:
+        nonlocal called
+        called = True
+        raise AssertionError("promotion must not run when guard fails")
+
+    monkeypatch.setattr(proof_module, "promote_graph_deltas", fail_if_called)
+
+    with pytest.raises(PermissionError, match="default Neo4j database"):
+        run_holdings_live_graph_proof(
+            cycle_id="cycle-1",
+            selection_ref="selection-1",
+            candidate_deltas=[_candidate_delta("delta-co", "CO_HOLDING")],
+            entity_reader=object(),  # type: ignore[arg-type]
+            client=FakeReadOnlyClient(),
+            status_manager=_status_manager(graph_generation_id=4),
+            env={
+                "GRAPH_ENGINE_LIVE_PROOF_CONFIRM": "1",
+                "GRAPH_ENGINE_LIVE_PROOF_NAMESPACE": "proof-20260507-a",
+                "NEO4J_DATABASE": "neo4j",
+            },
+            artifact_root=tmp_path / "proof-workspace",
+        )
+
+    assert called is False
+
+
+def test_live_graph_proof_harness_runs_promotion_readback_and_algorithm_summary(
+    monkeypatch,
+    tmp_path,
+) -> None:  # type: ignore[no-untyped-def]
+    calls: list[str] = []
+    plan = _promotion_plan()
+    client = FakeReadOnlyClient(
+        rows=[
+            {"edge_id": "edge-co", "relationship_type": "CO_HOLDING"},
+            {"edge_id": "edge-nb", "relationship_type": "NORTHBOUND_HOLD"},
+        ]
+    )
+
+    def fake_promote_graph_deltas(*args: Any, **kwargs: Any) -> PromotionPlan:
+        calls.append("promote")
+        assert kwargs["sync_to_live_graph"] is True
+        kwargs["canonical_writer"].write_canonical_records(plan)
+        return plan
+
+    def fake_algorithm_proof(*args: Any, **kwargs: Any) -> HoldingsAlgorithmProofSummary:
+        calls.append("algorithms")
+        return HoldingsAlgorithmProofSummary(
+            cycle_id="cycle-1",
+            graph_generation_id=4,
+            co_holding_path_count=1,
+            northbound_path_count=1,
+            total_path_count=2,
+            impacted_entity_count=1,
+            co_holding_diagnostics={},
+            northbound_diagnostics={},
+        )
+
+    monkeypatch.setattr(proof_module, "promote_graph_deltas", fake_promote_graph_deltas)
+    monkeypatch.setattr(proof_module, "run_holdings_algorithm_proof", fake_algorithm_proof)
+
+    summary = run_holdings_live_graph_proof(
+        cycle_id="cycle-1",
+        selection_ref="selection-1",
+        candidate_deltas=[
+            _candidate_delta("delta-co", "CO_HOLDING"),
+            _candidate_delta("delta-nb", "NORTHBOUND_HOLD"),
+        ],
+        entity_reader=object(),  # type: ignore[arg-type]
+        client=client,
+        status_manager=_status_manager(graph_generation_id=4),
+        env={
+            "GRAPH_ENGINE_LIVE_PROOF_CONFIRM": "1",
+            "GRAPH_ENGINE_LIVE_PROOF_NAMESPACE": "proof-20260507-a",
+            "NEO4J_DATABASE": "projectultproof20260507",
+        },
+        artifact_root=tmp_path / "proof-workspace",
+    )
+
+    assert calls == ["promote", "algorithms"]
+    assert summary.namespace == "proof-20260507-a"
+    assert summary.neo4j_database == "projectultproof20260507"
+    assert summary.layer_a_artifact.edge_count == 2
+    assert summary.edge_verification.relation_counts == {
+        "CO_HOLDING": 1,
+        "NORTHBOUND_HOLD": 1,
+    }
+    assert summary.algorithm_proof.total_path_count == 2
+    assert client.write_calls == []
+
+
+def _promotion_plan(*, relationship_type: str = "CO_HOLDING") -> PromotionPlan:
+    return PromotionPlan(
+        cycle_id="cycle-1",
+        selection_ref="selection-1",
+        delta_ids=["delta-co", "delta-nb"],
+        node_records=[
+            _node("node-a", "entity-a"),
+            _node("node-b", "entity-b"),
+        ],
+        edge_records=[
+            _edge(
+                "edge-co",
+                relationship_type,
+                properties={
+                    "evidence_refs": ["fact-co"],
+                    "jaccard_score": 0.5,
+                    "co_holding_fund_count": 3,
+                },
+            ),
+            _edge(
+                "edge-nb",
+                "NORTHBOUND_HOLD",
+                properties={
+                    "evidence_refs": ["fact-nb"],
+                    "metric_z_score": 2.4,
+                    "z_score_metric": "holding_ratio",
+                },
+            ),
+        ],
+        assertion_records=[],
+        created_at=NOW,
+    )
+
+
+def _candidate_delta(delta_id: str, relation_type: str) -> CandidateGraphDelta:
+    return CandidateGraphDelta(
+        delta_id=delta_id,
+        delta_type="edge_upsert",
+        source_node="node-a",
+        target_node="node-b",
+        relation_type=relation_type,
+        properties={"evidence_refs": [f"fact-{delta_id}"]},
+        evidence=[f"fact-{delta_id}"],
+        subsystem_id="subsystem-holdings",
+    )
+
+
+def _node(node_id: str, canonical_entity_id: str) -> GraphNodeRecord:
+    return GraphNodeRecord(
+        node_id=node_id,
+        canonical_entity_id=canonical_entity_id,
+        label="Entity",
+        properties={"canonical_id_rule_version": "proof/v1"},
+        created_at=NOW,
+        updated_at=NOW,
+    )
+
+
+def _edge(
+    edge_id: str,
+    relationship_type: str,
+    *,
+    properties: dict[str, Any],
+) -> GraphEdgeRecord:
+    return GraphEdgeRecord(
+        edge_id=edge_id,
+        source_node_id="node-a",
+        target_node_id="node-b",
+        relationship_type=relationship_type,
+        properties=properties,
+        weight=1.0,
+        created_at=NOW,
+        updated_at=NOW,
+    )
+
+
+def _status_manager(*, graph_generation_id: int) -> GraphStatusManager:
+    return GraphStatusManager(
+        InMemoryStatusStore(
+            Neo4jGraphStatus(
+                graph_status="ready",
+                graph_generation_id=graph_generation_id,
+                node_count=2,
+                edge_count=2,
+                key_label_counts={"Entity": 2},
+                checksum="abc123",
+                last_verified_at=NOW,
+                last_reload_at=None,
+            )
+        )
+    )
+
+
+def _propagation_result(
+    algorithm: str,
+    channel: str,
+    relationship_type: str,
+) -> PropagationResult:
+    breakdown = {
+        "reflexive": {"co_holding_crowding": {"diagnostics": {"missing": 1}}},
+    }
+    if channel == "event":
+        breakdown = {"event": {"northbound_anomaly": {"diagnostics": {}}}}
+    return PropagationResult(
+        cycle_id="cycle-1",
+        graph_generation_id=4,
+        activated_paths=[
+            {
+                "algorithm": algorithm,
+                "channel": channel,
+                "edge_id": f"edge-{channel}",
+                "relationship_type": relationship_type,
+                "target_node_id": "node-b",
+                "score": 1.0,
+            }
+        ],
+        impacted_entities=[
+            {
+                "channel": channel,
+                "node_id": "node-b",
+                "canonical_entity_id": "entity-b",
+                "score": 1.0,
+                "path_count": 1,
+            }
+        ],
+        channel_breakdown=breakdown,
+    )

--- a/tests/unit/test_holdings_live_graph_proof.py
+++ b/tests/unit/test_holdings_live_graph_proof.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from datetime import datetime, timezone
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -10,6 +11,7 @@ from contracts.schemas import CandidateGraphDelta
 import graph_engine.proofs.holdings_live_graph as proof_module
 from graph_engine.models import (
     GraphEdgeRecord,
+    GraphAssertionRecord,
     GraphNodeRecord,
     Neo4jGraphStatus,
     PropagationResult,
@@ -34,7 +36,13 @@ NOW = datetime(2026, 5, 7, 12, 0, tzinfo=timezone.utc)
 
 
 class FakeReadOnlyClient:
-    def __init__(self, rows: list[dict[str, Any]] | None = None) -> None:
+    def __init__(
+        self,
+        rows: list[dict[str, Any]] | None = None,
+        *,
+        database: str = "projectultproof20260507",
+    ) -> None:
+        self.config = SimpleNamespace(database=database)
         self.rows = rows or []
         self.read_calls: list[tuple[str, dict[str, Any]]] = []
         self.write_calls: list[tuple[str, dict[str, Any]]] = []
@@ -75,6 +83,47 @@ def test_live_graph_proof_guard_rejects_default_neo4j(tmp_path) -> None:  # type
 
     with pytest.raises(PermissionError, match="default Neo4j database"):
         validate_holdings_live_graph_proof_env(env, artifact_root=tmp_path / "proof-artifacts")
+
+
+@pytest.mark.parametrize("database", ["system", "prod", "production", "live"])
+def test_live_graph_proof_guard_rejects_unsafe_non_default_db_names(
+    tmp_path,
+    database: str,
+) -> None:  # type: ignore[no-untyped-def]
+    env = {
+        "GRAPH_ENGINE_LIVE_PROOF_CONFIRM": "1",
+        "GRAPH_ENGINE_LIVE_PROOF_NAMESPACE": "proof-20260507-a",
+        "NEO4J_DATABASE": database,
+    }
+
+    with pytest.raises(PermissionError, match="not allowed"):
+        validate_holdings_live_graph_proof_env(env, artifact_root=tmp_path / "proof-artifacts")
+
+
+def test_live_graph_proof_guard_requires_disposable_db_marker(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    env = {
+        "GRAPH_ENGINE_LIVE_PROOF_CONFIRM": "1",
+        "GRAPH_ENGINE_LIVE_PROOF_NAMESPACE": "proof-20260507-a",
+        "NEO4J_DATABASE": "analytics",
+    }
+
+    with pytest.raises(PermissionError, match="proof, smoke, or test"):
+        validate_holdings_live_graph_proof_env(env, artifact_root=tmp_path / "proof-artifacts")
+
+
+def test_live_graph_proof_guard_accepts_safe_proof_db(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    env = {
+        "GRAPH_ENGINE_LIVE_PROOF_CONFIRM": "1",
+        "GRAPH_ENGINE_LIVE_PROOF_NAMESPACE": "proof-20260507-a",
+        "NEO4J_DATABASE": "projectultproof20260507",
+    }
+
+    config = validate_holdings_live_graph_proof_env(
+        env,
+        artifact_root=tmp_path / "proof-artifacts",
+    )
+
+    assert config.neo4j_database == "projectultproof20260507"
 
 
 def test_live_graph_proof_guard_requires_namespace(tmp_path) -> None:  # type: ignore[no-untyped-def]
@@ -134,6 +183,37 @@ def test_layer_a_artifact_writer_sanitizes_manifest_and_records(tmp_path) -> Non
         "CO_HOLDING",
         "NORTHBOUND_HOLD",
     }
+
+
+def test_layer_a_artifact_redacts_nested_sensitive_values(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    plan = _sensitive_promotion_plan()
+
+    summary = write_layer_a_artifact(
+        plan,
+        artifact_root=tmp_path / "proof-workspace",
+        namespace="proof-20260507-a",
+    )
+
+    records_text = summary.records_path.read_text(encoding="utf-8")
+    assert "postgresql://" not in records_text
+    assert "ghp_secretvalue" not in records_text
+    assert "/Users/fanjie/Desktop/Cowork/project-ult" not in records_text
+    assert "raw_provider_payload" not in records_text
+    assert "projectultproof20260507" in records_text
+
+    records = [json.loads(line) for line in records_text.splitlines()]
+    node_record = next(record["record"] for record in records if record["record_type"] == "node")
+    edge_record = next(record["record"] for record in records if record["record_type"] == "edge")
+    assertion_record = next(
+        record["record"] for record in records if record["record_type"] == "assertion"
+    )
+
+    assert node_record["properties"]["local_path"] == "<redacted>"
+    assert edge_record["properties"]["lineage"]["database_url"] == "<redacted>"
+    assert edge_record["properties"]["lineage"]["nested"]["raw_payload"] == "<redacted>"
+    assert edge_record["properties"]["notes"] == "<redacted>"
+    assert assertion_record["evidence"]["provider_payload"] == "<redacted>"
+    assert assertion_record["evidence"]["safe_summary"] == "projectultproof20260507"
 
 
 def test_layer_a_canonical_writer_records_last_summary(tmp_path) -> None:  # type: ignore[no-untyped-def]
@@ -311,6 +391,38 @@ def test_live_graph_proof_harness_blocks_dangerous_db_before_promotion(
     assert called is False
 
 
+def test_live_graph_proof_harness_rejects_client_db_mismatch_before_promotion(
+    monkeypatch,
+    tmp_path,
+) -> None:  # type: ignore[no-untyped-def]
+    called = False
+
+    def fail_if_called(*args: Any, **kwargs: Any) -> PromotionPlan:
+        nonlocal called
+        called = True
+        raise AssertionError("promotion must not run when client database mismatches")
+
+    monkeypatch.setattr(proof_module, "promote_graph_deltas", fail_if_called)
+
+    with pytest.raises(PermissionError, match="client database does not match"):
+        run_holdings_live_graph_proof(
+            cycle_id="cycle-1",
+            selection_ref="selection-1",
+            candidate_deltas=[_candidate_delta("delta-co", "CO_HOLDING")],
+            entity_reader=object(),  # type: ignore[arg-type]
+            client=FakeReadOnlyClient(database="neo4j"),
+            status_manager=_status_manager(graph_generation_id=4),
+            env={
+                "GRAPH_ENGINE_LIVE_PROOF_CONFIRM": "1",
+                "GRAPH_ENGINE_LIVE_PROOF_NAMESPACE": "proof-20260507-a",
+                "NEO4J_DATABASE": "projectultproof20260507",
+            },
+            artifact_root=tmp_path / "proof-workspace",
+        )
+
+    assert called is False
+
+
 def test_live_graph_proof_harness_runs_promotion_readback_and_algorithm_summary(
     monkeypatch,
     tmp_path,
@@ -410,6 +522,59 @@ def _promotion_plan(*, relationship_type: str = "CO_HOLDING") -> PromotionPlan:
     )
 
 
+def _sensitive_promotion_plan() -> PromotionPlan:
+    return PromotionPlan(
+        cycle_id="cycle-1",
+        selection_ref="selection-1",
+        delta_ids=["delta-sensitive"],
+        node_records=[
+            _node(
+                "node-a",
+                "entity-a",
+                properties={
+                    "canonical_id_rule_version": "proof/v1",
+                    "local_path": "/Users/fanjie/Desktop/Cowork/project-ult/.local/proof",
+                },
+            )
+        ],
+        edge_records=[
+            _edge(
+                "edge-sensitive",
+                "CO_HOLDING",
+                properties={
+                    "evidence_refs": ["fact-sensitive"],
+                    "lineage": {
+                        "database_url": "postgresql://dp:secret@localhost:5432/proof",
+                        "nested": {
+                            "raw_payload": {
+                                "provider": "raw_provider_payload",
+                                "token": "ghp_secretvalue",
+                            }
+                        },
+                    },
+                    "notes": '{"token":"ghp_secretvalue","raw_payload":"raw_provider_payload"}',
+                    "safe_summary": "projectultproof20260507",
+                },
+            )
+        ],
+        assertion_records=[
+            GraphAssertionRecord(
+                assertion_id="assertion-sensitive",
+                source_node_id="node-a",
+                target_node_id=None,
+                assertion_type="HOLDINGS_PROOF",
+                evidence={
+                    "provider_payload": '{"token":"ghp_secretvalue"}',
+                    "safe_summary": "projectultproof20260507",
+                },
+                confidence=0.9,
+                created_at=NOW,
+            )
+        ],
+        created_at=NOW,
+    )
+
+
 def _candidate_delta(delta_id: str, relation_type: str) -> CandidateGraphDelta:
     return CandidateGraphDelta(
         delta_id=delta_id,
@@ -423,12 +588,17 @@ def _candidate_delta(delta_id: str, relation_type: str) -> CandidateGraphDelta:
     )
 
 
-def _node(node_id: str, canonical_entity_id: str) -> GraphNodeRecord:
+def _node(
+    node_id: str,
+    canonical_entity_id: str,
+    *,
+    properties: dict[str, Any] | None = None,
+) -> GraphNodeRecord:
     return GraphNodeRecord(
         node_id=node_id,
         canonical_entity_id=canonical_entity_id,
         label="Entity",
-        properties={"canonical_id_rule_version": "proof/v1"},
+        properties=properties or {"canonical_id_rule_version": "proof/v1"},
         created_at=NOW,
         updated_at=NOW,
     )


### PR DESCRIPTION
## Summary
- Adds guarded holdings live graph proof utilities for assembly runner use.
- Provides Layer A JSON/JSONL artifact writer, loaded-candidate reader, read-only Neo4j edge verifier, and explicit #55 algorithm proof summary.
- Adds an end-to-end harness that validates proof gates before invoking existing promotion live sync; it does not run real live proof in CI.

## Scope boundaries
- Requires GRAPH_ENGINE_LIVE_PROOF_CONFIRM=1, GRAPH_ENGINE_LIVE_PROOF_NAMESPACE, and non-default NEO4J_DATABASE.
- Keeps Neo4j writes limited to existing promote_graph_deltas(..., sync_to_live_graph=True) live sync barrier.
- Does not call run_full_propagation, add enums/schema, change contracts, or revive financial-doc/guarantees/related-party scope.

## Validation
- PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -m pytest -p no:cacheprovider -q tests/unit/test_holdings_live_graph_proof.py tests/unit/test_propagation_holdings.py tests/unit/test_promotion.py tests/contract/test_contracts_alignment.py tests/unit/test_propagation_channels.py tests/unit/test_schema.py
- .venv/bin/python -m ruff check graph_engine/proofs/__init__.py graph_engine/proofs/holdings_live_graph.py tests/unit/test_holdings_live_graph_proof.py
- git diff --cached --check
