### PR TITLE
[codex] Align graph-engine canary docs state

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,29 @@ Implemented interface/type decisions:
   not claim production rollout to live Neo4j, graph writeback, or new
   cross-module contracts.
 
+Current bounded canary / live-evidence state:
+
+- Bounded gated canary / live production evidence status: **PASS** for
+  the guarded proof/canary path only. This covers holdings-scoped
+  `CO_HOLDING` / `NORTHBOUND_HOLD` candidates, Layer A artifact evidence,
+  guarded live-graph sync/readback, explicit holdings algorithm summaries,
+  and CI evidence from the proof/canary hardening PRs.
+- Production hardening prerequisites and guards have landed for that
+  bounded path: explicit environment confirmation, safe namespace and
+  artifact-root validation, non-default disposable Neo4j database labels,
+  client database match checks, ready-status checks, relationship
+  allowlists, evidence manifests, and sanitized proof outputs.
+- This PASS does **not** mean default or full propagation is enabled. It
+  does **not** mean broad production rollout is complete. It does **not**
+  complete M4.7 / financial-doc scope, add contracts subtypes, or expand
+  the relationship scope beyond `CO_HOLDING` / `NORTHBOUND_HOLD`.
+
+Next step after the bounded canary evidence is post-canary
+operationalization and runbook hardening. Only after that should the
+project evaluate a controlled opt-in canary for default propagation; it
+should still remain gated and should not be documented as default-enabled
+or broadly rolled out until separate evidence lands.
+
 CLAUDE.md §10 domain invariants this module enforces by construction:
 
 - **Truth Before Mirror** (#1): Iceberg is canonical truth; Neo4j is

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -24,6 +24,17 @@ event/reflexive propagation、readonly query/simulation、snapshot generation
   `PLEDGE_STATUS`。
 - 未声明 live Neo4j production rollout；算法仅读取 ready live graph，
   不写 Neo4j。
+- bounded gated canary / live production evidence 已达到 PASS，但该
+  PASS 只覆盖 holdings-scoped `CO_HOLDING` / `NORTHBOUND_HOLD` proof /
+  canary 路径，不表示默认传播已启用，也不表示 broad production
+  rollout 已完成。
+- production hardening prerequisites / guards 已落地：显式环境确认、
+  safe namespace / artifact root、非默认 disposable Neo4j database label、
+  client database match、ready status guard、relationship allowlist、
+  evidence manifest 与 sanitized proof output。
+- 下一步是 post-canary operationalization / runbook hardening；之后才
+  进入 controlled opt-in default-propagation canary，不提前声明 default /
+  full propagation enabled。
 
 ## 里程碑进度
 
@@ -40,7 +51,16 @@ event/reflexive propagation、readonly query/simulation、snapshot generation
 | Issue | 当前状态 | 说明 |
 |------|----------|------|
 | #56 | 已完成 | `CO_HOLDING` / `NORTHBOUND_HOLD` enum、planner、query、channel 基础能力 |
-| #55 | holdings-only 已完成/closed | 已完成 co-holding crowding 与 northbound anomaly 显式算法；broad/default propagation、financial-doc 与 contracts subtype 均不在本 scope |
+| #55 | holdings-only 已完成/closed | 已完成 co-holding crowding 与 northbound anomaly 显式算法；bounded gated canary/live evidence PASS；broad/default propagation、financial-doc 与 contracts subtype 均不在本 scope |
+
+## 下一步
+
+1. Post-canary operationalization / runbook hardening。
+2. 在 runbook 与操作 guard 补齐后，再评估 controlled opt-in default-propagation
+   canary。
+3. 在单独证据完成前，不声明 default/full propagation enabled、broad
+   production rollout complete、M4.7 / financial-doc complete 或 contracts
+   subtype 支持。
 
 ## 验证命令
 


### PR DESCRIPTION
## Summary
- align README current state with bounded gated canary/live production evidence PASS
- mirror the current state and next-step ordering in docs/PROGRESS.md
- keep boundaries explicit: no default/full propagation enabled, no broad production rollout complete, no M4.7/financial-doc completion, no contracts subtype, relationship scope remains CO_HOLDING/NORTHBOUND_HOLD

## Validation
- git diff --check
- git diff --name-only (README.md, docs/PROGRESS.md only)
- rg docs alignment check for canary PASS, production hardening guards, next-step ordering, and negative boundary claims
- git diff --check HEAD~1..HEAD

## Scope
- docs only
- no code changes
- no contracts changes