### PR TITLE
Add guarded live graph rollout canary

### DIFF
--- a/graph_engine/promotion/service.py
+++ b/graph_engine/promotion/service.py
@@ -33,6 +33,7 @@ def promote_graph_deltas(
     client: Neo4jClient | None = None,
     status_manager: GraphStatusManager | None = None,
     sync_to_live_graph: bool = True,
+    allowed_relationship_types: set[str] | None = None,
 ) -> PromotionPlan:
     """Promote selected contract graph deltas, then optionally mirror them to Neo4j."""
 
@@ -48,6 +49,8 @@ def promote_graph_deltas(
     deltas = freeze_contract_deltas(cycle_id, contract_deltas, entity_reader)
     validate_entity_anchors(deltas, entity_reader)
     plan = build_promotion_plan(cycle_id, selection_ref, deltas)
+    if allowed_relationship_types is not None:
+        _validate_allowed_relationship_types(plan, allowed_relationship_types)
 
     if sync_to_live_graph and status_manager is not None:
         status_manager.require_ready()
@@ -67,6 +70,26 @@ def promote_graph_deltas(
         _sync_live_graph_with_status_barrier(plan, client, status_manager)
 
     return plan
+
+
+def _validate_allowed_relationship_types(
+    plan: PromotionPlan,
+    allowed_relationship_types: set[str],
+) -> None:
+    if not allowed_relationship_types:
+        raise ValueError("allowed_relationship_types must not be empty when provided")
+
+    relation_types = sorted({edge.relationship_type for edge in plan.edge_records})
+    disallowed = [
+        relationship_type
+        for relationship_type in relation_types
+        if relationship_type not in allowed_relationship_types
+    ]
+    if disallowed:
+        raise PermissionError(
+            "promotion plan contains relationship types outside the allowlist: "
+            + ", ".join(disallowed),
+        )
 
 
 def _require_contract_delta(delta: object) -> CandidateGraphDelta:

--- a/graph_engine/rollout/__init__.py
+++ b/graph_engine/rollout/__init__.py
@@ -1,0 +1,38 @@
+"""Guarded live-graph rollout and canary utilities."""
+
+from graph_engine.rollout.canary import (
+    EdgeReadbackSummary,
+    HoldingsAlgorithmCanarySummary,
+    LayerAArtifactCanonicalWriter,
+    LayerAArtifactSummary,
+    LoadedCandidateDeltaReader,
+    build_holdings_canary_context,
+    run_holdings_canary_algorithms,
+    run_live_graph_canary,
+    write_cold_reload_replay_evidence,
+)
+from graph_engine.rollout.evidence import EvidenceWriter, redact_evidence_payload
+from graph_engine.rollout.guard import (
+    LiveGraphRolloutConfig,
+    validate_client_database_matches_config,
+    validate_promotion_plan_relationship_allowlist,
+    validate_rollout_config,
+)
+
+__all__ = [
+    "EdgeReadbackSummary",
+    "EvidenceWriter",
+    "HoldingsAlgorithmCanarySummary",
+    "LayerAArtifactCanonicalWriter",
+    "LayerAArtifactSummary",
+    "LiveGraphRolloutConfig",
+    "LoadedCandidateDeltaReader",
+    "build_holdings_canary_context",
+    "redact_evidence_payload",
+    "run_holdings_canary_algorithms",
+    "run_live_graph_canary",
+    "validate_client_database_matches_config",
+    "validate_promotion_plan_relationship_allowlist",
+    "validate_rollout_config",
+    "write_cold_reload_replay_evidence",
+]

--- a/graph_engine/rollout/canary.py
+++ b/graph_engine/rollout/canary.py
@@ -1,0 +1,551 @@
+"""Opt-in live graph canary runner and cold-reload replay evidence."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from collections import Counter
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from contracts.schemas import CandidateGraphDelta
+
+from graph_engine.models import (
+    ColdReloadPlan,
+    Neo4jGraphStatus,
+    PropagationContext,
+    PropagationResult,
+    PromotionPlan,
+)
+from graph_engine.promotion.interfaces import EntityAnchorReader
+from graph_engine.promotion.service import promote_graph_deltas
+from graph_engine.propagation.holdings import (
+    HoldingsAlgorithmConfig,
+    run_co_holding_crowding,
+    run_northbound_anomaly,
+)
+from graph_engine.reload.interfaces import CanonicalReader
+from graph_engine.rollout.evidence import (
+    EvidenceWriter,
+    redact_evidence_payload,
+    safe_reload_ref_label,
+)
+from graph_engine.rollout.guard import (
+    LiveGraphRolloutConfig,
+    validate_candidate_relationship_allowlist,
+    validate_client_database_matches_config,
+    validate_promotion_plan_relationship_allowlist,
+    validate_rollout_config,
+)
+from graph_engine.status import GraphStatusManager
+
+_SAFE_FILE_COMPONENT_PATTERN = re.compile(r"[^A-Za-z0-9_.-]+")
+
+
+@dataclass(frozen=True)
+class LoadedCandidateDeltaReader:
+    """CandidateDeltaReader for preselected rollout candidates."""
+
+    deltas: Sequence[CandidateGraphDelta]
+    allowed_relationship_types: set[str]
+
+    def read_candidate_graph_deltas(
+        self,
+        cycle_id: str,
+        selection_ref: str,
+    ) -> list[CandidateGraphDelta]:
+        del cycle_id, selection_ref
+        validate_candidate_relationship_allowlist(
+            self.deltas,
+            self.allowed_relationship_types,
+        )
+        return list(self.deltas)
+
+
+@dataclass(frozen=True)
+class LayerAArtifactSummary:
+    """Summary of the Layer A artifact created before Neo4j sync."""
+
+    manifest_ref: str
+    records_ref: str
+    cycle_id: str
+    selection_ref: str
+    delta_count: int
+    node_count: int
+    edge_count: int
+    assertion_count: int
+    relation_counts: dict[str, int]
+
+
+@dataclass(frozen=True)
+class EdgeReadbackSummary:
+    """Read-only verification summary for canary edges."""
+
+    expected_edge_count: int
+    edge_count: int
+    relation_counts: dict[str, int]
+    missing_edge_ids: list[str]
+    disallowed_relation_types: list[str]
+
+
+@dataclass(frozen=True)
+class HoldingsAlgorithmCanarySummary:
+    """Summary from explicit holdings algorithms used by the canary."""
+
+    cycle_id: str
+    graph_generation_id: int
+    co_holding_path_count: int
+    northbound_path_count: int
+    total_path_count: int
+    impacted_entity_count: int
+    co_holding_diagnostics: dict[str, int]
+    northbound_diagnostics: dict[str, int]
+
+
+@dataclass(frozen=True)
+class LiveGraphCanarySummary:
+    """Canary runner result with evidence manifest location."""
+
+    namespace: str
+    mode: str
+    neo4j_database: str
+    cycle_id: str
+    selection_ref: str
+    layer_a_artifact: LayerAArtifactSummary
+    edge_readback: EdgeReadbackSummary
+    algorithm_summary: HoldingsAlgorithmCanarySummary
+    evidence_manifest_path: Path
+
+
+class LayerAArtifactCanonicalWriter:
+    """CanonicalWriter that persists a compact Layer A artifact for canary evidence."""
+
+    def __init__(self, artifact_root: str | Path, *, namespace: str) -> None:
+        self.artifact_root = Path(artifact_root).expanduser().resolve(strict=False)
+        self.namespace = _safe_file_component(namespace)
+        self.last_summary: LayerAArtifactSummary | None = None
+
+    def write_canonical_records(self, plan: PromotionPlan) -> None:
+        artifact_dir = (
+            self.artifact_root
+            / self.namespace
+            / "layer_a"
+            / _safe_file_component(plan.cycle_id)
+            / _safe_file_component(plan.selection_ref)
+        )
+        artifact_dir.mkdir(parents=True, exist_ok=True)
+        records_path = artifact_dir / "canonical_records.jsonl"
+        manifest_path = artifact_dir / "manifest.json"
+
+        relation_counts = _relation_counts(plan)
+        _atomic_write_text(
+            records_path,
+            "\n".join(_canonical_record_lines(plan)) + "\n",
+        )
+        _atomic_write_json(
+            manifest_path,
+            {
+                "artifact_type": "live_graph_rollout_layer_a",
+                "layer": "Layer A",
+                "namespace": self.namespace,
+                "cycle_id": plan.cycle_id,
+                "selection_ref": plan.selection_ref,
+                "records_ref": "canonical_records.jsonl",
+                "delta_count": len(plan.delta_ids),
+                "node_count": len(plan.node_records),
+                "edge_count": len(plan.edge_records),
+                "assertion_count": len(plan.assertion_records),
+                "relation_counts": relation_counts,
+                "relation_types": sorted(relation_counts),
+                "delta_ids": sorted(plan.delta_ids),
+                "created_at": plan.created_at,
+            },
+        )
+        self.last_summary = LayerAArtifactSummary(
+            manifest_ref=_relative_ref(manifest_path, self.artifact_root),
+            records_ref=_relative_ref(records_path, self.artifact_root),
+            cycle_id=plan.cycle_id,
+            selection_ref=plan.selection_ref,
+            delta_count=len(plan.delta_ids),
+            node_count=len(plan.node_records),
+            edge_count=len(plan.edge_records),
+            assertion_count=len(plan.assertion_records),
+            relation_counts=relation_counts,
+        )
+
+
+def run_live_graph_canary(
+    *,
+    cycle_id: str,
+    selection_ref: str,
+    candidate_deltas: Sequence[CandidateGraphDelta],
+    entity_reader: EntityAnchorReader,
+    client: Any,
+    status_manager: GraphStatusManager,
+    config: LiveGraphRolloutConfig,
+    env: Mapping[str, str | None] | None = None,
+    algorithm_config: HoldingsAlgorithmConfig | None = None,
+    result_limit: int = 100,
+    readback_hook: Callable[[Any, PromotionPlan, set[str]], EdgeReadbackSummary] | None = None,
+    evidence_writer: EvidenceWriter | None = None,
+) -> LiveGraphCanarySummary:
+    """Run the guarded holdings canary; this is not part of the default pipeline."""
+
+    guarded_config = validate_rollout_config(config, env=env)
+    if guarded_config.mode != "canary":
+        raise PermissionError("live graph canary runner requires mode='canary'")
+    validate_client_database_matches_config(client, guarded_config)
+    validate_candidate_relationship_allowlist(
+        candidate_deltas,
+        guarded_config.allowed_relationship_types,
+    )
+    pre_status = status_manager.require_ready()
+
+    canonical_writer = LayerAArtifactCanonicalWriter(
+        guarded_config.artifact_root,
+        namespace=guarded_config.namespace,
+    )
+    plan = promote_graph_deltas(
+        cycle_id,
+        selection_ref,
+        candidate_reader=LoadedCandidateDeltaReader(
+            candidate_deltas,
+            guarded_config.allowed_relationship_types,
+        ),
+        entity_reader=entity_reader,
+        canonical_writer=canonical_writer,
+        client=client,
+        status_manager=status_manager,
+        sync_to_live_graph=True,
+        allowed_relationship_types=guarded_config.allowed_relationship_types,
+    )
+    validate_promotion_plan_relationship_allowlist(
+        plan,
+        guarded_config.allowed_relationship_types,
+    )
+    if canonical_writer.last_summary is None:
+        raise RuntimeError("Layer A artifact writer did not record a summary")
+
+    edge_readback = (
+        readback_hook(client, plan, guarded_config.allowed_relationship_types)
+        if readback_hook is not None
+        else readback_canary_edges(
+            client,
+            plan=plan,
+            allowed_relationship_types=guarded_config.allowed_relationship_types,
+        )
+    )
+    post_status = status_manager.require_ready()
+    algorithm_summary = run_holdings_canary_algorithms(
+        build_holdings_canary_context(
+            cycle_id=cycle_id,
+            graph_generation_id=post_status.graph_generation_id,
+            namespace=guarded_config.namespace,
+        ),
+        client,
+        status_manager=status_manager,
+        config=algorithm_config,
+        result_limit=result_limit,
+    )
+
+    writer = evidence_writer or EvidenceWriter(
+        guarded_config.artifact_root,
+        namespace=guarded_config.namespace,
+    )
+    manifest_path = writer.write_manifest(
+        "live_graph_canary_evidence",
+        {
+            "artifact_type": "live_graph_canary_evidence",
+            "namespace": guarded_config.namespace,
+            "mode": guarded_config.mode,
+            "neo4j_database_label": guarded_config.neo4j_database,
+            "allowed_relationship_types": guarded_config.allowed_relationship_types,
+            "cycle_id": cycle_id,
+            "selection_ref": selection_ref,
+            "relation_counts": canonical_writer.last_summary.relation_counts,
+            "pre_status": _status_summary(pre_status),
+            "post_status": _status_summary(post_status),
+            "reload_ref": None,
+            "layer_a_artifact": canonical_writer.last_summary.__dict__,
+            "edge_readback": edge_readback.__dict__,
+            "holdings_algorithms": algorithm_summary.__dict__,
+        },
+    )
+
+    return LiveGraphCanarySummary(
+        namespace=guarded_config.namespace,
+        mode=guarded_config.mode,
+        neo4j_database=guarded_config.neo4j_database,
+        cycle_id=cycle_id,
+        selection_ref=selection_ref,
+        layer_a_artifact=canonical_writer.last_summary,
+        edge_readback=edge_readback,
+        algorithm_summary=algorithm_summary,
+        evidence_manifest_path=manifest_path,
+    )
+
+
+def readback_canary_edges(
+    client: Any,
+    *,
+    plan: PromotionPlan,
+    allowed_relationship_types: set[str],
+    strict: bool = True,
+) -> EdgeReadbackSummary:
+    """Verify synced canary edges through a read-only query."""
+
+    expected_edge_ids = sorted({edge.edge_id for edge in plan.edge_records})
+    if not expected_edge_ids:
+        raise ValueError("canary readback requires at least one edge")
+
+    rows = client.execute_read(
+        """
+MATCH ()-[relationship]->()
+WHERE relationship.edge_id IN $edge_ids
+RETURN relationship.edge_id AS edge_id,
+       type(relationship) AS relationship_type
+ORDER BY edge_id ASC
+""",
+        {"edge_ids": expected_edge_ids},
+    )
+    seen_edge_ids = sorted(
+        str(row.get("edge_id")) for row in rows if row.get("edge_id") is not None
+    )
+    relation_counts = dict(
+        sorted(Counter(str(row.get("relationship_type")) for row in rows).items())
+    )
+    missing_edge_ids = sorted(set(expected_edge_ids) - set(seen_edge_ids))
+    disallowed_relation_types = sorted(
+        relation_type
+        for relation_type in relation_counts
+        if relation_type not in allowed_relationship_types
+    )
+    summary = EdgeReadbackSummary(
+        expected_edge_count=len(expected_edge_ids),
+        edge_count=len(seen_edge_ids),
+        relation_counts=relation_counts,
+        missing_edge_ids=missing_edge_ids,
+        disallowed_relation_types=disallowed_relation_types,
+    )
+    if strict:
+        if missing_edge_ids:
+            raise ValueError(f"missing synced canary edges: {missing_edge_ids}")
+        if disallowed_relation_types:
+            raise ValueError(
+                "unexpected canary relationship types: "
+                + ", ".join(disallowed_relation_types),
+            )
+    return summary
+
+
+def build_holdings_canary_context(
+    *,
+    cycle_id: str,
+    graph_generation_id: int,
+    namespace: str,
+    world_state_ref: str | None = None,
+) -> PropagationContext:
+    """Build the context for explicit holdings algorithms in the canary."""
+
+    safe_namespace = _safe_file_component(namespace)
+    return PropagationContext(
+        cycle_id=cycle_id,
+        world_state_ref=world_state_ref or f"live-graph-canary:{safe_namespace}",
+        graph_generation_id=graph_generation_id,
+        enabled_channels=["event", "reflexive"],
+        channel_multipliers={"event": 1.0, "reflexive": 1.0},
+        regime_multipliers={"event": 1.0, "reflexive": 1.0},
+        decay_policy={},
+        regime_context={"rollout_namespace": safe_namespace},
+    )
+
+
+def run_holdings_canary_algorithms(
+    context: PropagationContext,
+    client: Any,
+    *,
+    status_manager: GraphStatusManager,
+    config: HoldingsAlgorithmConfig | None = None,
+    result_limit: int = 100,
+) -> HoldingsAlgorithmCanarySummary:
+    """Run only explicit holdings algorithms; no full propagation pipeline."""
+
+    if "event" not in context.enabled_channels or "reflexive" not in context.enabled_channels:
+        raise PermissionError("holdings canary requires event and reflexive channels")
+    co_holding = run_co_holding_crowding(
+        context,
+        client,
+        status_manager=status_manager,
+        config=config,
+        result_limit=result_limit,
+    )
+    northbound = run_northbound_anomaly(
+        context,
+        client,
+        status_manager=status_manager,
+        config=config,
+        result_limit=result_limit,
+    )
+    return HoldingsAlgorithmCanarySummary(
+        cycle_id=context.cycle_id,
+        graph_generation_id=context.graph_generation_id,
+        co_holding_path_count=len(co_holding.activated_paths),
+        northbound_path_count=len(northbound.activated_paths),
+        total_path_count=len(co_holding.activated_paths) + len(northbound.activated_paths),
+        impacted_entity_count=_merged_impacted_entity_count(co_holding, northbound),
+        co_holding_diagnostics=_co_holding_diagnostics(co_holding),
+        northbound_diagnostics=_northbound_diagnostics(northbound),
+    )
+
+
+def write_cold_reload_replay_evidence(
+    *,
+    snapshot_ref: str,
+    canonical_reader: CanonicalReader,
+    config: LiveGraphRolloutConfig,
+    env: Mapping[str, str | None] | None = None,
+    evidence_writer: EvidenceWriter | None = None,
+) -> Path:
+    """Prove the cold-reload artifact can be read without running destructive reload."""
+
+    guarded_config = validate_rollout_config(config, env=env)
+    plan = canonical_reader.read_cold_reload_plan(snapshot_ref)
+    validate_promotion_plan_relationship_allowlist(
+        _promotion_plan_from_reload_plan(plan),
+        guarded_config.allowed_relationship_types,
+    )
+    writer = evidence_writer or EvidenceWriter(
+        guarded_config.artifact_root,
+        namespace=guarded_config.namespace,
+    )
+    return writer.write_manifest(
+        "cold_reload_replay_evidence",
+        {
+            "artifact_type": "cold_reload_replay_evidence",
+            "namespace": guarded_config.namespace,
+            "mode": guarded_config.mode,
+            "neo4j_database_label": guarded_config.neo4j_database,
+            "reload_ref": safe_reload_ref_label(snapshot_ref),
+            "cycle_id": plan.cycle_id,
+            "projection_name": plan.projection_name,
+            "node_count": len(plan.node_records),
+            "edge_count": len(plan.edge_records),
+            "assertion_count": len(plan.assertion_records),
+            "relation_counts": dict(
+                sorted(Counter(edge.relationship_type for edge in plan.edge_records).items())
+            ),
+            "expected_snapshot": plan.expected_snapshot.model_dump(mode="json"),
+            "destructive_reload_executed": False,
+        },
+    )
+
+
+def _promotion_plan_from_reload_plan(plan: ColdReloadPlan) -> PromotionPlan:
+    return PromotionPlan(
+        cycle_id=plan.cycle_id,
+        selection_ref=f"cold-reload:{plan.snapshot_ref}",
+        delta_ids=[],
+        node_records=plan.node_records,
+        edge_records=plan.edge_records,
+        assertion_records=plan.assertion_records,
+        created_at=plan.created_at,
+    )
+
+
+def _canonical_record_lines(plan: PromotionPlan) -> list[str]:
+    records: list[dict[str, Any]] = []
+    for node in plan.node_records:
+        records.append({"record_type": "node", "record": node.model_dump(mode="json")})
+    for edge in plan.edge_records:
+        records.append({"record_type": "edge", "record": edge.model_dump(mode="json")})
+    for assertion in plan.assertion_records:
+        records.append(
+            {"record_type": "assertion", "record": assertion.model_dump(mode="json")}
+        )
+    return [
+        json.dumps(redact_evidence_payload(record), sort_keys=True, separators=(",", ":"))
+        for record in records
+    ]
+
+
+def _relation_counts(plan: PromotionPlan) -> dict[str, int]:
+    return dict(sorted(Counter(edge.relationship_type for edge in plan.edge_records).items()))
+
+
+def _status_summary(status: Neo4jGraphStatus) -> dict[str, Any]:
+    return {
+        "graph_status": status.graph_status,
+        "graph_generation_id": status.graph_generation_id,
+        "node_count": status.node_count,
+        "edge_count": status.edge_count,
+        "key_label_counts": dict(status.key_label_counts),
+        "checksum": status.checksum,
+        "last_verified_at": status.last_verified_at,
+        "last_reload_at": status.last_reload_at,
+        "writer_lock_token": status.writer_lock_token,
+    }
+
+
+def _co_holding_diagnostics(result: PropagationResult) -> dict[str, int]:
+    breakdown = result.channel_breakdown.get("reflexive", {}).get("co_holding_crowding", {})
+    return _int_diagnostics(breakdown.get("diagnostics"))
+
+
+def _northbound_diagnostics(result: PropagationResult) -> dict[str, int]:
+    breakdown = result.channel_breakdown.get("event", {}).get("northbound_anomaly", {})
+    return _int_diagnostics(breakdown.get("diagnostics"))
+
+
+def _int_diagnostics(value: Any) -> dict[str, int]:
+    if not isinstance(value, Mapping):
+        return {}
+    return {
+        str(key): int(count)
+        for key, count in value.items()
+        if isinstance(count, int | float)
+    }
+
+
+def _merged_impacted_entity_count(*results: PropagationResult) -> int:
+    entity_ids: set[str] = set()
+    for result in results:
+        for entity in result.impacted_entities:
+            node_id = entity.get("node_id")
+            if node_id is not None:
+                entity_ids.add(str(node_id))
+    return len(entity_ids)
+
+
+def _relative_ref(path: Path, artifact_root: Path) -> str:
+    try:
+        return str(path.relative_to(artifact_root))
+    except ValueError:
+        return path.name
+
+
+def _safe_file_component(value: str) -> str:
+    sanitized = _SAFE_FILE_COMPONENT_PATTERN.sub("-", value.strip()).strip(".-")
+    if not sanitized:
+        raise ValueError("file component must not be empty after sanitization")
+    return sanitized[:120]
+
+
+def _atomic_write_json(path: Path, payload: Mapping[str, Any]) -> None:
+    _atomic_write_text(
+        path,
+        json.dumps(
+            redact_evidence_payload(payload),
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        + "\n",
+    )
+
+
+def _atomic_write_text(path: Path, text: str) -> None:
+    tmp_path = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    tmp_path.write_text(text, encoding="utf-8")
+    tmp_path.replace(path)

--- a/graph_engine/rollout/evidence.py
+++ b/graph_engine/rollout/evidence.py
@@ -1,0 +1,130 @@
+"""Sanitized evidence manifests for guarded rollout paths."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from collections.abc import Mapping
+from datetime import date, datetime
+from pathlib import Path
+from typing import Any
+
+_SAFE_FILE_COMPONENT_PATTERN = re.compile(r"[^A-Za-z0-9_.-]+")
+_SENSITIVE_KEY_PATTERN = re.compile(
+    r"(token|secret|password|passwd|pwd|dsn|database_url|private_key|"
+    r"raw[_-]?(payload|response|provider)?|provider[_-]?payload|"
+    r"local[_-]?path|runtime[_-]?path)",
+    re.IGNORECASE,
+)
+_SENSITIVE_VALUE_PATTERNS = (
+    re.compile(r"\b(?:postgres(?:ql)?|mysql|redis|mongodb)://\S+", re.IGNORECASE),
+    re.compile(r"\bbolt(?:\+s|\+ssc)?://\S+", re.IGNORECASE),
+    re.compile(r"\b(?:ghp|gho|github_pat)_[A-Za-z0-9_]+\b"),
+    re.compile(r"\b[A-Za-z0-9_]*token[A-Za-z0-9_]*=[^\s,;]+", re.IGNORECASE),
+    re.compile(r"/Users/[^,\s\"']+"),
+    re.compile(r"/private/var/[^,\s\"']+"),
+    re.compile(r"/tmp/[^,\s\"']+"),
+)
+_REDACTED_VALUE = "<redacted>"
+
+
+class EvidenceWriter:
+    """Write sanitized rollout evidence JSON under an artifact namespace."""
+
+    def __init__(self, artifact_root: str | Path, *, namespace: str) -> None:
+        self.artifact_root = Path(artifact_root).expanduser().resolve(strict=False)
+        self.namespace = _safe_file_component(namespace)
+
+    def write_manifest(self, name: str, payload: Mapping[str, Any]) -> Path:
+        evidence_dir = self.artifact_root / self.namespace / "evidence"
+        evidence_dir.mkdir(parents=True, exist_ok=True)
+        manifest_path = evidence_dir / f"{_safe_file_component(name)}.json"
+        sanitized = redact_evidence_payload(payload)
+        _atomic_write_json(manifest_path, sanitized)
+        return manifest_path
+
+
+def redact_evidence_payload(value: Any, *, key: str | None = None) -> Any:
+    """Return a JSON-safe payload with secrets, local paths, and raw bodies redacted."""
+
+    if key is not None and _SENSITIVE_KEY_PATTERN.search(key):
+        return _REDACTED_VALUE
+    if isinstance(value, Mapping):
+        return {
+            str(item_key): redact_evidence_payload(item_value, key=str(item_key))
+            for item_key, item_value in value.items()
+        }
+    if isinstance(value, list):
+        return [redact_evidence_payload(item) for item in value]
+    if isinstance(value, tuple):
+        return [redact_evidence_payload(item) for item in value]
+    if isinstance(value, set | frozenset):
+        return sorted(redact_evidence_payload(item) for item in value)
+    if isinstance(value, datetime | date):
+        return value.isoformat()
+    if isinstance(value, Path):
+        return _REDACTED_VALUE
+    if isinstance(value, str):
+        return _redact_sensitive_string(value)
+    return value
+
+
+def safe_reload_ref_label(snapshot_ref: str) -> str:
+    """Record a reload ref label without leaking local filesystem paths."""
+
+    value = str(snapshot_ref or "").strip()
+    if not value:
+        raise ValueError("snapshot_ref must not be empty")
+    if value.startswith(("artifact://", "s3://", "gs://")):
+        return _redact_sensitive_string(value)
+    path = Path(value)
+    if path.is_absolute() or "/" in value or "\\" in value:
+        return path.name or _REDACTED_VALUE
+    return _redact_sensitive_string(value)
+
+
+def _redact_sensitive_string(value: str) -> str:
+    redacted = value
+    for pattern in _SENSITIVE_VALUE_PATTERNS:
+        redacted = pattern.sub(_REDACTED_VALUE, redacted)
+    if _looks_like_raw_payload_string(redacted):
+        return _REDACTED_VALUE
+    return redacted
+
+
+def _looks_like_raw_payload_string(value: str) -> bool:
+    stripped = value.strip()
+    if not (
+        (stripped.startswith("{") and stripped.endswith("}"))
+        or (stripped.startswith("[") and stripped.endswith("]"))
+    ):
+        return False
+    lowered = stripped.lower()
+    return any(
+        marker in lowered
+        for marker in (
+            '"password"',
+            '"private_key"',
+            '"raw_payload"',
+            '"raw_response"',
+            '"secret"',
+            '"token"',
+        )
+    )
+
+
+def _safe_file_component(value: str) -> str:
+    sanitized = _SAFE_FILE_COMPONENT_PATTERN.sub("-", value.strip()).strip(".-")
+    if not sanitized:
+        raise ValueError("file component must not be empty after sanitization")
+    return sanitized[:120]
+
+
+def _atomic_write_json(path: Path, payload: Any) -> None:
+    tmp_path = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    tmp_path.write_text(
+        json.dumps(payload, sort_keys=True, separators=(",", ":")) + "\n",
+        encoding="utf-8",
+    )
+    tmp_path.replace(path)

--- a/graph_engine/rollout/guard.py
+++ b/graph_engine/rollout/guard.py
@@ -1,0 +1,186 @@
+"""Fail-closed guards for opt-in live-graph rollout paths."""
+
+from __future__ import annotations
+
+import os
+import re
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal
+
+from contracts.schemas import CandidateGraphDelta
+
+from graph_engine.models import PromotionPlan
+
+RolloutMode = Literal["disabled", "canary", "production"]
+
+CONFIRM_ENV = "GRAPH_ENGINE_LIVE_GRAPH_ROLLOUT_CONFIRM"
+CONFIRM_VALUE = "1"
+HOLDINGS_RELATIONSHIP_ALLOWLIST = frozenset({"CO_HOLDING", "NORTHBOUND_HOLD"})
+
+_SAFE_IDENTIFIER_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]{2,95}$")
+_SAFE_DATABASE_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]{2,95}$")
+_DISPOSABLE_DATABASE_MARKER_PATTERN = re.compile(
+    r"(canary|proof|rollout|smoke|test)",
+    re.IGNORECASE,
+)
+_UNSAFE_NAMES = frozenset(
+    {
+        "default",
+        "live",
+        "main",
+        "neo4j",
+        "prod",
+        "production",
+        "system",
+    }
+)
+
+
+@dataclass(frozen=True)
+class LiveGraphRolloutConfig:
+    """Configuration required before any opt-in live graph rollout path runs."""
+
+    namespace: str
+    mode: RolloutMode
+    neo4j_database: str
+    allowed_relationship_types: set[str]
+    artifact_root: Path
+
+
+def validate_rollout_config(
+    config: LiveGraphRolloutConfig,
+    *,
+    env: Mapping[str, str | None] | None = None,
+) -> LiveGraphRolloutConfig:
+    """Validate rollout gates before artifacts, Layer A writes, or Neo4j writes."""
+
+    effective_env = os.environ if env is None else env
+    if config.mode == "disabled":
+        raise PermissionError("live graph rollout mode is disabled")
+    if config.mode not in {"canary", "production"}:
+        raise ValueError(f"unsupported live graph rollout mode: {config.mode!r}")
+    if effective_env.get(CONFIRM_ENV) != CONFIRM_VALUE:
+        raise PermissionError(f"{CONFIRM_ENV}=1 is required for live graph rollout")
+
+    namespace = _validate_namespace(config.namespace)
+    neo4j_database = _validate_neo4j_database(config.neo4j_database)
+    allowed_relationship_types = _validate_relationship_allowlist(
+        config.allowed_relationship_types,
+    )
+    artifact_root = _validate_artifact_root(config.artifact_root)
+
+    return LiveGraphRolloutConfig(
+        namespace=namespace,
+        mode=config.mode,
+        neo4j_database=neo4j_database,
+        allowed_relationship_types=allowed_relationship_types,
+        artifact_root=artifact_root,
+    )
+
+
+def validate_client_database_matches_config(
+    client: Any,
+    config: LiveGraphRolloutConfig,
+) -> None:
+    """Require the actual Neo4j client database to match the guarded database."""
+
+    expected_database = _validate_neo4j_database(config.neo4j_database)
+    actual_database = _client_database(client)
+    if actual_database != expected_database:
+        raise PermissionError(
+            "Neo4j client database does not match live graph rollout database: "
+            f"expected {expected_database!r}, actual {actual_database!r}",
+        )
+
+
+def validate_candidate_relationship_allowlist(
+    deltas: Sequence[CandidateGraphDelta],
+    allowed_relationship_types: set[str],
+) -> None:
+    """Fail closed unless all selected contract deltas are explicitly allowed."""
+
+    allowed = _validate_relationship_allowlist(allowed_relationship_types)
+    relation_types = sorted({delta.relation_type for delta in deltas})
+    disallowed = [
+        relation_type for relation_type in relation_types if relation_type not in allowed
+    ]
+    if disallowed:
+        raise PermissionError(
+            "candidate graph deltas contain relationship types outside the allowlist: "
+            + ", ".join(disallowed),
+        )
+
+
+def validate_promotion_plan_relationship_allowlist(
+    plan: PromotionPlan,
+    allowed_relationship_types: set[str],
+) -> None:
+    """Fail closed unless all promoted Layer A edges are explicitly allowed."""
+
+    allowed = _validate_relationship_allowlist(allowed_relationship_types)
+    relation_types = sorted({edge.relationship_type for edge in plan.edge_records})
+    disallowed = [
+        relation_type for relation_type in relation_types if relation_type not in allowed
+    ]
+    if disallowed:
+        raise PermissionError(
+            "promotion plan contains relationship types outside the allowlist: "
+            + ", ".join(disallowed),
+        )
+
+
+def _validate_namespace(namespace: str) -> str:
+    value = str(namespace or "").strip()
+    if not value:
+        raise PermissionError("live graph rollout namespace is required")
+    if not _SAFE_IDENTIFIER_PATTERN.fullmatch(value):
+        raise ValueError("live graph rollout namespace must be a safe identifier")
+    if value.lower() in _UNSAFE_NAMES:
+        raise PermissionError(f"live graph rollout namespace {value!r} is not allowed")
+    return value
+
+
+def _validate_neo4j_database(database: str) -> str:
+    value = str(database or "").strip()
+    if not value:
+        raise PermissionError("neo4j_database is required for live graph rollout")
+    if not _SAFE_DATABASE_PATTERN.fullmatch(value):
+        raise ValueError("neo4j_database must be a safe identifier")
+    if value.lower() in _UNSAFE_NAMES:
+        raise PermissionError(f"Neo4j database {value!r} is not allowed for rollout")
+    if not _DISPOSABLE_DATABASE_MARKER_PATTERN.search(value):
+        raise PermissionError(
+            "Neo4j rollout database name must include canary, proof, rollout, "
+            "smoke, or test",
+        )
+    return value
+
+
+def _validate_relationship_allowlist(
+    allowed_relationship_types: set[str],
+) -> set[str]:
+    if not allowed_relationship_types:
+        raise PermissionError("allowed_relationship_types is required for rollout")
+    values = {str(value).strip() for value in allowed_relationship_types}
+    if "" in values:
+        raise ValueError("allowed_relationship_types must not contain empty values")
+    return values
+
+
+def _validate_artifact_root(artifact_root: Path) -> Path:
+    path = Path(artifact_root).expanduser().resolve(strict=False)
+    if path.exists() and not path.is_dir():
+        raise ValueError("artifact_root must be a directory")
+    return path
+
+
+def _client_database(client: Any) -> str:
+    config = getattr(client, "config", None)
+    database = getattr(config, "database", None)
+    value = str(database or "").strip()
+    if not value:
+        raise PermissionError("Neo4j client database could not be verified")
+    _validate_neo4j_database(value)
+    return value

--- a/tests/unit/test_rollout.py
+++ b/tests/unit/test_rollout.py
@@ -1,0 +1,478 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+import graph_engine.promotion.service as promotion_service
+import graph_engine.rollout.canary as canary_module
+from graph_engine.models import (
+    CandidateGraphDelta,
+    ColdReloadPlan,
+    GraphEdgeRecord,
+    GraphMetricsSnapshot,
+    GraphNodeRecord,
+    Neo4jGraphStatus,
+    PropagationResult,
+    PromotionPlan,
+)
+from graph_engine.promotion.service import promote_graph_deltas
+from graph_engine.rollout import (
+    EdgeReadbackSummary,
+    EvidenceWriter,
+    HoldingsAlgorithmCanarySummary,
+    LiveGraphRolloutConfig,
+    build_holdings_canary_context,
+    redact_evidence_payload,
+    run_holdings_canary_algorithms,
+    run_live_graph_canary,
+    validate_client_database_matches_config,
+    validate_rollout_config,
+    write_cold_reload_replay_evidence,
+)
+from graph_engine.status import GraphStatusManager
+from tests.fakes import InMemoryStatusStore
+
+NOW = datetime(2026, 5, 7, 12, 0, tzinfo=timezone.utc)
+ENV = {"GRAPH_ENGINE_LIVE_GRAPH_ROLLOUT_CONFIRM": "1"}
+ALLOW_HOLDINGS = {"CO_HOLDING", "NORTHBOUND_HOLD"}
+
+
+class FakeClient:
+    def __init__(self, *, database: str = "graph-canary-test-20260507") -> None:
+        self.config = SimpleNamespace(database=database)
+        self.read_calls: list[tuple[str, dict[str, Any]]] = []
+        self.write_calls: list[tuple[str, dict[str, Any]]] = []
+
+    def execute_read(
+        self,
+        query: str,
+        parameters: dict[str, Any] | None = None,
+    ) -> list[dict[str, Any]]:
+        self.read_calls.append((query, parameters or {}))
+        return []
+
+    def execute_write(
+        self,
+        query: str,
+        parameters: dict[str, Any] | None = None,
+    ) -> list[dict[str, Any]]:
+        self.write_calls.append((query, parameters or {}))
+        return []
+
+
+class FakeEntityReader:
+    def canonical_entity_ids_for_node_ids(self, node_ids: set[str]) -> dict[str, str]:
+        return {node_id: f"entity-{node_id}" for node_id in node_ids}
+
+    def existing_entity_ids(self, entity_ids: set[str]) -> set[str]:
+        return set(entity_ids)
+
+
+class FakeCanonicalWriter:
+    def __init__(self) -> None:
+        self.plans: list[PromotionPlan] = []
+
+    def write_canonical_records(self, plan: PromotionPlan) -> None:
+        self.plans.append(plan)
+
+
+class FakeColdReloadReader:
+    def __init__(self, plan: ColdReloadPlan) -> None:
+        self.plan = plan
+        self.calls: list[str] = []
+        self.drop_all_calls = 0
+
+    def read_cold_reload_plan(self, snapshot_ref: str) -> ColdReloadPlan:
+        self.calls.append(snapshot_ref)
+        return self.plan
+
+    def drop_all(self) -> None:
+        self.drop_all_calls += 1
+
+
+def test_rollout_guard_requires_confirm_default_db_namespace_and_client_match(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    config = _config(tmp_path)
+
+    with pytest.raises(PermissionError, match="ROLLOUT_CONFIRM"):
+        validate_rollout_config(config, env={})
+
+    with pytest.raises(PermissionError, match="not allowed"):
+        validate_rollout_config(
+            _config(tmp_path, neo4j_database="neo4j"),
+            env=ENV,
+        )
+
+    with pytest.raises(PermissionError, match="not allowed"):
+        validate_rollout_config(
+            _config(tmp_path, neo4j_database="production"),
+            env=ENV,
+        )
+
+    with pytest.raises(PermissionError, match="namespace"):
+        validate_rollout_config(_config(tmp_path, namespace=""), env=ENV)
+
+    guarded = validate_rollout_config(config, env=ENV)
+    with pytest.raises(PermissionError, match="client database does not match"):
+        validate_client_database_matches_config(FakeClient(database="graph-canary-test-other"), guarded)
+
+
+def test_promotion_relation_allowlist_rejects_before_canonical_writer_and_sync(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sync_live_graph = MagicMock()
+    monkeypatch.setattr(promotion_service, "sync_live_graph", sync_live_graph)
+    writer = FakeCanonicalWriter()
+
+    with pytest.raises(PermissionError, match="SUPPLY_CHAIN"):
+        promote_graph_deltas(
+            "cycle-1",
+            "selection-1",
+            candidate_reader=_candidate_reader(
+                [_candidate_delta("delta-supply", "SUPPLY_CHAIN")]
+            ),
+            entity_reader=FakeEntityReader(),
+            canonical_writer=writer,
+            client=FakeClient(),
+            status_manager=_status_manager(),
+            sync_to_live_graph=True,
+            allowed_relationship_types=ALLOW_HOLDINGS,
+        )
+
+    assert writer.plans == []
+    sync_live_graph.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("graph_status", "writer_lock_token", "match"),
+    [
+        ("rebuilding", None, "graph_status='ready'"),
+        ("ready", "incremental-sync", "active writer lock"),
+    ],
+)
+def test_canary_status_guard_fails_before_promotion_and_neo4j(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+    graph_status: str,
+    writer_lock_token: str | None,
+    match: str,
+) -> None:  # type: ignore[no-untyped-def]
+    promote = MagicMock(side_effect=AssertionError("promotion must not run"))
+    monkeypatch.setattr(canary_module, "promote_graph_deltas", promote)
+    client = FakeClient()
+
+    with pytest.raises(PermissionError, match=match):
+        run_live_graph_canary(
+            cycle_id="cycle-1",
+            selection_ref="selection-1",
+            candidate_deltas=[_candidate_delta("delta-co", "CO_HOLDING")],
+            entity_reader=FakeEntityReader(),
+            client=client,
+            status_manager=_status_manager(
+                graph_status=graph_status,  # type: ignore[arg-type]
+                writer_lock_token=writer_lock_token,
+            ),
+            config=_config(tmp_path),
+            env=ENV,
+        )
+
+    promote.assert_not_called()
+    assert client.write_calls == []
+
+
+def test_evidence_writer_redacts_secrets_paths_and_raw_payload(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    writer = EvidenceWriter(tmp_path, namespace="canary-20260507")
+
+    path = writer.write_manifest(
+        "redaction",
+        {
+            "namespace": "canary-20260507",
+            "neo4j_database_label": "graph-canary-test-20260507",
+            "dsn": "postgresql://user:secret@localhost/db",
+            "password": "secret",
+            "local_path": "/Users/fanjie/Desktop/Cowork/project-ult/private.json",
+            "nested": {
+                "raw_payload": {"token": "ghp_secretvalue"},
+                "safe": "graph-canary-test-20260507",
+                "note": '{"token":"ghp_secretvalue","raw_payload":"x"}',
+            },
+        },
+    )
+
+    text = path.read_text(encoding="utf-8")
+    payload = json.loads(text)
+    assert "postgresql://" not in text
+    assert "ghp_secretvalue" not in text
+    assert "/Users/fanjie" not in text
+    assert payload["dsn"] == "<redacted>"
+    assert payload["password"] == "<redacted>"
+    assert payload["local_path"] == "<redacted>"
+    assert payload["nested"]["raw_payload"] == "<redacted>"
+    assert payload["nested"]["note"] == "<redacted>"
+    assert payload["nested"]["safe"] == "graph-canary-test-20260507"
+    assert redact_evidence_payload({"database_url": "postgresql://x"}) == {
+        "database_url": "<redacted>"
+    }
+
+
+def test_canary_runner_writes_evidence_and_uses_explicit_holdings_algorithms(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:  # type: ignore[no-untyped-def]
+    calls: list[str] = []
+    plan = _promotion_plan()
+
+    def fake_promote_graph_deltas(*args: Any, **kwargs: Any) -> PromotionPlan:
+        calls.append("promote")
+        assert kwargs["allowed_relationship_types"] == ALLOW_HOLDINGS
+        assert kwargs["sync_to_live_graph"] is True
+        kwargs["canonical_writer"].write_canonical_records(plan)
+        return plan
+
+    def fake_algorithms(*args: Any, **kwargs: Any) -> HoldingsAlgorithmCanarySummary:
+        calls.append("algorithms")
+        return HoldingsAlgorithmCanarySummary(
+            cycle_id="cycle-1",
+            graph_generation_id=4,
+            co_holding_path_count=1,
+            northbound_path_count=1,
+            total_path_count=2,
+            impacted_entity_count=1,
+            co_holding_diagnostics={},
+            northbound_diagnostics={},
+        )
+
+    monkeypatch.setattr(canary_module, "promote_graph_deltas", fake_promote_graph_deltas)
+    monkeypatch.setattr(canary_module, "run_holdings_canary_algorithms", fake_algorithms)
+
+    summary = run_live_graph_canary(
+        cycle_id="cycle-1",
+        selection_ref="selection-1",
+        candidate_deltas=[
+            _candidate_delta("delta-co", "CO_HOLDING"),
+            _candidate_delta("delta-nb", "NORTHBOUND_HOLD"),
+        ],
+        entity_reader=FakeEntityReader(),
+        client=FakeClient(),
+        status_manager=_status_manager(graph_generation_id=4),
+        config=_config(tmp_path),
+        env=ENV,
+        readback_hook=lambda client, plan, allowed: EdgeReadbackSummary(
+            expected_edge_count=2,
+            edge_count=2,
+            relation_counts={"CO_HOLDING": 1, "NORTHBOUND_HOLD": 1},
+            missing_edge_ids=[],
+            disallowed_relation_types=[],
+        ),
+    )
+
+    assert calls == ["promote", "algorithms"]
+    assert summary.layer_a_artifact.relation_counts == {
+        "CO_HOLDING": 1,
+        "NORTHBOUND_HOLD": 1,
+    }
+    evidence = json.loads(summary.evidence_manifest_path.read_text(encoding="utf-8"))
+    assert evidence["mode"] == "canary"
+    assert evidence["neo4j_database_label"] == "graph-canary-test-20260507"
+    assert evidence["relation_counts"] == {"CO_HOLDING": 1, "NORTHBOUND_HOLD": 1}
+    assert "run_full_propagation" not in canary_module.__dict__
+
+
+def test_holdings_canary_algorithm_summary_calls_only_explicit_algorithms(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[str] = []
+
+    def fake_co_holding(*args: Any, **kwargs: Any) -> PropagationResult:
+        calls.append("co")
+        return _propagation_result("co_holding_crowding", "reflexive")
+
+    def fake_northbound(*args: Any, **kwargs: Any) -> PropagationResult:
+        calls.append("nb")
+        return _propagation_result("northbound_anomaly", "event")
+
+    monkeypatch.setattr(canary_module, "run_co_holding_crowding", fake_co_holding)
+    monkeypatch.setattr(canary_module, "run_northbound_anomaly", fake_northbound)
+
+    summary = run_holdings_canary_algorithms(
+        build_holdings_canary_context(
+            cycle_id="cycle-1",
+            graph_generation_id=4,
+            namespace="canary-20260507",
+        ),
+        FakeClient(),
+        status_manager=_status_manager(graph_generation_id=4),
+    )
+
+    assert calls == ["co", "nb"]
+    assert summary.total_path_count == 2
+    assert "run_full_propagation" not in canary_module.__dict__
+
+
+def test_cold_reload_replay_evidence_reads_artifact_plan_without_destructive_reload(
+    tmp_path,
+) -> None:  # type: ignore[no-untyped-def]
+    reader = FakeColdReloadReader(_cold_reload_plan())
+
+    evidence_path = write_cold_reload_replay_evidence(
+        snapshot_ref="/Users/fanjie/Desktop/Cowork/project-ult/private/reload_plan.json",
+        canonical_reader=reader,
+        config=_config(tmp_path),
+        env=ENV,
+    )
+
+    evidence = json.loads(evidence_path.read_text(encoding="utf-8"))
+    assert reader.calls == ["/Users/fanjie/Desktop/Cowork/project-ult/private/reload_plan.json"]
+    assert reader.drop_all_calls == 0
+    assert evidence["destructive_reload_executed"] is False
+    assert evidence["reload_ref"] == "reload_plan.json"
+    assert "/Users/fanjie" not in evidence_path.read_text(encoding="utf-8")
+    assert evidence["relation_counts"] == {"CO_HOLDING": 1, "NORTHBOUND_HOLD": 1}
+
+
+def _config(
+    tmp_path,  # type: ignore[no-untyped-def]
+    *,
+    namespace: str = "canary-20260507",
+    neo4j_database: str = "graph-canary-test-20260507",
+) -> LiveGraphRolloutConfig:
+    return LiveGraphRolloutConfig(
+        namespace=namespace,
+        mode="canary",
+        neo4j_database=neo4j_database,
+        allowed_relationship_types=set(ALLOW_HOLDINGS),
+        artifact_root=tmp_path,
+    )
+
+
+def _candidate_reader(deltas: list[CandidateGraphDelta]) -> Any:
+    return SimpleNamespace(
+        read_candidate_graph_deltas=lambda cycle_id, selection_ref: list(deltas)
+    )
+
+
+def _candidate_delta(delta_id: str, relation_type: str) -> CandidateGraphDelta:
+    return CandidateGraphDelta(
+        delta_id=delta_id,
+        delta_type="edge_upsert",
+        source_node="node-a",
+        target_node="node-b",
+        relation_type=relation_type,
+        properties={"evidence_refs": [f"fact-{delta_id}"]},
+        evidence=[f"fact-{delta_id}"],
+        subsystem_id="subsystem-holdings",
+    )
+
+
+def _promotion_plan() -> PromotionPlan:
+    return PromotionPlan(
+        cycle_id="cycle-1",
+        selection_ref="selection-1",
+        delta_ids=["delta-co", "delta-nb"],
+        node_records=[_node("node-a", "entity-a"), _node("node-b", "entity-b")],
+        edge_records=[
+            _edge("edge-co", "CO_HOLDING"),
+            _edge("edge-nb", "NORTHBOUND_HOLD"),
+        ],
+        assertion_records=[],
+        created_at=NOW,
+    )
+
+
+def _cold_reload_plan() -> ColdReloadPlan:
+    plan = _promotion_plan()
+    return ColdReloadPlan(
+        snapshot_ref="snapshot-1",
+        cycle_id="cycle-1",
+        expected_snapshot=GraphMetricsSnapshot(
+            cycle_id="cycle-1",
+            snapshot_id="snapshot-1",
+            graph_generation_id=4,
+            node_count=2,
+            edge_count=2,
+            key_label_counts={"Entity": 2},
+            checksum="checksum",
+            created_at=NOW,
+        ),
+        node_records=plan.node_records,
+        edge_records=plan.edge_records,
+        assertion_records=[],
+        projection_name="graph_canary_test",
+        created_at=NOW,
+    )
+
+
+def _node(node_id: str, canonical_entity_id: str) -> GraphNodeRecord:
+    return GraphNodeRecord(
+        node_id=node_id,
+        canonical_entity_id=canonical_entity_id,
+        label="Entity",
+        properties={"canonical_id_rule_version": "test/v1"},
+        created_at=NOW,
+        updated_at=NOW,
+    )
+
+
+def _edge(edge_id: str, relationship_type: str) -> GraphEdgeRecord:
+    return GraphEdgeRecord(
+        edge_id=edge_id,
+        source_node_id="node-a",
+        target_node_id="node-b",
+        relationship_type=relationship_type,
+        properties={"evidence_refs": [f"fact-{edge_id}"]},
+        weight=1.0,
+        created_at=NOW,
+        updated_at=NOW,
+    )
+
+
+def _status_manager(
+    *,
+    graph_status: str = "ready",
+    graph_generation_id: int = 1,
+    writer_lock_token: str | None = None,
+) -> GraphStatusManager:
+    return GraphStatusManager(
+        InMemoryStatusStore(
+            Neo4jGraphStatus(
+                graph_status=graph_status,  # type: ignore[arg-type]
+                graph_generation_id=graph_generation_id,
+                node_count=2,
+                edge_count=2,
+                key_label_counts={"Entity": 2},
+                checksum="checksum",
+                last_verified_at=NOW if graph_status == "ready" else None,
+                last_reload_at=None,
+                writer_lock_token=writer_lock_token,
+            )
+        )
+    )
+
+
+def _propagation_result(algorithm: str, channel: str) -> PropagationResult:
+    relationship_type = "CO_HOLDING" if channel == "reflexive" else "NORTHBOUND_HOLD"
+    return PropagationResult(
+        cycle_id="cycle-1",
+        graph_generation_id=4,
+        activated_paths=[
+            {
+                "source_node_id": "node-a",
+                "target_node_id": "node-b",
+                "relationship_type": relationship_type,
+                "score": 0.5,
+            }
+        ],
+        impacted_entities=[{"node_id": "node-b", "score": 0.5}],
+        channel_breakdown={
+            channel: {
+                algorithm: {
+                    "relationship_type": relationship_type,
+                    "diagnostics": {},
+                }
+            }
+        },
+    )


### PR DESCRIPTION
## Summary
- add opt-in live graph rollout guard config with env confirmation, namespace/database/client DB checks, and fail-closed relationship allowlists
- add rollout canary/evidence module for Layer A artifact writing, guarded promotion sync, readback summaries, explicit holdings algorithm summaries, and sanitized manifests
- add cold reload replay evidence that only reads artifact plans and records evidence; it does not run destructive reload

## Tests
- PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -m pytest -p no:cacheprovider -q tests/unit/test_holdings_live_graph_proof.py tests/unit/test_propagation_holdings.py tests/unit/test_promotion.py tests/unit/test_sync.py tests/unit/test_reload.py tests/unit/test_query.py tests/unit/test_rollout.py
- .venv/bin/ruff check graph_engine/rollout tests/unit/test_rollout.py graph_engine/promotion/service.py
- git diff --check origin/main...HEAD
- git diff --check

## Boundaries
- contracts unchanged
- default pipeline unchanged
- no default run_full_propagation hookup
- no production rollout claimed