### PR TITLE
Add MVP20 two-hop context query helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,17 @@ evaluate a controlled opt-in canary for default propagation; it should
 still remain gated and should not be documented as default-enabled or
 broadly rolled out until separate evidence lands.
 
+## MVP20 Read Context
+
+`graph_engine.query.query_mvp20_context_subgraph` is the MVP20 read-side
+helper. It delegates to the status-gated `query_subgraph` path with graph
+depth fixed at `2`, requires exactly 20 decision target entity ids, and
+annotates returned nodes/edges as `decision_target` or `context_only`.
+
+This helper is context-only. It does not enable default propagation, full
+propagation, write routes, new relationships, financial-doc/M4.7 behavior,
+or broad rollout semantics.
+
 CLAUDE.md §10 domain invariants this module enforces by construction:
 
 - **Truth Before Mirror** (#1): Iceberg is canonical truth; Neo4j is

--- a/artifacts/frontend-api/impact.json
+++ b/artifacts/frontend-api/impact.json
@@ -11,6 +11,7 @@
         "seed_entity"
       ],
       "entity_id": "ENT_STOCK_600519.SH",
+      "entity_role": "decision_target",
       "impact_score": 1.0
     },
     {
@@ -22,7 +23,20 @@
         "EDGE_600519_300750_MACRO_EVENT"
       ],
       "entity_id": "ENT_STOCK_300750.SZ",
+      "entity_role": "decision_target",
       "impact_score": 0.35
+    },
+    {
+      "channels": [
+        "fundamental"
+      ],
+      "display_name": "Liquor",
+      "drivers": [
+        "EDGE_600519_SECTOR_LIQUOR"
+      ],
+      "entity_id": "SECTOR_LIQUOR",
+      "entity_role": "context_only",
+      "impact_score": 0.12
     }
   ],
   "metadata": {

--- a/artifacts/frontend-api/paths.json
+++ b/artifacts/frontend-api/paths.json
@@ -19,7 +19,8 @@
       "score": 0.35,
       "seed": "ENT_STOCK_600519.SH",
       "summary": "Macro event channel connects Kweichow Moutai to CATL.",
-      "target": "ENT_STOCK_300750.SZ"
+      "target": "ENT_STOCK_300750.SZ",
+      "target_role": "decision_target"
     },
     {
       "channel": "fundamental",
@@ -35,7 +36,8 @@
       "score": 1.0,
       "seed": "ENT_STOCK_600519.SH",
       "summary": "Kweichow Moutai belongs to the Liquor sector.",
-      "target": "SECTOR_LIQUOR"
+      "target": "SECTOR_LIQUOR",
+      "target_role": "context_only"
     }
   ]
 }

--- a/artifacts/frontend-api/subgraph.json
+++ b/artifacts/frontend-api/subgraph.json
@@ -9,7 +9,9 @@
         ]
       },
       "relationship_type": "SECTOR_MEMBERSHIP",
+      "source_entity_role": "decision_target",
       "source_node_id": "ENT_STOCK_600519.SH",
+      "target_entity_role": "context_only",
       "target_node_id": "SECTOR_LIQUOR",
       "weight": 1.0
     },
@@ -22,7 +24,9 @@
         ]
       },
       "relationship_type": "SECTOR_MEMBERSHIP",
+      "source_entity_role": "decision_target",
       "source_node_id": "ENT_STOCK_300750.SZ",
+      "target_entity_role": "context_only",
       "target_node_id": "SECTOR_BATTERY",
       "weight": 1.0
     },
@@ -35,7 +39,9 @@
         ]
       },
       "relationship_type": "EVENT_IMPACT",
+      "source_entity_role": "decision_target",
       "source_node_id": "ENT_STOCK_600519.SH",
+      "target_entity_role": "decision_target",
       "target_node_id": "ENT_STOCK_300750.SZ",
       "weight": 0.35
     }
@@ -47,6 +53,7 @@
   },
   "nodes": [
     {
+      "entity_role": "decision_target",
       "display_name": "Kweichow Moutai",
       "entity_id": "ENT_STOCK_600519.SH",
       "label": "Entity",
@@ -58,6 +65,7 @@
       }
     },
     {
+      "entity_role": "decision_target",
       "display_name": "CATL",
       "entity_id": "ENT_STOCK_300750.SZ",
       "label": "Entity",
@@ -69,6 +77,7 @@
       }
     },
     {
+      "entity_role": "context_only",
       "display_name": "Liquor",
       "label": "Sector",
       "node_id": "SECTOR_LIQUOR",
@@ -77,6 +86,7 @@
       }
     },
     {
+      "entity_role": "context_only",
       "display_name": "Battery",
       "label": "Sector",
       "node_id": "SECTOR_BATTERY",

--- a/graph_engine/query/__init__.py
+++ b/graph_engine/query/__init__.py
@@ -5,11 +5,31 @@ from graph_engine.query.service import (
     query_propagation_paths,
     query_subgraph,
 )
+from graph_engine.query.mvp20 import (
+    MVP20_CONTEXT_ONLY_ROLE,
+    MVP20_DECISION_TARGET_COUNT,
+    MVP20_DECISION_TARGET_ROLE,
+    MVP20_GRAPH_DEPTH,
+    annotate_mvp20_context_edges,
+    annotate_mvp20_context_nodes,
+    mvp20_entity_role,
+    query_mvp20_context_subgraph,
+    validate_mvp20_decision_targets,
+)
 from graph_engine.query.simulation import simulate_readonly_impact
 
 __all__ = [
     "MAX_QUERY_DEPTH",
+    "MVP20_CONTEXT_ONLY_ROLE",
+    "MVP20_DECISION_TARGET_COUNT",
+    "MVP20_DECISION_TARGET_ROLE",
+    "MVP20_GRAPH_DEPTH",
+    "annotate_mvp20_context_edges",
+    "annotate_mvp20_context_nodes",
+    "mvp20_entity_role",
     "query_propagation_paths",
+    "query_mvp20_context_subgraph",
     "query_subgraph",
     "simulate_readonly_impact",
+    "validate_mvp20_decision_targets",
 ]

--- a/graph_engine/query/mvp20.py
+++ b/graph_engine/query/mvp20.py
@@ -1,0 +1,193 @@
+"""MVP20 read-side helpers for bounded context graph reads."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any, Literal
+
+from graph_engine.client import Neo4jClient
+from graph_engine.models import GraphQueryResult
+from graph_engine.query.service import query_subgraph
+from graph_engine.status import GraphStatusManager
+
+MVP20_GRAPH_DEPTH = 2
+MVP20_DECISION_TARGET_COUNT = 20
+MVP20_DECISION_TARGET_ROLE = "decision_target"
+MVP20_CONTEXT_ONLY_ROLE = "context_only"
+MVP20EntityRole = Literal["decision_target", "context_only"]
+
+
+def query_mvp20_context_subgraph(
+    seed_entities: list[str],
+    *,
+    decision_target_entities: Sequence[str],
+    client: Neo4jClient,
+    status_manager: GraphStatusManager,
+    result_limit: int = 500,
+) -> GraphQueryResult:
+    """Return the MVP20 depth-2 read graph with context-only role annotations.
+
+    This is a read helper over ``query_subgraph`` only. It does not enable
+    default propagation, full propagation, writes, or relationship expansion
+    beyond the bounded two-hop context read.
+    """
+
+    decision_targets = validate_mvp20_decision_targets(decision_target_entities)
+    result = query_subgraph(
+        seed_entities,
+        MVP20_GRAPH_DEPTH,
+        client=client,
+        status_manager=status_manager,
+        result_limit=result_limit,
+        max_depth=MVP20_GRAPH_DEPTH,
+    )
+    annotated_nodes = annotate_mvp20_context_nodes(
+        result.subgraph_nodes,
+        decision_targets,
+    )
+    annotated_edges = annotate_mvp20_context_edges(
+        result.subgraph_edges,
+        decision_targets,
+        node_roles_by_id=_node_roles_by_id(annotated_nodes),
+    )
+    return result.model_copy(
+        update={
+            "subgraph_nodes": annotated_nodes,
+            "subgraph_edges": annotated_edges,
+        }
+    )
+
+
+def validate_mvp20_decision_targets(
+    decision_target_entities: Sequence[str],
+) -> tuple[str, ...]:
+    """Validate the MVP20 decision target universe as exactly 20 unique ids."""
+
+    if isinstance(decision_target_entities, (str, bytes)) or not isinstance(
+        decision_target_entities,
+        Sequence,
+    ):
+        raise ValueError("decision_target_entities must be a sequence of strings")
+
+    seen: set[str] = set()
+    normalized: list[str] = []
+    for entity in decision_target_entities:
+        if not isinstance(entity, str):
+            raise ValueError("decision_target_entities must contain strings")
+        stripped = entity.strip()
+        if not stripped:
+            raise ValueError("decision_target_entities must contain non-empty ids")
+        if stripped in seen:
+            raise ValueError("decision_target_entities must contain unique ids")
+        seen.add(stripped)
+        normalized.append(stripped)
+
+    if len(normalized) != MVP20_DECISION_TARGET_COUNT:
+        raise ValueError(
+            "MVP20 decision target universe must contain exactly "
+            f"{MVP20_DECISION_TARGET_COUNT} unique ids",
+        )
+    return tuple(normalized)
+
+
+def annotate_mvp20_context_nodes(
+    nodes: Sequence[Mapping[str, Any]],
+    decision_target_entities: Sequence[str],
+) -> list[dict[str, Any]]:
+    """Annotate query nodes as decision targets or context-only related entities."""
+
+    decision_targets = frozenset(decision_target_entities)
+    annotated: list[dict[str, Any]] = []
+    for node in nodes:
+        payload = dict(node)
+        role = mvp20_entity_role(_entity_id_from_node(payload), decision_targets)
+        payload["entity_role"] = role
+        payload["metadata"] = _metadata_with_role(payload.get("metadata"), role)
+        annotated.append(payload)
+    return annotated
+
+
+def annotate_mvp20_context_edges(
+    edges: Sequence[Mapping[str, Any]],
+    decision_target_entities: Sequence[str],
+    *,
+    node_roles_by_id: Mapping[str, MVP20EntityRole] | None = None,
+) -> list[dict[str, Any]]:
+    """Annotate edge endpoint roles without changing relationship semantics."""
+
+    decision_targets = frozenset(decision_target_entities)
+    node_roles = dict(node_roles_by_id or {})
+    annotated: list[dict[str, Any]] = []
+    for edge in edges:
+        payload = dict(edge)
+        source_id = _text_or_none(payload.get("source_node_id"))
+        target_id = _text_or_none(payload.get("target_node_id"))
+        source_role = node_roles.get(source_id or "") or mvp20_entity_role(
+            source_id,
+            decision_targets,
+        )
+        target_role = node_roles.get(target_id or "") or mvp20_entity_role(
+            target_id,
+            decision_targets,
+        )
+        payload["source_entity_role"] = source_role
+        payload["target_entity_role"] = target_role
+        metadata = payload.get("metadata")
+        if not isinstance(metadata, Mapping):
+            metadata = {}
+        payload["metadata"] = {
+            **dict(metadata),
+            "mvp20_source_entity_role": source_role,
+            "mvp20_target_entity_role": target_role,
+        }
+        annotated.append(payload)
+    return annotated
+
+
+def mvp20_entity_role(
+    entity_id: str | None,
+    decision_target_entities: Sequence[str],
+) -> MVP20EntityRole:
+    """Classify an entity id against the MVP20 decision target universe."""
+
+    if entity_id is not None and entity_id in decision_target_entities:
+        return MVP20_DECISION_TARGET_ROLE
+    return MVP20_CONTEXT_ONLY_ROLE
+
+
+def _entity_id_from_node(node: Mapping[str, Any]) -> str | None:
+    for key in ("canonical_entity_id", "entity_id", "node_id"):
+        text = _text_or_none(node.get(key))
+        if text:
+            return text
+    return None
+
+
+def _metadata_with_role(metadata: Any, role: MVP20EntityRole) -> dict[str, Any]:
+    payload = dict(metadata) if isinstance(metadata, Mapping) else {}
+    payload["mvp20_entity_role"] = role
+    return payload
+
+
+def _node_roles_by_id(nodes: Sequence[Mapping[str, Any]]) -> dict[str, MVP20EntityRole]:
+    roles: dict[str, MVP20EntityRole] = {}
+    for node in nodes:
+        raw_role = node.get("entity_role")
+        if raw_role == MVP20_DECISION_TARGET_ROLE:
+            role: MVP20EntityRole = MVP20_DECISION_TARGET_ROLE
+        elif raw_role == MVP20_CONTEXT_ONLY_ROLE:
+            role = MVP20_CONTEXT_ONLY_ROLE
+        else:
+            continue
+        for key in ("node_id", "canonical_entity_id", "entity_id"):
+            node_id = _text_or_none(node.get(key))
+            if node_id:
+                roles[node_id] = role
+    return roles
+
+
+def _text_or_none(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None

--- a/tests/contract/test_frontend_api_artifacts.py
+++ b/tests/contract/test_frontend_api_artifacts.py
@@ -27,7 +27,10 @@ def test_frontend_api_subgraph_artifact_shape() -> None:
     assert isinstance(payload["edges"], list)
     assert payload["nodes"][0]["node_id"] == "ENT_STOCK_600519.SH"
     assert payload["nodes"][0]["display_name"] == "Kweichow Moutai"
+    assert payload["nodes"][0]["entity_role"] == "decision_target"
+    assert payload["nodes"][2]["entity_role"] == "context_only"
     assert payload["edges"][0]["source_node_id"] == "ENT_STOCK_600519.SH"
+    assert payload["edges"][0]["target_entity_role"] == "context_only"
     assert payload["edges"][0]["relationship_type"]
 
 
@@ -38,9 +41,12 @@ def test_frontend_api_paths_artifact_shape() -> None:
     assert isinstance(paths, list)
     assert paths[0]["seed"] == "ENT_STOCK_600519.SH"
     assert paths[0]["target"] == "ENT_STOCK_300750.SZ"
+    assert paths[0]["target_role"] == "decision_target"
     assert paths[0]["channel"] == "event"
     assert isinstance(paths[0]["nodes"], list)
     assert isinstance(paths[0]["edges"], list)
+    assert paths[1]["target"] == "SECTOR_LIQUOR"
+    assert paths[1]["target_role"] == "context_only"
 
 
 def test_frontend_api_impact_artifact_shape() -> None:
@@ -52,6 +58,9 @@ def test_frontend_api_impact_artifact_shape() -> None:
     assert isinstance(items, list)
     assert items[1]["entity_id"] == "ENT_STOCK_300750.SZ"
     assert items[1]["display_name"] == "CATL"
+    assert items[1]["entity_role"] == "decision_target"
+    assert items[2]["entity_id"] == "SECTOR_LIQUOR"
+    assert items[2]["entity_role"] == "context_only"
 
 
 def _load_json(path: Path) -> dict[str, Any]:

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -15,8 +15,11 @@ from graph_engine.models import (
 )
 from graph_engine.query import (
     MAX_QUERY_DEPTH,
+    MVP20_GRAPH_DEPTH,
     query_propagation_paths,
+    query_mvp20_context_subgraph,
     query_subgraph,
+    validate_mvp20_decision_targets,
 )
 from graph_engine.status import GraphStatusManager
 from tests.fakes import InMemoryStatusStore
@@ -653,6 +656,63 @@ def test_query_apis_do_not_call_execute_write() -> None:
     assert client.write_calls == []
 
 
+def test_validate_mvp20_decision_targets_requires_exact_unique_universe() -> None:
+    assert validate_mvp20_decision_targets(_mvp20_targets()) == tuple(_mvp20_targets())
+
+    with pytest.raises(ValueError, match="exactly 20"):
+        validate_mvp20_decision_targets(_mvp20_targets()[:-1])
+    with pytest.raises(ValueError, match="unique"):
+        validate_mvp20_decision_targets([*_mvp20_targets()[:-1], "entity-a"])
+
+
+def test_query_mvp20_context_subgraph_locks_depth_two_and_marks_context_only() -> None:
+    client = FakeQueryClient()
+
+    result = query_mvp20_context_subgraph(
+        ["entity-a"],
+        decision_target_entities=_mvp20_targets(),
+        client=client,  # type: ignore[arg-type]
+        status_manager=_status_manager(),
+        result_limit=10,
+    )
+
+    roles = {
+        node["canonical_entity_id"]: node["entity_role"]
+        for node in result.subgraph_nodes
+    }
+    assert result.depth == MVP20_GRAPH_DEPTH
+    assert result.result_limit == 10
+    assert roles == {
+        "entity-a": "decision_target",
+        "entity-b": "decision_target",
+        "entity-c": "context_only",
+    }
+    assert all(
+        node["metadata"]["mvp20_entity_role"] == node["entity_role"]
+        for node in result.subgraph_nodes
+    )
+    assert {
+        edge["target_entity_role"] for edge in result.subgraph_edges
+    } == {"decision_target", "context_only"}
+    assert client.write_calls == []
+    assert all("run_full_propagation" not in query for query, _ in client.read_calls)
+
+
+def test_query_mvp20_context_subgraph_validates_targets_before_reading() -> None:
+    client = FakeQueryClient()
+
+    with pytest.raises(ValueError, match="exactly 20"):
+        query_mvp20_context_subgraph(
+            ["entity-a"],
+            decision_target_entities=_mvp20_targets()[:-1],
+            client=client,  # type: ignore[arg-type]
+            status_manager=_status_manager(),
+        )
+
+    assert client.read_calls == []
+    assert client.write_calls == []
+
+
 def _node_rows() -> list[dict[str, Any]]:
     return [
         {
@@ -814,6 +874,14 @@ def _edge_channels(edge: dict[str, Any]) -> tuple[str, ...]:
     if edge["relationship_type"] == "NORTHBOUND_HOLD":
         return ("event", "reflexive")
     return ("fundamental",)
+
+
+def _mvp20_targets() -> list[str]:
+    return [
+        "entity-a",
+        "entity-b",
+        *[f"entity-target-{index:02d}" for index in range(18)],
+    ]
 
 
 def _status_manager(


### PR DESCRIPTION
## Summary
- add MVP20 read-side helper capped at graph depth 2
- annotate decision_target and context_only roles on graph fixture outputs
- avoid enabling default/full propagation or new relation semantics

## Tests
- python3 -m pytest tests/unit/test_query.py tests/contract/test_frontend_api_artifacts.py
- git diff --check