### PR TITLE
Harden propagation canary runbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ queries. Sole owner of:
 Source of truth:
 
 - `docs/graph-engine.project-doc.md`
+- `docs/PROPAGATION_CANARY_RUNBOOK.md` (holdings-only propagation
+  canary guardrails and evidence checklist)
 - `CLAUDE.md` (project-specific guardrails — domain rules, status
   guard, blocker triggers)
 
@@ -90,10 +92,11 @@ Current bounded canary / live-evidence state:
   the relationship scope beyond `CO_HOLDING` / `NORTHBOUND_HOLD`.
 
 Next step after the bounded canary evidence is post-canary
-operationalization and runbook hardening. Only after that should the
-project evaluate a controlled opt-in canary for default propagation; it
-should still remain gated and should not be documented as default-enabled
-or broadly rolled out until separate evidence lands.
+operationalization using the hardened runbook in
+`docs/PROPAGATION_CANARY_RUNBOOK.md`. Only after that should the project
+evaluate a controlled opt-in canary for default propagation; it should
+still remain gated and should not be documented as default-enabled or
+broadly rolled out until separate evidence lands.
 
 CLAUDE.md §10 domain invariants this module enforces by construction:
 
@@ -176,6 +179,14 @@ PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -m pytest -p no:cacheprovider -q \
   tests/unit/test_propagation_holdings.py tests/unit/test_propagation_merge.py \
   tests/unit/test_snapshots.py tests/unit/test_propagation_channels.py \
   tests/unit/test_schema.py tests/boundary/test_red_lines.py
+```
+
+Focused propagation canary / runbook hardening evidence:
+
+```bash
+PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -m pytest -p no:cacheprovider -q \
+  tests/unit/test_rollout.py tests/unit/test_rollout_runbook.py \
+  tests/unit/test_holdings_live_graph_proof.py
 ```
 
 Refresh global pass/skip counts only after running the full suite in the

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -1,6 +1,6 @@
 # graph-engine 项目进度总览
 
-> **最后更新**: 2026-05-07
+> **最后更新**: 2026-05-08
 > **项目文档**: [graph-engine.project-doc.md](./graph-engine.project-doc.md)
 > **任务拆解**: [TASK_BREAKDOWN.md](./TASK_BREAKDOWN.md)
 
@@ -32,8 +32,12 @@ event/reflexive propagation、readonly query/simulation、snapshot generation
   safe namespace / artifact root、非默认 disposable Neo4j database label、
   client database match、ready status guard、relationship allowlist、
   evidence manifest 与 sanitized proof output。
-- 下一步是 post-canary operationalization / runbook hardening；之后才
-  进入 controlled opt-in default-propagation canary，不提前声明 default /
+- propagation canary runbook hardening baseline 已补在
+  [PROPAGATION_CANARY_RUNBOOK.md](./PROPAGATION_CANARY_RUNBOOK.md)：锁定
+  disposable DB/default DB guard、Layer A -> sync verification、rollback /
+  read-only algorithm diagnostics 与 evidence hygiene。
+- 下一步是按 hardened runbook 做 post-canary operationalization；之后才
+  评估 controlled opt-in default-propagation canary，不提前声明 default /
   full propagation enabled。
 
 ## 里程碑进度
@@ -55,9 +59,10 @@ event/reflexive propagation、readonly query/simulation、snapshot generation
 
 ## 下一步
 
-1. Post-canary operationalization / runbook hardening。
-2. 在 runbook 与操作 guard 补齐后，再评估 controlled opt-in default-propagation
-   canary。
+1. 按 [PROPAGATION_CANARY_RUNBOOK.md](./PROPAGATION_CANARY_RUNBOOK.md)
+   做 post-canary operationalization。
+2. 在 runbook 与操作 guard 继续经实跑验证后，再评估 controlled opt-in
+   default-propagation canary。
 3. 在单独证据完成前，不声明 default/full propagation enabled、broad
    production rollout complete、M4.7 / financial-doc complete 或 contracts
    subtype 支持。
@@ -69,6 +74,10 @@ PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -m pytest -p no:cacheprovider -q \
   tests/unit/test_propagation_holdings.py tests/unit/test_propagation_merge.py \
   tests/unit/test_snapshots.py tests/unit/test_propagation_channels.py \
   tests/unit/test_schema.py tests/boundary/test_red_lines.py
+
+PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -m pytest -p no:cacheprovider -q \
+  tests/unit/test_rollout.py tests/unit/test_rollout_runbook.py \
+  tests/unit/test_holdings_live_graph_proof.py
 ```
 
 ## 保留边界

--- a/docs/PROPAGATION_CANARY_RUNBOOK.md
+++ b/docs/PROPAGATION_CANARY_RUNBOOK.md
@@ -1,0 +1,105 @@
+# Propagation Canary Runbook
+
+This runbook is for the guarded holdings propagation canary only. Issue #55
+is CLOSED/COMPLETED for holdings-only explicit algorithms:
+`run_co_holding_crowding`, `run_northbound_anomaly`, and
+`run_holdings_algorithms`. It does not restore the old financial-doc,
+guarantee-chain, related-party, contracts subtype, or broad propagation scope.
+
+## Scope
+
+- Relationship scope is limited to `CO_HOLDING` and `NORTHBOUND_HOLD`.
+- The canary is opt-in and gated. It does not enable default or full
+  propagation.
+- The canary evidence does not mean broad rollout is complete.
+- The canary writes Layer A artifacts before the live-graph sync and then uses
+  read-only checks and explicit holdings algorithms for diagnostics.
+- The canary must not emit formal graph snapshots or write algorithm results
+  back to Neo4j.
+
+## Required Gates
+
+Before any live PG or Neo4j proof path is allowed:
+
+- Set `GRAPH_ENGINE_LIVE_GRAPH_ROLLOUT_CONFIRM=1` in the runner environment.
+- Use `LiveGraphRolloutConfig.mode="canary"` for `run_live_graph_canary`.
+- Use a unique namespace such as `canary-<ticket>-<date>`. Do not use
+  `default`, `live`, `main`, `neo4j`, `prod`, `production`, or `system`.
+- Use a disposable Neo4j database whose name contains `canary`, `proof`,
+  `rollout`, `smoke`, or `test`. The default `neo4j` database and production
+  database labels are forbidden.
+- Verify the actual Neo4j client database matches the guarded config before
+  promotion or sync.
+- Set `allowed_relationship_types` to holdings relationships only. Do not add
+  `SUPPLY_CHAIN`, `OWNERSHIP`, financial-doc, or subtype relationship values.
+- Keep PG DSNs, Neo4j credentials, tokens, and local proof paths in the runner
+  environment or secret manager only. Do not write persistent repo config.
+
+## Execution Checklist
+
+1. Select a small, frozen canary candidate set from the upstream queue.
+2. Validate every candidate delta before promotion. The set must contain only
+   `CO_HOLDING` and `NORTHBOUND_HOLD`.
+3. Validate the rollout config, namespace, disposable Neo4j database label,
+   artifact root, and client database match.
+4. Require `Neo4jGraphStatus.graph_status == "ready"` and no active writer
+   lock before promotion.
+5. Run `run_live_graph_canary` with injected candidates, entity reader, Neo4j
+   client, status manager, and guarded config.
+6. Confirm the Layer A artifact summary exists before accepting any Neo4j sync
+   result.
+7. Read back synced edges with `readback_canary_edges`. This must be a
+   read-only query scoped by promoted `edge_id` values.
+8. Require post-sync ready status before algorithm diagnostics.
+9. Run only explicit holdings diagnostics through
+   `run_holdings_canary_algorithms`. Do not call or route through
+   `run_full_propagation`.
+10. Write only sanitized evidence under the canary namespace.
+
+## Layer A To Sync Verification
+
+A passing canary must show all of these in sanitized evidence:
+
+- Layer A artifact relation counts match the candidate scope.
+- Neo4j readback `missing_edge_ids` is empty.
+- Neo4j readback `disallowed_relation_types` is empty.
+- Readback relation counts contain only `CO_HOLDING` and `NORTHBOUND_HOLD`.
+- Pre-sync and post-sync graph status are both ready.
+- Algorithm diagnostics include separate co-holding and northbound summaries.
+
+Any mismatch fails the canary. Do not broaden the allowlist to make the
+readback pass.
+
+## Rollback And Diagnostics
+
+The canary rollback posture is fail-closed:
+
+- Stop on guard, Layer A, sync, readback, or algorithm diagnostic failure.
+- Do not run destructive reload from this canary runbook.
+- If a disposable Neo4j database is contaminated, discard or recreate that
+  disposable database out of band. Never repair by targeting the default DB.
+- Use `write_cold_reload_replay_evidence` only to prove a reload artifact can
+  be read. Its evidence must keep `destructive_reload_executed` false.
+- Treat zero or unexpected algorithm counts as read-only diagnostics. They do
+  not authorize default propagation, full propagation, broad rollout, or
+  graph writeback.
+
+## Evidence Hygiene
+
+Do not commit runtime artifacts, parquet files, generated manifests, stdout,
+stderr, exit-code files, local proof paths, tokens, DSNs, or raw provider
+payloads. Evidence committed to the repo must be documentation or tests only,
+not live run output.
+
+## Verification Commands
+
+```bash
+git diff --check
+PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -m pytest -p no:cacheprovider -q \
+  tests/unit/test_rollout.py tests/unit/test_rollout_runbook.py \
+  tests/unit/test_holdings_live_graph_proof.py
+PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -m pytest -p no:cacheprovider -q \
+  tests/unit/test_propagation_holdings.py tests/unit/test_propagation_merge.py \
+  tests/unit/test_propagation_channels.py tests/unit/test_schema.py \
+  tests/boundary/test_red_lines.py
+```

--- a/graph_engine/rollout/guard.py
+++ b/graph_engine/rollout/guard.py
@@ -166,6 +166,12 @@ def _validate_relationship_allowlist(
     values = {str(value).strip() for value in allowed_relationship_types}
     if "" in values:
         raise ValueError("allowed_relationship_types must not contain empty values")
+    disallowed = sorted(values - HOLDINGS_RELATIONSHIP_ALLOWLIST)
+    if disallowed:
+        raise PermissionError(
+            "allowed_relationship_types may only include holdings relationships: "
+            + ", ".join(disallowed),
+        )
     return values
 
 

--- a/tests/unit/test_rollout.py
+++ b/tests/unit/test_rollout.py
@@ -43,8 +43,14 @@ ALLOW_HOLDINGS = {"CO_HOLDING", "NORTHBOUND_HOLD"}
 
 
 class FakeClient:
-    def __init__(self, *, database: str = "graph-canary-test-20260507") -> None:
+    def __init__(
+        self,
+        *,
+        database: str = "graph-canary-test-20260507",
+        rows: list[dict[str, Any]] | None = None,
+    ) -> None:
         self.config = SimpleNamespace(database=database)
+        self.rows = rows or []
         self.read_calls: list[tuple[str, dict[str, Any]]] = []
         self.write_calls: list[tuple[str, dict[str, Any]]] = []
 
@@ -54,7 +60,7 @@ class FakeClient:
         parameters: dict[str, Any] | None = None,
     ) -> list[dict[str, Any]]:
         self.read_calls.append((query, parameters or {}))
-        return []
+        return list(self.rows)
 
     def execute_write(
         self,
@@ -119,6 +125,17 @@ def test_rollout_guard_requires_confirm_default_db_namespace_and_client_match(tm
     guarded = validate_rollout_config(config, env=ENV)
     with pytest.raises(PermissionError, match="client database does not match"):
         validate_client_database_matches_config(FakeClient(database="graph-canary-test-other"), guarded)
+
+
+def test_rollout_guard_rejects_allowlist_outside_holdings_scope(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    with pytest.raises(PermissionError, match="holdings relationships"):
+        validate_rollout_config(
+            _config(
+                tmp_path,
+                allowed_relationship_types={"CO_HOLDING", "SUPPLY_CHAIN"},
+            ),
+            env=ENV,
+        )
 
 
 def test_promotion_relation_allowlist_rejects_before_canonical_writer_and_sync(
@@ -242,8 +259,8 @@ def test_canary_runner_writes_evidence_and_uses_explicit_holdings_algorithms(
             northbound_path_count=1,
             total_path_count=2,
             impacted_entity_count=1,
-            co_holding_diagnostics={},
-            northbound_diagnostics={},
+            co_holding_diagnostics={"candidate_pair_count": 3},
+            northbound_diagnostics={"window_count": 2},
         )
 
     monkeypatch.setattr(canary_module, "promote_graph_deltas", fake_promote_graph_deltas)
@@ -279,7 +296,49 @@ def test_canary_runner_writes_evidence_and_uses_explicit_holdings_algorithms(
     assert evidence["mode"] == "canary"
     assert evidence["neo4j_database_label"] == "graph-canary-test-20260507"
     assert evidence["relation_counts"] == {"CO_HOLDING": 1, "NORTHBOUND_HOLD": 1}
+    assert evidence["layer_a_artifact"]["relation_counts"] == {
+        "CO_HOLDING": 1,
+        "NORTHBOUND_HOLD": 1,
+    }
+    assert evidence["edge_readback"]["missing_edge_ids"] == []
+    assert evidence["edge_readback"]["disallowed_relation_types"] == []
+    assert evidence["holdings_algorithms"]["co_holding_diagnostics"] == {
+        "candidate_pair_count": 3,
+    }
+    assert evidence["holdings_algorithms"]["northbound_diagnostics"] == {
+        "window_count": 2,
+    }
     assert "run_full_propagation" not in canary_module.__dict__
+
+
+def test_readback_canary_edges_is_read_only_and_reports_sync_failures() -> None:
+    client = FakeClient(
+        rows=[
+            {"edge_id": "edge-co", "relationship_type": "CO_HOLDING"},
+            {"edge_id": "edge-bad", "relationship_type": "SUPPLY_CHAIN"},
+        ],
+    )
+
+    with pytest.raises(ValueError, match="missing synced canary edges"):
+        canary_module.readback_canary_edges(
+            client,
+            plan=_promotion_plan(),
+            allowed_relationship_types=ALLOW_HOLDINGS,
+        )
+
+    summary = canary_module.readback_canary_edges(
+        client,
+        plan=_promotion_plan(),
+        allowed_relationship_types=ALLOW_HOLDINGS,
+        strict=False,
+    )
+
+    assert summary.missing_edge_ids == ["edge-nb"]
+    assert summary.disallowed_relation_types == ["SUPPLY_CHAIN"]
+    assert summary.relation_counts == {"CO_HOLDING": 1, "SUPPLY_CHAIN": 1}
+    assert client.write_calls == []
+    assert "MATCH" in client.read_calls[0][0]
+    assert "MERGE" not in client.read_calls[0][0]
 
 
 def test_holdings_canary_algorithm_summary_calls_only_explicit_algorithms(
@@ -339,12 +398,13 @@ def _config(
     *,
     namespace: str = "canary-20260507",
     neo4j_database: str = "graph-canary-test-20260507",
+    allowed_relationship_types: set[str] | None = None,
 ) -> LiveGraphRolloutConfig:
     return LiveGraphRolloutConfig(
         namespace=namespace,
         mode="canary",
         neo4j_database=neo4j_database,
-        allowed_relationship_types=set(ALLOW_HOLDINGS),
+        allowed_relationship_types=set(allowed_relationship_types or ALLOW_HOLDINGS),
         artifact_root=tmp_path,
     )
 

--- a/tests/unit/test_rollout_runbook.py
+++ b/tests/unit/test_rollout_runbook.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_propagation_canary_runbook_pins_holdings_scope_and_hygiene() -> None:
+    text = (REPO_ROOT / "docs" / "PROPAGATION_CANARY_RUNBOOK.md").read_text(
+        encoding="utf-8",
+    )
+    normalized = " ".join(text.split())
+
+    required_phrases = [
+        "Issue #55 is CLOSED/COMPLETED for holdings-only explicit algorithms",
+        "`CO_HOLDING` and `NORTHBOUND_HOLD`",
+        "does not enable default or full propagation",
+        "does not mean broad rollout is complete",
+        "financial-doc",
+        "contracts subtype",
+        "Use a disposable Neo4j database",
+        "The default `neo4j` database and production database labels are forbidden",
+        "Verify the actual Neo4j client database matches the guarded config",
+        "Do not call or route through `run_full_propagation`",
+        "Do not commit runtime artifacts",
+        "tokens, DSNs, or raw provider payloads",
+    ]
+
+    for phrase in required_phrases:
+        assert phrase in normalized
+
+
+def test_readme_and_progress_reference_propagation_canary_runbook() -> None:
+    readme = (REPO_ROOT / "README.md").read_text(encoding="utf-8")
+    progress = (REPO_ROOT / "docs" / "PROGRESS.md").read_text(encoding="utf-8")
+
+    assert "docs/PROPAGATION_CANARY_RUNBOOK.md" in readme
+    assert "PROPAGATION_CANARY_RUNBOOK.md" in progress


### PR DESCRIPTION
## Summary
- add holdings-only propagation canary runbook for disposable Neo4j DB guards, Layer A to sync verification, rollback/read-only diagnostics, and evidence hygiene
- enforce rollout allowed_relationship_types as CO_HOLDING/NORTHBOUND_HOLD only
- add rollout/runbook tests for allowlist rejection, readback diagnostics, and docs boundaries

## Tests
- PYTHONPATH=../contracts/src PYTHONDONTWRITEBYTECODE=1 python3 -m pytest -p no:cacheprovider -q tests/unit/test_rollout.py tests/unit/test_rollout_runbook.py tests/unit/test_holdings_live_graph_proof.py tests/unit/test_propagation_holdings.py tests/unit/test_propagation_merge.py tests/unit/test_propagation_channels.py tests/unit/test_schema.py tests/boundary/test_red_lines.py
- git diff --check
- artifact scan for parquet/manifest/stdout/stderr/exitcode

Repo .venv lacks pytest, so local verification used system python3 with PYTHONPATH=../contracts/src.

## Scope
This keeps #55 holdings-only explicit algorithms closed/completed. It does not restore financial-doc/contracts-subtype/broad scope, does not enable default/full propagation, and does not claim broad production rollout complete.